### PR TITLE
chore: scrub all admission control references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in the admission control pipeline or agent
+about: Report a bug in the review pipeline or agent
 labels: bug
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,10 +3,10 @@
 ## 1. System Overview
 
 Eagle Eyed Dom is a deterministic code and dependency review platform for CI. It
-exposes two evaluation paths — a legacy dependency admission pipeline and a 15-plugin
+exposes two evaluation paths — a legacy dependency review pipeline and a 15-plugin
 review system — both fully fail-open with zero LLM in the decision path.
 
-**Dependency admission** (`evaluate` command): when a PR modifies a dependency manifest,
+**Dependency review** (`evaluate` command): when a PR modifies a dependency manifest,
 the pipeline detects changed packages, runs vulnerability and license scanners in
 parallel, normalizes findings, evaluates them against an OPA policy, assembles a
 structured decision, writes a Markdown memo for PR commenting, persists evidence
@@ -23,7 +23,7 @@ All failure paths are fail-open: a scanner timeout produces a `ScanResult.skippe
 plugin exception returns `PluginResult(error=...)`, an OPA failure produces
 `needs_review`, a DB failure falls back to `NullRepository`. Nothing blocks the build.
 
-### Dependency Admission Pipeline
+### Dependency Review Pipeline
 
 ```
 PR diff / SBOM pair
@@ -33,7 +33,7 @@ PR diff / SBOM pair
   (diff.py / sbom_diff.py)
         |
         v
-  AdmissionRequest list
+  ReviewRequest list
         |
         +-----> ScanOrchestrator.run()   <-- ThreadPoolExecutor (scanners in parallel)
         |            |  Syft  |  OSV  |  Trivy  |  ScanCode  |
@@ -57,7 +57,7 @@ PR diff / SBOM pair
         +-----> create_seal()                 (SHA-256 chain)
         |
         v
-  list[AdmissionDecision]
+  list[ReviewDecision]
   (returned to CLI / Jenkins step)
 ```
 
@@ -104,10 +104,10 @@ repo path / diff
 
 | Module | Responsibility |
 |--------|---------------|
-| `cli/main.py` | Click CLI entry point. Four commands: `evaluate` (dependency admission pipeline), `review` (15-plugin repo review), `plugins` (list registered plugins), and `check-health` (binary + DB probe). Reads diff from file or stdin, constructs the appropriate pipeline or registry, delegates all logic, formats output. Never contains business logic. SARIF output (`--format sarif`) and watch mode (`--watch`) are coordinated here but implemented in `core/sarif.py` and the watchdog observer respectively. |
+| `cli/main.py` | Click CLI entry point. Four commands: `evaluate` (dependency review pipeline), `review` (15-plugin repo review), `plugins` (list registered plugins), and `check-health` (binary + DB probe). Reads diff from file or stdin, constructs the appropriate pipeline or registry, delegates all logic, formats output. Never contains business logic. SARIF output (`--format sarif`) and watch mode (`--watch`) are coordinated here but implemented in `core/sarif.py` and the watchdog observer respectively. |
 
-Imports: `click`, `structlog`, `core.models.OperatingMode`, `core.pipeline.AdmissionPipeline`,
-`core.config.AdmissionSettings`, `core.plugin.PluginCategory`, `core.renderer.render_comment`,
+Imports: `click`, `structlog`, `core.models.OperatingMode`, `core.pipeline.ReviewPipeline`,
+`core.config.EedomSettings`, `core.plugin.PluginCategory`, `core.renderer.render_comment`,
 `core.sarif.to_sarif`, `core.repo_config.load_repo_config`, `plugins.get_default_registry`.
 
 The CLI catches `Exception` only at the outermost boundary to exit with code 1. Watch mode
@@ -130,16 +130,16 @@ The agent catches all exceptions and exits 0 (fail-open). Pipeline failures neve
 
 | Module | Responsibility |
 |--------|---------------|
-| `config.py` | `AdmissionSettings` — Pydantic `BaseSettings` with `ADMISSION_` prefix. Custom `_CommaSeparatedEnvSource` handles comma-separated scanner lists. `SecretStr` for `llm_api_key`. Validates at startup; missing `db_dsn` raises immediately. |
-| `models.py` | All domain objects as Pydantic models. Six `StrEnum` types. `AdmissionDecision.model_post_init` computes `should_comment` and `should_mark_unstable` from operating mode x verdict. |
-| `pipeline.py` | `AdmissionPipeline` — stateless per call. Two entry points: `evaluate()` for diff-based (PyPI) and `evaluate_sbom()` for SBOM-based (ecosystem-agnostic). Wires all subsystems together. Enforces per-package pipeline timeout. |
+| `config.py` | `EedomSettings` — Pydantic `BaseSettings` with `EEDOM_` prefix. Custom `_CommaSeparatedEnvSource` handles comma-separated scanner lists. `SecretStr` for `llm_api_key`. Validates at startup; missing `db_dsn` raises immediately. |
+| `models.py` | All domain objects as Pydantic models. Six `StrEnum` types. `ReviewDecision.model_post_init` computes `should_comment` and `should_mark_unstable` from operating mode x verdict. |
+| `pipeline.py` | `ReviewPipeline` — stateless per call. Two entry points: `evaluate()` for diff-based (PyPI) and `evaluate_sbom()` for SBOM-based (ecosystem-agnostic). Wires all subsystems together. Enforces per-package pipeline timeout. |
 | `pipeline_helpers.py` | Extracted helpers keeping `pipeline.py` under 500 lines: `resolve_git_sha`, `count_transitive_deps_from_scan`, `parse_changes`, `sbom_changes_to_requests`. |
 | `orchestrator.py` | `ScanOrchestrator` — parallel execution via `ThreadPoolExecutor`. Combined wall-clock timeout. Returns results in original scanner order. Never raises. |
-| `diff.py` | `DependencyDiffDetector` — parses unified diff output; extracts before/after content for `requirements.txt` and `pyproject.toml`; computes added/removed/upgraded/downgraded changes; creates `AdmissionRequest` objects. |
+| `diff.py` | `DependencyDiffDetector` — parses unified diff output; extracts before/after content for `requirements.txt` and `pyproject.toml`; computes added/removed/upgraded/downgraded changes; creates `ReviewRequest` objects. |
 | `sbom_diff.py` | `diff_sboms()` — ecosystem-agnostic diffing via CycloneDX SBOMs. purl-based ecosystem detection for 17 ecosystems. `packaging.version.Version` for upgrade vs downgrade classification. |
 | `normalizer.py` | `normalize_findings()` — deduplicates vulnerability findings across scanners by `(advisory_id, category, package_name, version)`, highest severity wins. License findings pass through undeduped. Returns merged list + severity summary dict. |
 | `policy.py` | `OpaEvaluator` — builds OPA input (`input.pkg`, not `input.package`), invokes `opa eval` subprocess, parses `deny`/`warn`/`decision` from result, maps to `DecisionVerdict`. All failures degrade to `needs_review`. |
-| `decision.py` | `assemble_decision()` — pure function that constructs `AdmissionDecision` from parts. Zero I/O. |
+| `decision.py` | `assemble_decision()` — pure function that constructs `ReviewDecision` from parts. Zero I/O. |
 | `memo.py` | `generate_memo()` — pure function producing Markdown for PR comments. Truncates at 3900 chars. |
 | `plugin.py` | `ScannerPlugin` ABC and `PluginCategory` enum. `PluginResult` dataclass. `render()` method with Jinja2 template dispatch and `_render_inline()` fallback. |
 | `registry.py` | `PluginRegistry` — register, filter, and run plugins. `discover_plugins()` auto-loads `ScannerPlugin` subclasses from a directory. `run_all()` runs scan plugins first, then the `opa` policy plugin with all aggregated findings. |
@@ -171,10 +171,10 @@ Imports: `core` modules import only from `core` and `data.scanners.base`. The lo
 
 ## 3. Pipeline Flow
 
-Function call chain for `AdmissionPipeline.evaluate()` (`pipeline.py:56`):
+Function call chain for `ReviewPipeline.evaluate()` (`pipeline.py:56`):
 
 ```
-AdmissionPipeline.evaluate(diff_text, pr_url, team, mode, repo_path)
+ReviewPipeline.evaluate(diff_text, pr_url, team, mode, repo_path)
   resolve_git_sha(repo_path)                              # pipeline_helpers.py:24
   DependencyDiffDetector.detect_changed_files(diff_text) # diff.py:212
   parse_changes(detector, diff_text, changed_files)      # pipeline_helpers.py:53
@@ -254,7 +254,7 @@ propagate.
 `quality`, `supply_chain`.
 
 The legacy `Scanner` ABC in `data/scanners/base.py` remains in use for the dependency
-admission pipeline. `ScannerPlugin` is the newer interface for the review system —
+review pipeline. `ScannerPlugin` is the newer interface for the review system —
 both coexist.
 
 ### PluginRegistry
@@ -322,8 +322,8 @@ Error messages are produced by `errors.py:error_msg(ErrorCode, plugin_name, ...)
 
 ## 5. Policy Engine
 
-OPA evaluates `policies/admission.rego` via subprocess. Input is serialized to a temp
-file and passed with `-i`. The query target is `data.admission`.
+OPA evaluates `policies/policy.rego` via subprocess. Input is serialized to a temp
+file and passed with `-i`. The query target is `data.policy`.
 
 ### Input Schema
 
@@ -353,7 +353,7 @@ The `build_opa_input()` function (`policy.py:48`) builds:
 The field is `pkg`, not `package`. `package` is a reserved keyword in Rego (`rego.v1`);
 using it as an input field causes a parse error. All OPA rules reference `input.pkg`.
 
-### Rego Rules (`policies/admission.rego`)
+### Rego Rules (`policies/policy.rego`)
 
 | Rule | Type | Trigger |
 |------|------|---------|
@@ -450,7 +450,7 @@ dimensions produce specific `ValidationError` objects included in retry guidance
 | deny=0, warn=0 | `approve` | false | false |
 | any OPA failure | `needs_review` | true | true |
 
-`should_comment` and `should_mark_unstable` are computed in `AdmissionDecision.model_post_init`
+`should_comment` and `should_mark_unstable` are computed in `ReviewDecision.model_post_init`
 (`models.py:247`) via `_compute_should_comment()` and `_compute_should_mark_unstable()`.
 In `monitor` mode both are always `False` — the pipeline logs but never comments or fails the build.
 
@@ -464,7 +464,7 @@ In `monitor` mode both are always `False` — the pipeline logs but never commen
 ### Package Evaluation Failure
 
 If an unhandled exception occurs during per-package evaluation (`pipeline.py:215`), the
-pipeline appends an `AdmissionDecision` with `verdict=needs_review`, empty findings, and
+pipeline appends an `ReviewDecision` with `verdict=needs_review`, empty findings, and
 `triggered_rules=["package evaluation failed unexpectedly"]`. The pipeline continues to
 the next package.
 
@@ -478,7 +478,7 @@ the next package.
   decisions.parquet              <- append-only audit log (all runs)
   <short_sha>/<YYYYMMDDHHmm>/   <- run_id directory
     <package_name>/
-      decision.json              <- full AdmissionDecision (orjson)
+      decision.json              <- full ReviewDecision (orjson)
       memo.md                    <- Markdown memo
     seal.json                    <- integrity seal for this run
 ```
@@ -602,16 +602,16 @@ are skipped.
 ```
 
 `sbom_changes_to_requests()` (`pipeline_helpers.py:77`) converts these to
-`AdmissionRequest` objects; `removed` changes are skipped.
+`ReviewRequest` objects; `removed` changes are skipped.
 
 
 ## 11. Data Model
 
 ```mermaid
 classDiagram
-    class AdmissionDecision {
+    class ReviewDecision {
         +UUID decision_id
-        +AdmissionRequest request
+        +ReviewRequest request
         +DecisionVerdict decision
         +list~Finding~ findings
         +list~ScanResult~ scan_results
@@ -622,7 +622,7 @@ classDiagram
         +bool should_mark_unstable
         +float pipeline_duration_seconds
     }
-    class AdmissionRequest {
+    class ReviewRequest {
         +UUID request_id
         +RequestType request_type
         +str ecosystem
@@ -659,10 +659,10 @@ classDiagram
         +str policy_bundle_version
         +str note
     }
-    AdmissionDecision --> AdmissionRequest
-    AdmissionDecision --> PolicyEvaluation
-    AdmissionDecision "1" --> "*" Finding
-    AdmissionDecision "1" --> "*" ScanResult
+    ReviewDecision --> ReviewRequest
+    ReviewDecision --> PolicyEvaluation
+    ReviewDecision "1" --> "*" Finding
+    ReviewDecision "1" --> "*" ScanResult
     ScanResult "1" --> "*" Finding
 ```
 
@@ -674,7 +674,7 @@ classDiagram
 ### Migration 001 — Core Pipeline Tables
 
 ```
-admission_requests
+review_requests
   PK: request_id (UUID)
   ecosystem, package_name, target_version, current_version
   team, scope, pr_url, pr_number, repo_name, commit_sha, use_case
@@ -683,23 +683,23 @@ admission_requests
 
 scan_results
   PK: scan_result_id
-  FK: request_id -> admission_requests
+  FK: request_id -> review_requests
   tool_name, status, finding_count, duration_seconds, raw_output_path
 
 policy_evaluations
   PK: evaluation_id
-  FK: request_id -> admission_requests
+  FK: request_id -> review_requests
   policy_version, decision, triggered_rules (JSONB), constraints (JSONB)
 
-admission_decisions
+review_decisions
   PK: decision_id
-  FK: request_id -> admission_requests
+  FK: request_id -> review_requests
   decision, findings_summary (JSONB), evidence_bundle_path, memo_text
   pipeline_duration_seconds, operating_mode
 
 bypass_records
   PK: bypass_id
-  FK: request_id -> admission_requests
+  FK: request_id -> review_requests
   bypass_type CHECK IN ('timeout','manual','kill_switch')
   invoked_by, reason
 ```
@@ -748,7 +748,7 @@ to the caller.
 
 | Component | Failure | Recovery | User-visible effect |
 |-----------|---------|----------|---------------------|
-| Config load | Missing `ADMISSION_DB_DSN` | CLI exits 0 with message | "Pipeline skipped — configuration unavailable" |
+| Config load | Missing `EEDOM_DB_DSN` | CLI exits 0 with message | "Pipeline skipped — configuration unavailable" |
 | DB connect | `ConnectionPool` fails | Falls back to `NullRepository` | `db_unavailable` log warning; pipeline continues |
 | DB query | Any psycopg exception | Exception logged; method returns silently | Decision not persisted in DB |
 | Scanner binary missing | `OSError` in subprocess | `ScanResult.not_installed(name)` | Scanner listed as failed in memo |
@@ -764,7 +764,7 @@ to the caller.
 | Evidence write | Any `OSError` | Exception logged; `store()` returns `""` | Evidence not written; pipeline continues |
 | Seal creation | Any exception | `logger.exception("seal_creation_failed")` | Run not sealed; pipeline still returns decisions |
 | Parquet write | Any exception | `logger.error("parquet_write_failed")` | Audit log not updated for this run |
-| Package eval error | Any unhandled exception | `AdmissionDecision(needs_review)` appended | One package verdict = needs_review |
+| Package eval error | Any unhandled exception | `ReviewDecision(needs_review)` appended | One package verdict = needs_review |
 | LLM advisory | Any failure | Returns `""` | Advisory omitted from memo |
 | Pipeline timeout (300s) | Elapsed >= 300s | Remaining packages skipped, decisions returned | `pipeline_timeout_reached` log warning |
 
@@ -784,7 +784,7 @@ calls in `db.py` use `_safe_dsn(self._dsn)` instead of the raw DSN.
 
 ### SecretStr for LLM API Key
 
-`AdmissionSettings.llm_api_key` is typed as `SecretStr | None` (`config.py:82`).
+`EedomSettings.llm_api_key` is typed as `SecretStr | None` (`config.py:82`).
 Pydantic's `SecretStr` redacts the value in `repr()` and `str()`, preventing accidental
 logging. `taskfit.py:243` calls `get_secret_value()` explicitly when building the
 Authorization header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 ### Added
 
 **GATEKEEPER Copilot Agent — reactive PR review**
-- New `src/eedom/agent/` module: GitHub Copilot Agent that wraps the existing admission pipeline for reactive PR review
+- New `src/eedom/agent/` module: GitHub Copilot Agent that wraps the existing review pipeline for reactive PR review
 - 8-tool scanning suite (all deterministic, no LLM in the scanning pipeline):
   - Syft (SBOM generation, 18 ecosystems)
   - OSV-Scanner (CVE/GHSA database lookup)
@@ -89,9 +89,9 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 ### Added
 
 **Phase 0 — Jenkins PoC foundation**
-- `AdmissionPipeline` entry point: evaluates dependency changes on PRs via Jenkins
+- `ReviewPipeline` entry point: evaluates dependency changes on PRs via Jenkins
 - CLI (`src/eedom/cli/main.py`) with `monitor` and `advise` operating modes
-- Jenkins shared library (`jenkins/vars/dependencyAdmission.groovy`) with `withEnv`-based parameter passing
+- Jenkins shared library (`jenkins/vars/dependencyReview.groovy`) with `withEnv`-based parameter passing
 
 **Scanners**
 - `OsvScanner` — OSV-Scanner CVE detection; non-recursive invocation to avoid recursive scanning on monorepos
@@ -107,7 +107,7 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 - `FindingNormalizer` — cross-scanner deduplication; highest severity wins on disagreement; dedup key includes finding category to prevent non-vuln collapses
 
 **Policy**
-- OPA `admission.rego` policy with deny rules for critical CVEs, license violations, package age, and transitive dependency depth
+- OPA `policy.rego` policy with deny rules for critical CVEs, license violations, package age, and transitive dependency depth
 - `package_metadata` populated from PyPI client (`first_published_date`) and Syft SBOM (`transitive_dep_count`) so age and depth rules fire
 - CVSS base score parsing with vector heuristic fallback — no more silent `info` rating for untagged vulns
 
@@ -127,14 +127,14 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 - `db_dsn` typed as `pydantic.SecretStr` to prevent accidental string serialization of credentials
 
 **Configuration**
-- All timeouts configurable via `AdmissionConfig`; no hardcoded values in business logic
+- All timeouts configurable via `ReviewConfig`; no hardcoded values in business logic
 - Startup validation fails fast on missing critical config fields
 
 ### Fixed
 
 **Dogfood bugs (caught post-initial-commit)**
 - `OsvScanner` was invoked with `--recursive` flag, causing it to re-scan nested `node_modules` and virtualenvs; removed flag and scoped scan to project root
-- OPA reserved word collision: renamed `input.package` to `input.pkg` in `admission.rego` (reserved word in Rego)
+- OPA reserved word collision: renamed `input.package` to `input.pkg` in `policy.rego` (reserved word in Rego)
 - DB connection timeout mis-configured as string instead of int; `psycopg2` rejected the value silently and fell back to no timeout
 
 **Review Pass 1 — 15 critical/high findings (all fixed)**
@@ -166,10 +166,10 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 - Path traversal in `EvidenceStore` via unvalidated `artifact_name` → guard added (F-022)
 - LLM prompt injection from PyPI metadata fields → structured role separation + sanitization (F-013)
 - LLM API key stored as `str` → `pydantic.SecretStr` (F-021)
-- `db_dsn` exposed as plain string → `SecretStr` in `AdmissionConfig`
+- `db_dsn` exposed as plain string → `SecretStr` in `ReviewConfig`
 
 ### Changed
 
-- Pipeline logic extracted from CLI presentation layer into `AdmissionPipeline` in `core/pipeline.py`; `main.py` is now a thin adapter (F-024)
+- Pipeline logic extracted from CLI presentation layer into `ReviewPipeline` in `core/pipeline.py`; `main.py` is now a thin adapter (F-024)
 - Evidence keyed by commit SHA + timestamp instead of random UUID — enables deterministic replay and audit correlation
 - Scanner result factory functions moved from `data/scanners/base.py` to `core/models.py` to fix tier inversion

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Three-tier — imports flow downward only (cli -> core -> data):
 
 ## OPA Policy
 
-6 rules in `policies/admission.rego`. Critical/high vulns deny. Forbidden licenses deny. Package age < 30 days denies. Malicious packages deny. Medium vulns warn. High transitive dep count warns.
+6 rules in `policies/policy.rego`. Critical/high vulns deny. Forbidden licenses deny. Package age < 30 days denies. Malicious packages deny. Medium vulns warn. High transitive dep count warns.
 
 ## Dev Ports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Admission Control
+# Contributing to Dependency Review
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ opa test policies/            # OPA policy unit tests
 First-run sanity check:
 
 ```bash
-uv run python -c "from eedom.core.pipeline import AdmissionPipeline; print('ok')"
+uv run python -c "from eedom.core.pipeline import ReviewPipeline; print('ok')"
 ```
 
 ## Project Structure
@@ -83,7 +83,7 @@ uv run pytest tests/integration/ -v   # requires Docker + scanner binaries
 
 **Fail-open** — scanner timeouts skip with a notation in the evidence bundle; OPA failures route to `needs_review`; DB failures log and continue. Nothing blocks the build.
 
-**Timeouts** — every external call must have an explicit timeout. Read it from `AdmissionConfig`, never hardcode it. Default values live in the config model.
+**Timeouts** — every external call must have an explicit timeout. Read it from `ReviewConfig`, never hardcode it. Default values live in the config model.
 
 **Secrets** — `pydantic.SecretStr` for all credential fields. Never log DSNs or API keys.
 
@@ -104,10 +104,10 @@ Scanner output must be normalized via `FindingNormalizer` before reaching `core`
 
 ## Adding an OPA Rule
 
-1. Add the new rule to `policies/admission.rego`
-2. Add a test case in `policies/admission_test.rego` — both passing and failing inputs
+1. Add the new rule to `policies/policy.rego`
+2. Add a test case in `policies/policy_test.rego` — both passing and failing inputs
 3. Update `policies/INPUT_SCHEMA.md` with any new input fields the rule reads
-4. Populate the new field in `AdmissionPipeline._build_package_metadata()` in `core/pipeline.py`
+4. Populate the new field in `ReviewPipeline._build_package_metadata()` in `core/pipeline.py`
 5. Run `opa test policies/` — all tests must pass
 
 Rules must be written defensively: `input.pkg.field` with `default` assignments so that missing fields produce `needs_review`, not `deny` or silent bypass.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,21 @@
 
 ---
 
-When a PR touches a dependency manifest — `requirements.txt`, `package.json`, `Cargo.toml`, `go.mod`, any of 18 ecosystems — Eagle Eyed Dom detects the changed packages, runs 15 plugins in parallel, deduplicates findings, evaluates them against OPA policy, writes tamper-evident evidence, and appends the decision to a Parquet audit log.
+## Why This Exists
+
+Every PR that touches a dependency or a source file needs someone to answer the same mechanical questions: any known CVEs? License compatible? Package too new to trust? Secrets leaked? Complexity getting worse?
+
+Those checks aren't hard. They're tedious. And they're the reason your senior engineers spend half their review time on things a script could catch — while the stuff that actually needs a human brain (architecture, logic, design intent) gets a tired "LGTM" at the end.
+
+**So what?** When reviews bottleneck, one of two things happens. Teams either slow down — PRs queue up, deploys stall, developers context-switch while waiting — or they speed up wrong. Reviews get rubber-stamped. A critical CVE ships because nobody had the energy to check transitive deps on the fourth PR of the afternoon. A copyleft license sneaks into a commercial codebase because the reviewer was focused on the actual code change, not the new dependency it pulled in.
+
+Both outcomes cost real money. One costs velocity. The other costs incidents.
+
+**Eagle Eyed Dom doesn't replace human review. It removes the mechanical half so humans can do the half that requires judgment.** Fifteen plugins run the checks that don't need a brain. OPA policy makes the accept/reject decision deterministically. The reviewer opens a PR and the dependency, vulnerability, license, complexity, and secret checks are already done — with evidence, an audit trail, and a clear verdict. They can skip straight to "does this design make sense?"
+
+---
+
+When a PR touches a dependency manifest — `requirements.txt`, `package.json`, `Cargo.toml`, `go.mod`, any of 18 ecosystems — eedom detects the changed packages, runs 15 plugins in parallel, deduplicates findings, evaluates them against OPA policy, writes tamper-evident evidence, and appends the decision to a Parquet audit log.
 
 Every scanning tool is deterministic. The decision is deterministic. Nothing blocks the build unless OPA says so.
 
@@ -204,7 +218,7 @@ Or use the composite action (`action.yml`):
 
 ## OPA Policy Rules
 
-6 rules in `policies/admission.rego`. All individually toggleable via `input.config.rules_enabled`.
+6 rules in `policies/policy.rego`. All individually toggleable via `input.config.rules_enabled`.
 
 | Rule | Type | Trigger | Default |
 |------|------|---------|---------|
@@ -254,7 +268,7 @@ src/eedom/
 │   ├── sbom_diff.py        #   CycloneDX SBOM differ (18 ecosystems via purl)
 │   ├── normalizer.py       #   Finding deduplication (highest severity wins)
 │   ├── orchestrator.py     #   Parallel scanner runner (ThreadPoolExecutor)
-│   ├── decision.py         #   Pure assembler — OPA verdict → AdmissionDecision
+│   ├── decision.py         #   Pure assembler — OPA verdict → ReviewDecision
 │   ├── memo.py             #   Markdown PR comment generator
 │   ├── seal.py             #   SHA-256 evidence chain
 │   └── taskfit*.py         #   Optional LLM advisory (disabled by default)
@@ -326,19 +340,19 @@ Nothing blocks the build unless OPA says so. Every external call has a timeout. 
 
 ## Configuration
 
-### CLI (`ADMISSION_*` prefix)
+### CLI (`EEDOM_*` prefix)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ADMISSION_OPERATING_MODE` | `monitor` | `monitor` or `advise` |
-| `ADMISSION_DB_DSN` | — | PostgreSQL DSN (optional — NullRepository fallback) |
-| `ADMISSION_EVIDENCE_PATH` | `./evidence` | Evidence + Parquet root |
-| `ADMISSION_ENABLED_SCANNERS` | `syft,osv-scanner,trivy,scancode` | Active scanners |
-| `ADMISSION_SCANNER_TIMEOUT` | `60` | Per-scanner timeout (s) |
-| `ADMISSION_COMBINED_SCANNER_TIMEOUT` | `180` | Combined scanner timeout (s) |
-| `ADMISSION_OPA_TIMEOUT` | `10` | OPA timeout (s) |
-| `ADMISSION_PIPELINE_TIMEOUT` | `300` | Per-package timeout (s) |
-| `ADMISSION_LLM_ENABLED` | `false` | Enable optional LLM task-fit advisory |
+| `EEDOM_OPERATING_MODE` | `monitor` | `monitor` or `advise` |
+| `EEDOM_DB_DSN` | — | PostgreSQL DSN (optional — NullRepository fallback) |
+| `EEDOM_EVIDENCE_PATH` | `./evidence` | Evidence + Parquet root |
+| `EEDOM_ENABLED_SCANNERS` | `syft,osv-scanner,trivy,scancode` | Active scanners |
+| `EEDOM_SCANNER_TIMEOUT` | `60` | Per-scanner timeout (s) |
+| `EEDOM_COMBINED_SCANNER_TIMEOUT` | `180` | Combined scanner timeout (s) |
+| `EEDOM_OPA_TIMEOUT` | `10` | OPA timeout (s) |
+| `EEDOM_PIPELINE_TIMEOUT` | `300` | Per-package timeout (s) |
+| `EEDOM_LLM_ENABLED` | `false` | Enable optional LLM task-fit advisory |
 
 ### GATEKEEPER (`GATEKEEPER_*` prefix)
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Dependency Admission Control'
+name: 'Dependency Dependency Review'
 description: 'Evaluate dependency changes for security, license, and policy compliance'
 
 inputs:
@@ -45,15 +45,15 @@ runs:
         git diff origin/${{ github.base_ref }}...HEAD > "$RUNNER_TEMP/dep-changes.diff"
         echo "diff-path=$RUNNER_TEMP/dep-changes.diff" >> "$GITHUB_OUTPUT"
 
-    - name: Run admission control
+    - name: Run dependency review
       id: evaluate
       shell: bash
       env:
-        ADMISSION_OPERATING_MODE: ${{ inputs.operating-mode }}
-        ADMISSION_DB_DSN: ${{ inputs.db-dsn }}
-        ADMISSION_EVIDENCE_PATH: ${{ inputs.evidence-path }}
-        ADMISSION_OPA_POLICY_PATH: ${{ inputs.policy-path }}
-        ADMISSION_ENABLED_SCANNERS: ${{ inputs.enabled-scanners }}
+        EEDOM_OPERATING_MODE: ${{ inputs.operating-mode }}
+        EEDOM_DB_DSN: ${{ inputs.db-dsn }}
+        EEDOM_EVIDENCE_PATH: ${{ inputs.evidence-path }}
+        EEDOM_OPA_POLICY_PATH: ${{ inputs.policy-path }}
+        EEDOM_ENABLED_SCANNERS: ${{ inputs.enabled-scanners }}
       run: |
         DECISION_FILE="$RUNNER_TEMP/decision.json"
         MEMO_FILE="$RUNNER_TEMP/memo.md"
@@ -95,14 +95,14 @@ runs:
         MARKER="<!-- eedom-result -->"
         COMMENT_BODY="$MARKER
         <details>
-        <summary>Dependency Admission Control</summary>
+        <summary>Dependency Dependency Review</summary>
 
         $(cat "$MEMO_FILE")
 
         </details>
 
         ---
-        *Posted by [Admission Control](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) at $(date -u +%Y-%m-%dT%H:%M:%SZ)*"
+        *Posted by [Dependency Review](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) at $(date -u +%Y-%m-%dT%H:%M:%SZ)*"
 
         # Upsert: find existing comment or create new
         EXISTING=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
@@ -122,4 +122,4 @@ runs:
       if: inputs.operating-mode == 'advise' && steps.evaluate.outputs.decision == 'reject'
       shell: bash
       run: |
-        echo "::warning::Dependency admission control: REJECT — see PR comment for details"
+        echo "::warning::Dependency dependency review: REJECT — see PR comment for details"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 services:
   postgres:
     image: postgres:16
-    container_name: admission-postgres
+    container_name: eedom-postgres
     environment:
-      POSTGRES_DB: admission
-      POSTGRES_USER: admission
-      POSTGRES_PASSWORD: admission_dev
+      POSTGRES_DB: eedom
+      POSTGRES_USER: eedom
+      POSTGRES_PASSWORD: eedom_dev
     ports:
       - "12432:5432"
     volumes:
-      - admission_pgdata:/var/lib/postgresql/data
+      - eedom_pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U admission -d admission"]
+      test: ["CMD-SHELL", "pg_isready -U eedom -d eedom"]
       interval: 5s
       timeout: 3s
       retries: 10
       start_period: 10s
 
 volumes:
-  admission_pgdata:
+  eedom_pgdata:

--- a/docs/adr/001-agent-module-as-separate-entry-point.md
+++ b/docs/adr/001-agent-module-as-separate-entry-point.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-The admission control pipeline currently has one entry point: the Click CLI at `cli/main.py`. We need to add a GitHub Copilot Agent that wraps the same pipeline for reactive PR review. The agent needs its own configuration (enforcement mode, GitHub token, LLM settings) and its own execution flow (LLM tool-calling loop, PR comment posting).
+The review pipeline currently has one entry point: the Click CLI at `cli/main.py`. We need to add a GitHub Copilot Agent that wraps the same pipeline for reactive PR review. The agent needs its own configuration (enforcement mode, GitHub token, LLM settings) and its own execution flow (LLM tool-calling loop, PR comment posting).
 
 Two approaches were considered:
 1. Extend the CLI with agent subcommands
@@ -14,12 +14,12 @@ Two approaches were considered:
 
 ## Decision
 
-We will create `src/eedom/agent/` as a separate presentation-tier module, parallel to `cli/`. The agent imports from `core/` and `data/` — the same tiers the CLI uses. No shared code is duplicated; the agent calls `AdmissionPipeline.evaluate()` directly.
+We will create `src/eedom/agent/` as a separate presentation-tier module, parallel to `cli/`. The agent imports from `core/` and `data/` — the same tiers the CLI uses. No shared code is duplicated; the agent calls `ReviewPipeline.evaluate()` directly.
 
 ## Consequences
 
 - The CLI continues to work unmodified — zero risk of regression
-- The agent has its own config (`AgentSettings` with `GATEKEEPER_` prefix) independent of `AdmissionSettings`
-- The agent must construct an `AdmissionSettings` internally to pass to `AdmissionPipeline`, mapping its own config fields
+- The agent has its own config (`AgentSettings` with `GATEKEEPER_` prefix) independent of `EedomSettings`
+- The agent must construct an `EedomSettings` internally to pass to `ReviewPipeline`, mapping its own config fields
 - Two entry points means two places to maintain environment documentation
 - The three-tier architecture is preserved: `agent/` is presentation, `core/` is logic, `data/` is persistence

--- a/docs/architecture-plan-v1.md
+++ b/docs/architecture-plan-v1.md
@@ -1,4 +1,4 @@
-# Agentic Dependency Admission Control
+# Agentic Dependency Dependency Review
 
 ## OSS Architecture, Operating Model, and Epic-Level Implementation Packet
 
@@ -6,7 +6,7 @@
 
 # 1. Executive Summary
 
-This document defines a **platform-agnostic, event-driven dependency admission control system** for governing how third-party software packages and version upgrades are approved for use.
+This document defines a **platform-agnostic, event-driven dependency dependency review system** for governing how third-party software packages and version upgrades are approved for use.
 
 The core objective is to move dependency security from a **reactive scanning model** to a **proactive eedom model**.
 
@@ -41,7 +41,7 @@ This model is particularly attractive when an organization already uses Argo but
 Modern development teams regularly introduce third-party packages and version upgrades to accelerate delivery. In practice, those changes often occur with inconsistent or incomplete review. Typical organizational failure modes include:
 
 - dependency approval happens informally through chat or tribal knowledge
-- repositories proxy public ecosystems without strong admission controls
+- repositories proxy public ecosystems without strong dependency reviews
 - version upgrades are treated as routine housekeeping rather than change risk events
 - teams optimize for speed and convenience over minimum necessary dependency footprint
 - scanners produce findings, but there is no central decision point controlling approval
@@ -62,7 +62,7 @@ These gaps create exposure across several dimensions:
 
 The target state is a system where:
 
-> Nothing becomes generally consumable in the internal development environment without passing through a consistent, explainable, and auditable dependency admission process.
+> Nothing becomes generally consumable in the internal development environment without passing through a consistent, explainable, and auditable dependency review process.
 
 ---
 
@@ -129,9 +129,9 @@ The target state is a system where:
 
 # 4. Core Concept
 
-## 4.1 Dependency Admission Control
+## 4.1 Dependency Dependency Review
 
-The closest conceptual analogue is **Kubernetes Admission Control**.
+The closest conceptual analogue is **Kubernetes Dependency Review**.
 
 In Kubernetes, requests to create or modify objects are intercepted before acceptance. Policies validate or mutate the request, and the cluster either accepts or rejects the object.
 
@@ -140,12 +140,12 @@ This system applies the same mental model to software dependencies.
 | Kubernetes                          | This System                               |
 | ----------------------------------- | ----------------------------------------- |
 | API request to create/update object | Request to add package or upgrade version |
-| Admission webhook                   | Admission orchestrator                    |
+| Review webhook                   | Review orchestrator                    |
 | Policy engine                       | OPA policy evaluation                     |
 | Allow / deny / mutate               | Approve / reject / constrain              |
 | Cluster state                       | Internal artifact availability state      |
 
-The result is a **Dependency Admission Controller**.
+The result is a **Dependency Dependency Reviewler**.
 
 ## 4.2 Why this is different from standard scanning
 
@@ -180,7 +180,7 @@ This system must answer broader questions:
    - agentic/LLM analysis informs decisions
    - OPA and deterministic rules enforce decisions
 
-4. **Admission before broad consumption**
+4. **Review before broad consumption**
 
    - packages may exist in quarantine, but not in approved repositories until a decision is made
 
@@ -237,7 +237,7 @@ This system must answer broader questions:
 Trigger Source
   -> Event Layer
   -> Workflow Orchestration
-  -> Admission Orchestrator
+  -> Review Orchestrator
       -> Package Metadata Enrichment
       -> SBOM Generation
       -> Security Scanners
@@ -329,7 +329,7 @@ Recommended characteristics:
 
 ## 9.1 Closest Conceptual Prior Art
 
-### Kubernetes admission controllers
+### Kubernetes dependency reviewlers
 
 Examples:
 
@@ -362,7 +362,7 @@ Examples:
 - SLSA-aligned practices
 - GUAC
 
-These establish provenance and evidence but do not independently solve contextual package admission.
+These establish provenance and evidence but do not independently solve contextual package review.
 
 ## 9.2 Coverage vs gap
 
@@ -384,7 +384,7 @@ These establish provenance and evidence but do not independently solve contextua
 ### Largely uncovered and differentiated
 
 - task-fit / intent-aware dependency reasoning
-- centralized, event-driven dependency admission control
+- centralized, event-driven dependency dependency review
 - upgrade risk delta analysis as a first-class workflow
 - explainable, unified decision control plane that composes scanners and policy
 
@@ -392,7 +392,7 @@ These establish provenance and evidence but do not independently solve contextua
 
 This system can be positioned as:
 
-> Kubernetes-style admission control for software dependencies, implemented as an event-driven, policy-enforced control plane with contextual risk reasoning.
+> Kubernetes-style dependency review for software dependencies, implemented as an event-driven, policy-enforced control plane with contextual risk reasoning.
 
 ---
 
@@ -1597,7 +1597,7 @@ Outputs:
 - durable orchestrated workflow backbone
 - reusable workflow templates
 
-## Epic 4: Admission Orchestrator Service
+## Epic 4: Review Orchestrator Service
 
 Objective: Build the core control-plane application.
 
@@ -1707,7 +1707,7 @@ Outputs:
 - standardized decision outputs
 - auditable evidence storage
 
-## Epic 10: New Package Admission Workflow
+## Epic 10: New Package Review Workflow
 
 Objective: Deliver the first end-to-end package approval capability.
 
@@ -1863,11 +1863,11 @@ Include:
 - Platform Foundation
 - Event and Triggering Foundation
 - Workflow Orchestration Foundation
-- Admission Orchestrator Service
+- Review Orchestrator Service
 - minimal Scanner Integration Framework
 - initial Policy Engine
 - Registry Control
-- New Package Admission Workflow
+- New Package Review Workflow
 
 Outcome:
 
@@ -2118,7 +2118,7 @@ It transforms dependency governance from:
 
 into:
 
-- proactive, event-driven, policy-enforced admission control with contextual reasoning and lifecycle reassessment
+- proactive, event-driven, policy-enforced dependency review with contextual reasoning and lifecycle reassessment
 
 This is the architectural shift.
 
@@ -2128,7 +2128,7 @@ This is the architectural shift.
 
 The design is fully achievable with open-source technology.
 
-What does not exist off the shelf is not the scanning layer, the workflow layer, or even the policy layer. Those all exist. The core work is composing them into a coherent **dependency admission control system** with:
+What does not exist off the shelf is not the scanning layer, the workflow layer, or even the policy layer. Those all exist. The core work is composing them into a coherent **dependency dependency review system** with:
 
 - strong event handling
 - durable workflows
@@ -2154,7 +2154,7 @@ This section translates the design into **build-ready architecture guidance** fo
 | Service              | Responsibility                     | Tech suggestion           |
 | -------------------- | ---------------------------------- | ------------------------- |
 | API Gateway          | external entrypoint, auth, routing | NGINX / Kong              |
-| Admission API        | request intake + validation        | Go / FastAPI              |
+| Review API        | request intake + validation        | Go / FastAPI              |
 | Orchestrator Workers | workflow logic, Temporal workers   | Go preferred              |
 | Scanner Workers      | execute scanning jobs              | containerized jobs (Argo) |
 | Policy Service       | OPA sidecar or centralized         | OPA                       |
@@ -2176,20 +2176,20 @@ This section translates the design into **build-ready architecture guidance** fo
 ## 36.2 Namespace / Deployment Layout (Kubernetes)
 
 ```
-dep-admission-core/
+dep-review-core/
   api
   orchestrator
   policy
 
-dep-admission-execution/
+dep-review-execution/
   scanners
   argo-workflows
 
-dep-admission-data/
+dep-review-data/
   postgres
   minio
 
-dep-admission-observability/
+dep-review-observability/
   prometheus
   grafana
   loki
@@ -2411,9 +2411,9 @@ flowchart TB
     end
 
     subgraph CP["Control Plane"]
-        ADMIT["Admission API"]
+        ADMIT["Review API"]
         TEMP["Temporal Workflows"]
-        ORCH["Admission Orchestrator"]
+        ORCH["Review Orchestrator"]
         POLICY["OPA Policy Engine"]
         TASKFIT["Task-Fit / Agentic Reasoning"]
         DECIDE["Decision Assembly"]
@@ -2525,9 +2525,9 @@ Audit / Search / Analytics"]
 
 ```mermaid
 flowchart LR
-    A["Requests / Events"] --> B["Admission API"]
+    A["Requests / Events"] --> B["Review API"]
     B --> C["Temporal Control Plane"]
-    C --> D["Admission Orchestrator"]
+    C --> D["Review Orchestrator"]
 
     D --> E["Argo Scanner Workflows"]
     E --> E1["SBOM / Vuln / License / Code / Provenance"]
@@ -2553,26 +2553,26 @@ flowchart LR
 ```mermaid
 flowchart TB
     subgraph CLUSTER["k3s / Kubernetes Cluster"]
-        subgraph CORE["dep-admission-core"]
-            API2["Admission API"]
+        subgraph CORE["dep-review-core"]
+            API2["Review API"]
             ORCH2["Orchestrator Workers"]
             OPA2["OPA"]
             NOTIF2["Notification Service"]
         end
 
-        subgraph EXEC["dep-admission-execution"]
+        subgraph EXEC["dep-review-execution"]
             TEMP2["Temporal"]
             ARGO2["Argo Workflows"]
             SCAN2["Scanner Jobs"]
         end
 
-        subgraph DATA["dep-admission-data"]
+        subgraph DATA["dep-review-data"]
             PG2["PostgreSQL"]
             MINIO2["MinIO"]
             SEARCH2["OpenSearch"]
         end
 
-        subgraph OBS2["dep-admission-observability"]
+        subgraph OBS2["dep-review-observability"]
             PROM2["Prometheus"]
             GRAF2["Grafana"]
             LOKI2["Loki"]
@@ -2608,7 +2608,7 @@ flowchart TB
 ```mermaid
 sequenceDiagram
     participant U as User / CI / Event Source
-    participant API as Admission API
+    participant API as Review API
     participant T as Temporal Workflow
     participant O as Orchestrator Worker
     participant A as Argo Workflow
@@ -2636,7 +2636,7 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant D as Developer
-    participant API as Admission API
+    participant API as Review API
     participant T as Temporal
     participant O as Orchestrator
     participant E as Metadata Enrichment
@@ -2667,7 +2667,7 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant D as Developer / CI
-    participant API as Admission API
+    participant API as Review API
     participant T as Temporal
     participant O as Orchestrator
     participant CUR as Current Version Metadata
@@ -2794,7 +2794,7 @@ flowchart LR
 
 ```mermaid
 flowchart TB
-    API3["Admission API"] --> TEMP3["Temporal"]
+    API3["Review API"] --> TEMP3["Temporal"]
     TEMP3 --> ORCH3["Orchestrator Workers"]
     ORCH3 --> OPA3["OPA"]
     ORCH3 --> ARGO3["Argo Workflows"]
@@ -2814,7 +2814,7 @@ flowchart TB
 flowchart TD
     E1["Epic 1: Platform Foundation"] --> E2["Epic 2: Event and Triggering"]
     E1 --> E3["Epic 3: Workflow Orchestration"]
-    E1 --> E4["Epic 4: Admission Orchestrator"]
+    E1 --> E4["Epic 4: Review Orchestrator"]
     E2 --> E4
     E3 --> E4
     E4 --> E5["Epic 5: Metadata Enrichment"]

--- a/docs/architecture-plan-v2.md
+++ b/docs/architecture-plan-v2.md
@@ -1,4 +1,4 @@
-# Agentic Dependency Admission Control — v2
+# Agentic Dependency Dependency Review — v2
 
 ## OSS Architecture, Operating Model, and Phased Implementation Plan
 
@@ -6,7 +6,7 @@
 
 # 1. Executive Summary
 
-This document defines a **platform-agnostic, event-driven dependency admission control system** for governing how third-party software packages and version upgrades are approved for use.
+This document defines a **platform-agnostic, event-driven dependency dependency review system** for governing how third-party software packages and version upgrades are approved for use.
 
 The core objective is to move dependency security from a **reactive scanning model** to a **proactive eedom model**.
 
@@ -31,7 +31,7 @@ The architecture is explicitly **not tied to any single artifact backend**. Any 
 
 This revision preserves the north-star architecture from v1 but fundamentally reworks how we get there:
 
-- **Phase 0 is a Jenkins CI proof of concept** — no new infrastructure, no new cluster, no Temporal, no Argo. Dependency admission runs as a Jenkins pipeline using existing CI infrastructure.
+- **Phase 0 is a Jenkins CI proof of concept** — no new infrastructure, no new cluster, no Temporal, no Argo. Dependency review runs as a Jenkins pipeline using existing CI infrastructure.
 - **Build-vs-buy analysis added** — existing tools cover ~60% of the capability stack. We build only the differentiated value and compose the rest.
 - **Three operating modes from day one** — monitor, advise, enforce. Launch in monitor. Graduate to enforce per-team, not org-wide.
 - **Team sizing and operational cost** explicitly stated per phase.
@@ -46,7 +46,7 @@ This revision preserves the north-star architecture from v1 but fundamentally re
 Modern development teams regularly introduce third-party packages and version upgrades to accelerate delivery. In practice, those changes often occur with inconsistent or incomplete review. Typical organizational failure modes include:
 
 - dependency approval happens informally through chat or tribal knowledge
-- repositories proxy public ecosystems without strong admission controls
+- repositories proxy public ecosystems without strong dependency reviews
 - version upgrades are treated as routine housekeeping rather than change risk events
 - teams optimize for speed and convenience over minimum necessary dependency footprint
 - scanners produce findings, but there is no central decision point controlling approval
@@ -67,7 +67,7 @@ These gaps create exposure across several dimensions:
 
 The target state is a system where:
 
-> Nothing becomes generally consumable in the internal development environment without passing through a consistent, explainable, and auditable dependency admission process.
+> Nothing becomes generally consumable in the internal development environment without passing through a consistent, explainable, and auditable dependency review process.
 
 ---
 
@@ -99,9 +99,9 @@ The target state is a system where:
 
 # 4. Core Concept
 
-## 4.1 Dependency Admission Control
+## 4.1 Dependency Dependency Review
 
-The closest conceptual analogue is **Kubernetes Admission Control**.
+The closest conceptual analogue is **Kubernetes Dependency Review**.
 
 In Kubernetes, requests to create or modify objects are intercepted before acceptance. Policies validate or mutate the request, and the cluster either accepts or rejects the object.
 
@@ -110,12 +110,12 @@ This system applies the same mental model to software dependencies.
 | Kubernetes                          | This System                               |
 | ----------------------------------- | ----------------------------------------- |
 | API request to create/update object | Request to add package or upgrade version |
-| Admission webhook                   | Admission orchestrator                    |
+| Review webhook                   | Review orchestrator                    |
 | Policy engine                       | OPA policy evaluation                     |
 | Allow / deny / mutate               | Approve / reject / constrain              |
 | Cluster state                       | Internal artifact availability state      |
 
-The result is a **Dependency Admission Controller**.
+The result is a **Dependency Dependency Reviewler**.
 
 ## 4.2 Why this is different from standard scanning
 
@@ -141,7 +141,7 @@ This system must answer broader questions:
 2. **Event-driven first** — requests and changes should trigger evaluation immediately
 3. **Repository-agnostic** — Artifactory, Nexus, Harbor, GitHub Packages, CodeArtifact, or internal proxies can all fit
 4. **Reasoning is advisory; policy is authoritative** — agentic/LLM analysis informs decisions; OPA and deterministic rules enforce decisions
-5. **Admission before broad consumption** — packages may exist in quarantine, but not in approved repositories until a decision is made
+5. **Review before broad consumption** — packages may exist in quarantine, but not in approved repositories until a decision is made
 6. **Upgrades are first-class risk events** — version bumps are not treated as routine by default
 7. **Auditability by default** — every decision should have an evidence trail
 8. **Progressive automation** — start with human review and narrow auto-approvals; expand automation as confidence increases
@@ -175,7 +175,7 @@ The system must support three operating modes from day one. This is non-negotiab
 - Dependency changes that violate policy are blocked
 - Approved alternatives are surfaced with rejections
 - Exception and bypass paths are available
-- Purpose: actual admission control
+- Purpose: actual dependency review
 
 ## 6.4 Mode Transition Rules
 
@@ -193,7 +193,7 @@ The system must support three operating modes from day one. This is non-negotiab
 
 When the system is unavailable or producing false positives at scale:
 
-- **Automatic bypass**: if the admission pipeline does not return a decision within the configured timeout (default: 5 minutes), the dependency change proceeds with a logged `BYPASS_TIMEOUT` decision
+- **Automatic bypass**: if the review pipeline does not return a decision within the configured timeout (default: 5 minutes), the dependency change proceeds with a logged `BYPASS_TIMEOUT` decision
 - **Manual bypass**: authorized users can invoke a bypass command (CLI, API, or Jenkins parameter) that logs a `BYPASS_MANUAL` decision with the invoker's identity and stated reason
 - **Kill switch**: platform operators can set the entire system to monitor mode via a single configuration change, restoring full developer autonomy immediately
 - All bypass events are logged, auditable, and included in dashboards
@@ -224,7 +224,7 @@ These capabilities exist in mature, well-maintained open-source tools. We should
 
 | Capability | Existing Coverage | Gap |
 |---|---|---|
-| Repository firewall / quarantine | Nexus Pro, JFrog Xray | OSS options require manual configuration; no event-driven admission workflow |
+| Repository firewall / quarantine | Nexus Pro, JFrog Xray | OSS options require manual configuration; no event-driven review workflow |
 | Policy gates on dependencies | Xray, Sonatype Lifecycle | Proprietary, vendor-locked, limited contextual reasoning |
 | SBOM diff / upgrade analysis | None turnkey | Individual tools exist but no unified upgrade-risk workflow |
 
@@ -235,7 +235,7 @@ These capabilities exist in mature, well-maintained open-source tools. We should
 | Capability | Market Status |
 |---|---|
 | Task-fit / intent-aware dependency reasoning | No existing solution |
-| Centralized, event-driven dependency admission control plane | No turnkey OSS solution |
+| Centralized, event-driven dependency dependency review plane | No turnkey OSS solution |
 | Upgrade risk delta analysis as a first-class workflow | No unified solution |
 | Explainable decision memos composing scanner + policy + context | No existing solution |
 | Three-mode (monitor/advise/enforce) progressive rollout | No existing solution |
@@ -247,8 +247,8 @@ These capabilities exist in mature, well-maintained open-source tools. We should
 | Approach | Covers | Doesn't Cover | Cost Model | Lock-in Risk |
 |---|---|---|---|---|
 | Sonatype Lifecycle + Firewall | Vuln scanning, license, quarantine, policy | Task-fit, upgrade intelligence, unified control plane | Per-developer licensing | High (proprietary policy engine) |
-| JFrog Xray + Advanced Security | Vuln scanning, license, contextual analysis, secrets | Task-fit reasoning, event-driven admission workflow | Platform licensing | High (Artifactory-coupled) |
-| This system (OSS) | Everything above + task-fit + upgrade intelligence + admission control | Requires build + ops investment | Infrastructure + team cost | None (OSS stack) |
+| JFrog Xray + Advanced Security | Vuln scanning, license, contextual analysis, secrets | Task-fit reasoning, event-driven review workflow | Platform licensing | High (Artifactory-coupled) |
+| This system (OSS) | Everything above + task-fit + upgrade intelligence + dependency review | Requires build + ops investment | Infrastructure + team cost | None (OSS stack) |
 
 **Recommendation**: If the organization wants task-fit reasoning, upgrade intelligence, and vendor independence, build this system. If the organization only needs vulnerability scanning and basic policy gates, buy Sonatype or JFrog — it's cheaper and faster.
 
@@ -309,7 +309,7 @@ The following are assumed to exist before product development begins. If they do
 
 ## 9.1 Closest Conceptual Prior Art
 
-### Kubernetes admission controllers
+### Kubernetes dependency reviewlers
 
 Examples: OPA Gatekeeper, Kyverno
 
@@ -325,7 +325,7 @@ These provide parts of the capability stack: vulnerability scanning, policy enfo
 
 Examples: Sigstore, in-toto, SLSA-aligned practices, GUAC
 
-These establish provenance and evidence but do not independently solve contextual package admission.
+These establish provenance and evidence but do not independently solve contextual package review.
 
 ## 9.2 Coverage vs gap
 
@@ -345,14 +345,14 @@ These establish provenance and evidence but do not independently solve contextua
 ### Largely uncovered and differentiated
 
 - task-fit / intent-aware dependency reasoning
-- centralized, event-driven dependency admission control
+- centralized, event-driven dependency dependency review
 - upgrade risk delta analysis as a first-class workflow
 - explainable, unified decision control plane that composes scanners and policy
 - progressive rollout with monitor/advise/enforce modes
 
 ## 9.3 Positioning statement
 
-> Kubernetes-style admission control for software dependencies, implemented as an event-driven, policy-enforced control plane with contextual risk reasoning and progressive enforcement.
+> Kubernetes-style dependency review for software dependencies, implemented as an event-driven, policy-enforced control plane with contextual risk reasoning and progressive enforcement.
 
 ---
 
@@ -616,7 +616,7 @@ The system defaults to **fail-open** in all phases. This means:
 - If a scanner fails or times out, the workflow continues without that scanner's results. The decision memo notes the missing scanner output.
 - If the OPA policy evaluation fails, the request is marked `NEEDS_HUMAN_REVIEW` — it is not auto-rejected.
 - If the orchestrator service is unavailable, dependency changes proceed normally. No blocking occurs.
-- If the Jenkins pipeline step fails, the build continues. The admission step is advisory, not a build gate (until enforce mode is enabled for that team).
+- If the Jenkins pipeline step fails, the build continues. The review step is advisory, not a build gate (until enforce mode is enabled for that team).
 
 ## 14.2 Fail-closed behavior (opt-in)
 
@@ -1037,7 +1037,7 @@ The task-fit layer is only useful when the approved-alternatives catalog is popu
 2. Auto-approve these as the initial approved catalog
 3. For each approved package, record its primary use case category
 4. Seed the alternatives mapping: for each category, list the approved options
-5. Expand the catalog as new packages are approved through the admission process
+5. Expand the catalog as new packages are approved through the review process
 
 This bootstrap is a **prerequisite** for transitioning any team to advise or enforce mode. It should be completed during the PoC phase using existing lockfile data.
 
@@ -1255,7 +1255,7 @@ The biggest non-technical risk is workflow bypass. Teams will bypass if:
 
 ### Platform engineering
 
-- operate the admission control system
+- operate the dependency review system
 - maintain Jenkins pipeline (PoC) or orchestrator service (later phases)
 - maintain registry integrations
 - manage operating mode transitions
@@ -1282,7 +1282,7 @@ The biggest non-technical risk is workflow bypass. Teams will bypass if:
 
 | Function | Owner |
 |---|---|
-| Admission system ops | Platform |
+| Review system ops | Platform |
 | Scanner execution reliability | Platform / Security shared |
 | OPA policy rules | Security |
 | Approved alternatives catalog | Security / Platform / App enablement shared |
@@ -1355,7 +1355,7 @@ Ongoing ops: 2-3 FTE for full platform operations.
 | Sonatype Lifecycle | 0.5-1 eng-month (integration) | 0.25 FTE | $50-200K licensing | Moderate-High |
 | JFrog Xray + Advanced | 0.5-1 eng-month (integration) | 0.25 FTE | $50-250K licensing | Moderate-High |
 
-**Decision point**: if the organization values vendor independence and the differentiated capabilities (task-fit, upgrade intelligence, admission control plane), the build cost is justified. If only vulnerability scanning and basic policy gates are needed, buy.
+**Decision point**: if the organization values vendor independence and the differentiated capabilities (task-fit, upgrade intelligence, dependency review plane), the build cost is justified. If only vulnerability scanning and basic policy gates are needed, buy.
 
 ---
 
@@ -1396,7 +1396,7 @@ This plan is organized around delivery phases, not a waterfall of 17 sequential 
 
 ### Epic 0.1: Jenkins Pipeline Foundation
 
-Objective: Build a Jenkins shared library that detects dependency changes and runs admission evaluation.
+Objective: Build a Jenkins shared library that detects dependency changes and runs review evaluation.
 
 Scope:
 
@@ -1415,7 +1415,7 @@ Outputs:
 
 - working Jenkins pipeline evaluating dependency changes on PRs
 - decision database with queryable records
-- PR comments with admission decisions
+- PR comments with review decisions
 
 ### Epic 0.2: Initial Policy Bundle
 
@@ -1468,7 +1468,7 @@ Outputs:
 
 ## Phase 1: Service Extraction (4-6 weeks)
 
-### Epic 1.1: Admission Orchestrator Service
+### Epic 1.1: Review Orchestrator Service
 
 Objective: Extract the Jenkins pipeline logic into a standalone service.
 
@@ -1763,7 +1763,7 @@ A developer's build is blocked by a false positive in enforce mode.
 
 # 34. Recommended MVP (Phase 0 Jenkins PoC)
 
-The MVP is a Jenkins pipeline that proves the admission control concept works with zero new infrastructure.
+The MVP is a Jenkins pipeline that proves the dependency review concept works with zero new infrastructure.
 
 **Included:**
 
@@ -1817,7 +1817,7 @@ PR (dependency file change)
 Trigger Source
   → Event Layer (NATS / Webhooks)
   → Workflow Orchestration (Temporal)
-  → Admission Orchestrator
+  → Review Orchestrator
       → Package Metadata Enrichment
       → SBOM Generation
       → Security Scanners (via Argo Workflows)
@@ -1906,9 +1906,9 @@ flowchart TB
     end
 
     subgraph CP["Control Plane"]
-        ADMIT["Admission API"]
+        ADMIT["Review API"]
         TEMP["Temporal Workflows"]
-        ORCH["Admission Orchestrator"]
+        ORCH["Review Orchestrator"]
         POLICY["OPA Policy Engine"]
         TASKFIT2["Task-Fit Reasoning"]
         DECIDE2["Decision Assembly"]
@@ -2019,7 +2019,7 @@ sequenceDiagram
     J->>OS: Store evidence bundle
     J->>GH: Post PR comment with findings
     J->>J: Set build status per operating mode
-    GH-->>D: PR shows admission results
+    GH-->>D: PR shows review results
 ```
 
 ## 36.4 Operating Mode State Diagram
@@ -2040,7 +2040,7 @@ stateDiagram-v2
 ```mermaid
 sequenceDiagram
     participant U as User / CI / Event Source
-    participant API as Admission API
+    participant API as Review API
     participant T as Temporal Workflow
     participant O as Orchestrator Worker
     participant A as Argo Workflow
@@ -2068,7 +2068,7 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant D as Developer
-    participant API as Admission API
+    participant API as Review API
     participant O as Orchestrator
     participant E as Metadata Enrichment
     participant S as Scanners
@@ -2097,7 +2097,7 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant D as Developer / CI
-    participant API as Admission API
+    participant API as Review API
     participant O as Orchestrator
     participant CUR as Current Version Data
     participant TAR as Target Version Data

--- a/docs/elevator-pitch.md
+++ b/docs/elevator-pitch.md
@@ -1,4 +1,19 @@
-# Eagle Eyed Dom — Automated Code Review for CI
+<div align="center">
+  <img src="../assets/hero.svg" alt="Eagle Eyed Dom" width="900">
+  <br>
+  <strong>Fully deterministic dependency review for CI.</strong><br>
+  15 plugins. 6 OPA policy rules. 18 ecosystems. Zero LLM in the decision path.
+  <br><br>
+
+  <a href="../README.md#quick-start"><img src="https://img.shields.io/badge/get_started-→-d4251a?style=flat-square" alt="Get Started"></a>
+  <a href="../README.md#the-15-plugins"><img src="https://img.shields.io/badge/15_plugins-deterministic-f2c14a?style=flat-square&labelColor=0e0706" alt="15 Plugins"></a>
+  <a href="../README.md#opa-policy-rules"><img src="https://img.shields.io/badge/OPA-6_rules-1e3a8a?style=flat-square" alt="OPA Rules"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-PolyForm_Shield-7ae582?style=flat-square" alt="PolyForm Shield License"></a>
+</div>
+
+<br>
+
+---
 
 ## The problem
 

--- a/docs/solutions/integration-issues/mock-masked-integration-wiring-failures.md
+++ b/docs/solutions/integration-issues/mock-masked-integration-wiring-failures.md
@@ -39,7 +39,7 @@ Each module's unit tests verify that module's behavior in isolation. The scanner
 
 ### Layer 3: E2E tests mock at the wrong boundary
 
-The E2E integration test (`test_e2e.py`) was supposed to catch these bugs. Instead, it mocked `ScanOrchestrator` at the class level (replacing it entirely), mocked `DependencyDiffDetector.parse_requirements_diff` to inject fake changes, and limited `ADMISSION_ENABLED_SCANNERS` to only the two scanners whose constructors happened to work. The E2E test effectively rewired the pipeline to avoid the broken paths, then verified the non-broken subset worked.
+The E2E integration test (`test_e2e.py`) was supposed to catch these bugs. Instead, it mocked `ScanOrchestrator` at the class level (replacing it entirely), mocked `DependencyDiffDetector.parse_requirements_diff` to inject fake changes, and limited `EEDOM_ENABLED_SCANNERS` to only the two scanners whose constructors happened to work. The E2E test effectively rewired the pipeline to avoid the broken paths, then verified the non-broken subset worked.
 
 **The test passed because it tested a different pipeline than the one the CLI actually runs.**
 

--- a/docs/solutions/integration-issues/review-loop-resolution-pass1-to-pass2.md
+++ b/docs/solutions/integration-issues/review-loop-resolution-pass1-to-pass2.md
@@ -46,7 +46,7 @@ The system had 246 passing tests but was entirely non-functional in production. 
 
 ### Architecture extraction
 
-`cli/main.py` (285 lines of business logic) → `core/pipeline.py` (AdmissionPipeline class) + thin CLI adapter (150 lines). The presentation layer no longer owns business logic.
+`cli/main.py` (285 lines of business logic) → `core/pipeline.py` (ReviewPipeline class) + thin CLI adapter (150 lines). The presentation layer no longer owns business logic.
 
 ## Regressions Caught During Pass 2
 

--- a/docs/solutions/performance-issues/architecture-violations-coupling-and-sequential-scanners.md
+++ b/docs/solutions/performance-issues/architecture-violations-coupling-and-sequential-scanners.md
@@ -69,23 +69,23 @@ This is ALL business logic. The CLI should be a thin adapter: parse args → cal
 ```python
 # After — extract to core/pipeline.py
 # core/pipeline.py
-class AdmissionPipeline:
-    def __init__(self, config: AdmissionSettings):
+class ReviewPipeline:
+    def __init__(self, config: EedomSettings):
         self._config = config
         self._orchestrator = self._build_orchestrator()
         self._opa = OpaEvaluator(...)
         self._evidence = EvidenceStore(...)
         self._db = self._connect_db()
 
-    def evaluate(self, diff_text: str, pr_url: str, team: str, mode: OperatingMode) -> list[AdmissionDecision]:
+    def evaluate(self, diff_text: str, pr_url: str, team: str, mode: OperatingMode) -> list[ReviewDecision]:
         """Run the full pipeline. Returns decisions for all changed packages."""
         ...
 
 # cli/main.py — thin adapter
 @cli.command()
 def evaluate(repo_path, diff, pr_url, team, operating_mode, output_json):
-    config = AdmissionSettings()
-    pipeline = AdmissionPipeline(config)
+    config = EedomSettings()
+    pipeline = ReviewPipeline(config)
     diff_text = _read_diff(diff)
     decisions = pipeline.evaluate(diff_text, pr_url, team, OperatingMode(operating_mode))
     for d in decisions:

--- a/docs/solutions/runtime-errors/silent-safety-rule-bypasses.md
+++ b/docs/solutions/runtime-errors/silent-safety-rule-bypasses.md
@@ -121,4 +121,4 @@ Both bypasses share the same root cause: **the contract between producer and con
 
 - `.wfc/reviews/REVIEW-main-001.md` — findings F-010, F-012
 - `policies/INPUT_SCHEMA.md` — the OPA input schema that the Python code should match
-- `policies/admission_test.rego` — OPA tests that pass with correct input but never verify Python produces correct input
+- `policies/policy_test.rego` — OPA tests that pass with correct input but never verify Python produces correct input

--- a/docs/solutions/security-issues/injection-and-secret-leaks-across-layers.md
+++ b/docs/solutions/security-issues/injection-and-secret-leaks-across-layers.md
@@ -1,6 +1,6 @@
 ---
 title: "Injection and Secret Leaks Across Three Layers"
-component: jenkins/vars/dependencyAdmission.groovy, src/eedom/data/db.py, src/eedom/core/taskfit.py
+component: jenkins/vars/dependencyReview.groovy, src/eedom/data/db.py, src/eedom/core/taskfit.py
 tags: security, injection, shell-injection, credential-leak, prompt-injection, jenkins, secrets, owasp
 category: security-issues
 date: 2026-04-23
@@ -28,7 +28,7 @@ Each agent implemented its layer correctly from a functional standpoint but appl
 
 ### Vulnerability 1: Jenkins shell injection (F-008, severity 8)
 
-`dependencyAdmission.groovy:142` constructs a shell command via Groovy string interpolation with single-quote wrapping:
+`dependencyReview.groovy:142` constructs a shell command via Groovy string interpolation with single-quote wrapping:
 
 ```groovy
 // Before — shell injection via single-quote breakout

--- a/policies/INPUT_SCHEMA.md
+++ b/policies/INPUT_SCHEMA.md
@@ -1,6 +1,6 @@
-# OPA Admission Policy — Input Schema
+# OPA Policy — Input Schema
 
-The `admission` package expects a single JSON input object with three top-level keys:
+The `policy` package expects a single JSON input object with three top-level keys:
 `findings`, `package`, and `config`.
 
 ## `input.findings` — array of scanner findings

--- a/policies/policy.rego
+++ b/policies/policy.rego
@@ -1,4 +1,4 @@
-package admission
+package policy
 
 import rego.v1
 

--- a/policies/policy_test.rego
+++ b/policies/policy_test.rego
@@ -1,8 +1,8 @@
-package admission_test
+package policy_test
 
 import rego.v1
 
-import data.admission
+import data.policy
 
 # --- Helper: base input with no findings and all rules enabled ---
 
@@ -47,7 +47,7 @@ test_critical_vuln_deny if {
 		"advisory_id": "CVE-2024-1234",
 		"source_tool": "osv-scanner",
 	}]})
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 1
 	some msg in result
 	contains(msg, "CVE-2024-1234")
@@ -66,7 +66,7 @@ test_high_vuln_deny if {
 		"advisory_id": "CVE-2024-5555",
 		"source_tool": "trivy",
 	}]})
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 1
 	some msg in result
 	contains(msg, "CVE-2024-5555")
@@ -85,9 +85,9 @@ test_medium_vuln_warn_only if {
 		"advisory_id": "CVE-2024-5678",
 		"source_tool": "osv-scanner",
 	}]})
-	deny_result := admission.deny with input as inp
+	deny_result := policy.deny with input as inp
 	count(deny_result) == 0
-	warn_result := admission.warn with input as inp
+	warn_result := policy.warn with input as inp
 	count(warn_result) == 1
 	some msg in warn_result
 	contains(msg, "CVE-2024-5678")
@@ -97,11 +97,11 @@ test_medium_vuln_warn_only if {
 # --- No findings results in allow ---
 
 test_no_findings_approve if {
-	deny_result := admission.deny with input as clean_input
+	deny_result := policy.deny with input as clean_input
 	count(deny_result) == 0
-	warn_result := admission.warn with input as clean_input
+	warn_result := policy.warn with input as clean_input
 	count(warn_result) == 0
-	decision := admission.decision with input as clean_input
+	decision := policy.decision with input as clean_input
 	decision == "approve"
 }
 
@@ -118,7 +118,7 @@ test_forbidden_license_deny if {
 		"source_tool": "scancode",
 		"license_id": "GPL-3.0-only",
 	}]})
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 1
 	some msg in result
 	contains(msg, "GPL-3.0-only")
@@ -138,7 +138,7 @@ test_allowed_license_no_deny if {
 		"source_tool": "scancode",
 		"license_id": "MIT",
 	}]})
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 0
 }
 
@@ -150,7 +150,7 @@ test_young_package_deny if {
 		"first_published_date": "2099-01-01T00:00:00Z",
 	})
 	inp := object.union(clean_input, {"pkg": young_package})
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 1
 	some msg in result
 	contains(msg, "days old")
@@ -160,7 +160,7 @@ test_young_package_deny if {
 
 test_old_package_no_deny if {
 	# 2020-01-01 is well over 90 days old
-	result := admission.deny with input as clean_input
+	result := policy.deny with input as clean_input
 	count(result) == 0
 }
 
@@ -176,7 +176,7 @@ test_malicious_package_deny if {
 		"advisory_id": "MAL-2024-9999",
 		"source_tool": "osv-scanner",
 	}]})
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	some msg in result
 	contains(msg, "MAL-2024-9999")
 	contains(msg, "evil-pkg@0.1.0")
@@ -187,7 +187,7 @@ test_malicious_package_deny if {
 test_transitive_deps_warn if {
 	heavy_package := object.union(base_package, {"transitive_dep_count": 250})
 	inp := object.union(clean_input, {"pkg": heavy_package})
-	warn_result := admission.warn with input as inp
+	warn_result := policy.warn with input as inp
 	count(warn_result) == 1
 	some msg in warn_result
 	contains(msg, "250")
@@ -214,9 +214,9 @@ test_disabled_critical_vuln_no_deny if {
 		"pkg": base_package,
 		"config": disabled_config,
 	}
-	deny_result := admission.deny with input as inp
+	deny_result := policy.deny with input as inp
 	count(deny_result) == 0
-	warn_result := admission.warn with input as inp
+	warn_result := policy.warn with input as inp
 	count(warn_result) == 0
 }
 
@@ -239,7 +239,7 @@ test_disabled_forbidden_license_no_deny if {
 		"pkg": base_package,
 		"config": disabled_config,
 	}
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 0
 }
 
@@ -261,7 +261,7 @@ test_disabled_malicious_no_deny if {
 		"pkg": base_package,
 		"config": disabled_config,
 	}
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 0
 }
 
@@ -302,7 +302,7 @@ test_multiple_deny_reasons if {
 		"pkg": base_package,
 		"config": base_config,
 	}
-	result := admission.deny with input as inp
+	result := policy.deny with input as inp
 	count(result) == 3
 }
 
@@ -318,7 +318,7 @@ test_decision_reject if {
 		"advisory_id": "CVE-2024-0001",
 		"source_tool": "osv-scanner",
 	}]})
-	decision := admission.decision with input as inp
+	decision := policy.decision with input as inp
 	decision == "reject"
 }
 
@@ -334,13 +334,13 @@ test_decision_approve_with_constraints if {
 		"advisory_id": "CVE-2024-9999",
 		"source_tool": "osv-scanner",
 	}]})
-	decision := admission.decision with input as inp
+	decision := policy.decision with input as inp
 	decision == "approve_with_constraints"
 }
 
 # --- Decision: approve when no deny and no warn ---
 
 test_decision_approve if {
-	decision := admission.decision with input as clean_input
+	decision := policy.decision with input as clean_input
 	decision == "approve"
 }

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,7 +1,7 @@
-"""GitHub Copilot Agent for dependency admission control and code review.
+"""GitHub Copilot Agent for dependency dependency review and code review.
 # tested-by: tests/unit/test_agent_main.py
 
 Reactive PR flow: triggers on lockfile/manifest changes, evaluates packages via
-the admission pipeline, runs Semgrep on changed files, and posts per-package
+the review pipeline, runs Semgrep on changed files, and posts per-package
 review comments with task-fit reasoning.
 """

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -1,8 +1,8 @@
 """Agent-specific configuration for GATEKEEPER.
 # tested-by: tests/unit/test_agent_config.py
 
-Separate from AdmissionSettings — uses GATEKEEPER_ env prefix.
-The agent constructs an AdmissionSettings internally when calling the pipeline.
+Separate from EedomSettings — uses GATEKEEPER_ env prefix.
+The agent constructs an EedomSettings internally when calling the pipeline.
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ class AgentSettings(BaseSettings):
     pipeline_timeout: int = 300
     # TODO: replace with Optional[str] once no-DB mode is implemented.
     # Currently triggers NullRepository fallback in the pipeline.
-    # Removal condition: when AdmissionSettings.db_dsn becomes optional.
+    # Removal condition: when EedomSettings.db_dsn becomes optional.
     db_dsn: str = "postgresql://unused:unused@localhost/unused"
     policy_version: str = "1.0.0"
 

--- a/src/agent/main.py
+++ b/src/agent/main.py
@@ -132,7 +132,7 @@ class GatekeeperAgent:
         agent = GitHubCopilotAgent(
             instructions=system_prompt,
             name="gatekeeper",
-            description="Dependency admission control and code review agent",
+            description="Dependency dependency review and code review agent",
             tools=[
                 evaluate_change,
                 check_package,

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -130,13 +130,13 @@ def build_system_prompt(
         alt_section = f"\n\nApproved alternative packages in this organization: {alt_list}"
 
     return f"""\
-You are GATEKEEPER, a dependency admission control and code review agent for a \
+You are GATEKEEPER, a dependency dependency review and code review agent for a \
 software engineering organization.
 
 Your job: when a pull request changes dependency manifests or source code, you \
 evaluate the changes and post clear, concise review comments. You have three tools:
 
-1. **evaluate_change** — runs the full admission pipeline (5 scanners + OPA policy) \
+1. **evaluate_change** — runs the full review pipeline (5 scanners + OPA policy) \
 on a PR diff. Call this for every PR with dependency changes.
 2. **check_package** — evaluates a single package via scanners + OPA. Use for \
 targeted lookups.

--- a/src/agent/tool_helpers.py
+++ b/src/agent/tool_helpers.py
@@ -132,12 +132,12 @@ def get_agent_settings() -> object:
 
 
 def make_pipeline_config() -> object:
-    """Build AdmissionSettings from AgentSettings."""
-    from eedom.core.config import AdmissionSettings
+    """Build EedomSettings from AgentSettings."""
+    from eedom.core.config import EedomSettings
     from eedom.core.models import OperatingMode
 
     agent_cfg = get_agent_settings()
-    return AdmissionSettings(
+    return EedomSettings(
         db_dsn=agent_cfg.db_dsn,
         operating_mode=OperatingMode.advise,
         evidence_path=str(agent_cfg.evidence_path),
@@ -209,13 +209,13 @@ def run_pipeline(
     team: str,
     repo_path: str,
 ) -> tuple[list, list[dict], dict]:
-    """Run the admission pipeline. Returns (decisions, sbom_changes, raw_sbom)."""
+    """Run the review pipeline. Returns (decisions, sbom_changes, raw_sbom)."""
     from eedom.core.models import OperatingMode
-    from eedom.core.pipeline import AdmissionPipeline
+    from eedom.core.pipeline import ReviewPipeline
     from eedom.core.sbom_diff import diff_sboms
 
     config = make_pipeline_config()
-    pipeline = AdmissionPipeline(config)
+    pipeline = ReviewPipeline(config)
 
     manifest_changes = detect_manifest_changes(diff_text)
     python_manifests = manifest_changes.pop("pypi", [])

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -1,7 +1,7 @@
 """GATEKEEPER agent tool definitions.
 # tested-by: tests/unit/test_agent_tools.py
 
-Three @tool functions wrapping the admission pipeline and Semgrep.
+Three @tool functions wrapping the review pipeline and Semgrep.
 Internal helpers live in tool_helpers.py.
 """
 
@@ -23,14 +23,14 @@ from eedom.agent.tool_helpers import (
     run_pipeline,
     validate_paths,
 )
-from eedom.core.models import AdmissionDecision
+from eedom.core.models import ReviewDecision
 from eedom.plugins import get_default_registry
 
 logger = structlog.get_logger(__name__)
 
 
-def _serialize_decision(decision: AdmissionDecision) -> dict:
-    """Serialize an AdmissionDecision to a dict for the agent."""
+def _serialize_decision(decision: ReviewDecision) -> dict:
+    """Serialize an ReviewDecision to a dict for the agent."""
     findings_summary: dict[str, int] = {}
     for f in decision.findings:
         sev = f.severity.value
@@ -63,7 +63,7 @@ def _serialize_decision(decision: AdmissionDecision) -> dict:
 @tool(
     name="evaluate_change",
     description=(
-        "Run the full admission pipeline on a PR diff. Supports 18+ ecosystems "
+        "Run the full review pipeline on a PR diff. Supports 18+ ecosystems "
         "(Python, npm, Cargo, Go, Ruby, Maven, NuGet, Dart, PHP, Elixir, Swift, "
         "CocoaPods, and more). Executes 6 tools: Syft (SBOM), OSV-Scanner, "
         "Trivy, ScanCode (vulnerabilities + licenses) + OPA policy + Semgrep "
@@ -76,7 +76,7 @@ def evaluate_change(
     team: Annotated[str, "The team that owns the repository"],
     repo_path: Annotated[str, "Path to the repository root"],
 ) -> dict:
-    """Run full admission pipeline on a PR diff."""
+    """Run full review pipeline on a PR diff."""
     try:
         decisions, sbom_changes, raw_sbom = run_pipeline(
             diff_text,

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,4 +1,4 @@
-"""CLI entry point for the Admission Control pipeline."""
+"""CLI entry point for the Review pipeline."""
 
 # tested-by: tests/unit/test_cli.py
 
@@ -56,7 +56,7 @@ class DebounceTimer:
 
 @click.group()
 def cli() -> None:
-    """Agentic Dependency Admission Control — PoC CLI."""
+    """Agentic Dependency Dependency Review — PoC CLI."""
 
 
 @cli.command()
@@ -86,14 +86,14 @@ def evaluate(
     operating_mode: str,
     output_json: str | None,
 ) -> None:
-    """Run the full admission control pipeline on dependency changes."""
+    """Run the full review pipeline on dependency changes."""
     diff_text = _read_diff(diff)
     mode = OperatingMode(operating_mode)
 
     try:
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
-        config = AdmissionSettings()  # type: ignore[call-arg]
+        config = EedomSettings()  # type: ignore[call-arg]
     except Exception:
         logger.warning(
             "config_load_failed", msg="Pipeline skipped — config unavailable (fail-open)"
@@ -104,9 +104,9 @@ def evaluate(
     try:
         import orjson
 
-        from eedom.core.pipeline import AdmissionPipeline
+        from eedom.core.pipeline import ReviewPipeline
 
-        pipeline = AdmissionPipeline(config)
+        pipeline = ReviewPipeline(config)
         decisions = pipeline.evaluate(
             diff_text=diff_text,
             pr_url=pr_url,
@@ -156,9 +156,9 @@ def check_health() -> None:
     click.echo()
 
     try:
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
-        config = AdmissionSettings()  # type: ignore[call-arg]
+        config = EedomSettings()  # type: ignore[call-arg]
         from eedom.data.db import DecisionRepository
 
         db = DecisionRepository(dsn=config.db_dsn)
@@ -396,7 +396,7 @@ def query(question: str, db_path: str) -> None:
     \b
       eedom query "which functions have the highest fan-out?"
       eedom query "show me dead code"
-      eedom query "what depends on AdmissionPipeline"
+      eedom query "what depends on ReviewPipeline"
       eedom query "are there circular imports?"
     """
     from eedom.core.nl_query import TEMPLATES, query_code

--- a/src/data/db.py
+++ b/src/data/db.py
@@ -1,4 +1,4 @@
-"""Decision record repository -- persistence layer for admission decisions.
+"""Decision record repository -- persistence layer for review decisions.
 # tested-by: tests/unit/test_db.py
 
 Fail-open design: database failures are logged and absorbed, never raised.
@@ -16,8 +16,8 @@ import structlog
 from psycopg_pool import ConnectionPool
 
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     BypassRecord,
     PolicyEvaluation,
     ScanResult,
@@ -28,15 +28,15 @@ logger = structlog.get_logger(__name__)
 
 @runtime_checkable
 class RepositoryProtocol(Protocol):
-    """Structural contract for admission pipeline repository implementations."""
+    """Structural contract for review pipeline repository implementations."""
 
-    def save_request(self, request: AdmissionRequest) -> None: ...
+    def save_request(self, request: ReviewRequest) -> None: ...
     def save_scan_results(self, request_id: uuid.UUID, results: list[ScanResult]) -> None: ...
     def save_policy_evaluation(
         self, request_id: uuid.UUID, evaluation: PolicyEvaluation
     ) -> None: ...
-    def save_decision(self, request_id: uuid.UUID, decision: AdmissionDecision) -> None: ...
-    def get_decision_by_request_id(self, request_id: uuid.UUID) -> AdmissionDecision | None: ...
+    def save_decision(self, request_id: uuid.UUID, decision: ReviewDecision) -> None: ...
+    def get_decision_by_request_id(self, request_id: uuid.UUID) -> ReviewDecision | None: ...
     def save_bypass(self, record: BypassRecord) -> None: ...
     def close(self) -> None: ...
     def connect(self) -> bool: ...
@@ -64,10 +64,10 @@ def _safe_dsn(dsn: str) -> str:
 
 
 class DecisionRepository:
-    """Postgres-backed repository for admission pipeline records.
+    """Postgres-backed repository for review pipeline records.
 
     All methods absorb database errors -- they log the failure and return
-    gracefully so the admission pipeline is never blocked by storage issues.
+    gracefully so the review pipeline is never blocked by storage issues.
     """
 
     def __init__(self, dsn: str, query_timeout: int = 10, connect_timeout: int = 5) -> None:
@@ -106,8 +106,8 @@ class DecisionRepository:
             f"SET LOCAL statement_timeout = '{self._query_timeout * _QUERY_TIMEOUT_MS_MULTIPLIER}'"
         )
 
-    def save_request(self, request: AdmissionRequest) -> None:
-        """INSERT an admission request record."""
+    def save_request(self, request: ReviewRequest) -> None:
+        """INSERT an review request record."""
         if self._pool is None:
             logger.warning("save_request_skipped", reason="no_pool")
             return
@@ -118,7 +118,7 @@ class DecisionRepository:
                     cur.execute(self._timeout_sql())
                     cur.execute(
                         """
-                        INSERT INTO admission_requests (
+                        INSERT INTO review_requests (
                             request_id, request_type, ecosystem, package_name,
                             target_version, current_version, team, scope,
                             pr_url, pr_number, repo_name, commit_sha,
@@ -240,8 +240,8 @@ class DecisionRepository:
                 exc_info=True,
             )
 
-    def save_decision(self, request_id: uuid.UUID, decision: AdmissionDecision) -> None:
-        """INSERT a final admission decision record."""
+    def save_decision(self, request_id: uuid.UUID, decision: ReviewDecision) -> None:
+        """INSERT a final review decision record."""
         if self._pool is None:
             logger.warning("save_decision_skipped", reason="no_pool")
             return
@@ -254,7 +254,7 @@ class DecisionRepository:
                     cur.execute(self._timeout_sql())
                     cur.execute(
                         """
-                        INSERT INTO admission_decisions (
+                        INSERT INTO review_decisions (
                             decision_id, request_id, decision,
                             findings_summary, evidence_bundle_path,
                             memo_text, pipeline_duration_seconds,
@@ -288,7 +288,7 @@ class DecisionRepository:
                 exc_info=True,
             )
 
-    def get_decision_by_request_id(self, request_id: uuid.UUID) -> AdmissionDecision | None:
+    def get_decision_by_request_id(self, request_id: uuid.UUID) -> ReviewDecision | None:
         """SELECT a decision by request_id. Returns None if not found or on error."""
         if self._pool is None:
             logger.warning("get_decision_skipped", reason="no_pool")
@@ -310,8 +310,8 @@ class DecisionRepository:
                             r.repo_name, r.commit_sha, r.use_case,
                             r.operating_mode AS req_operating_mode,
                             r.created_at AS req_created_at
-                        FROM admission_decisions d
-                        JOIN admission_requests r ON r.request_id = d.request_id
+                        FROM review_decisions d
+                        JOIN review_requests r ON r.request_id = d.request_id
                         WHERE d.request_id = %s
                         ORDER BY d.created_at DESC
                         LIMIT 1
@@ -323,7 +323,7 @@ class DecisionRepository:
             if row is None:
                 return None
 
-            request = AdmissionRequest(
+            request = ReviewRequest(
                 request_id=uuid.UUID(row[8]),
                 request_type=row[9],
                 ecosystem=row[10],
@@ -343,7 +343,7 @@ class DecisionRepository:
 
             findings = orjson.loads(row[2]) if row[2] else []
 
-            return AdmissionDecision(
+            return ReviewDecision(
                 decision_id=uuid.UUID(row[0]),
                 request=request,
                 decision=row[1],
@@ -421,7 +421,7 @@ class NullRepository:
     def close(self) -> None:
         pass
 
-    def save_request(self, request: AdmissionRequest) -> None:
+    def save_request(self, request: ReviewRequest) -> None:
         pass
 
     def save_scan_results(self, request_id: uuid.UUID, results: list[ScanResult]) -> None:
@@ -430,10 +430,10 @@ class NullRepository:
     def save_policy_evaluation(self, request_id: uuid.UUID, evaluation: PolicyEvaluation) -> None:
         pass
 
-    def save_decision(self, request_id: uuid.UUID, decision: AdmissionDecision) -> None:
+    def save_decision(self, request_id: uuid.UUID, decision: ReviewDecision) -> None:
         pass
 
-    def get_decision_by_request_id(self, request_id: uuid.UUID) -> AdmissionDecision | None:
+    def get_decision_by_request_id(self, request_id: uuid.UUID) -> ReviewDecision | None:
         return None
 
     def save_bypass(self, record: BypassRecord) -> None:

--- a/src/data/parquet_writer.py
+++ b/src/data/parquet_writer.py
@@ -1,7 +1,7 @@
 """Parquet evidence writer — append-only columnar audit log.
 # tested-by: tests/unit/test_parquet_writer.py
 
-Writes admission decisions to a single append-only parquet file per
+Writes review decisions to a single append-only parquet file per
 evidence root. Enables DuckDB-powered analytics and LLM-queryable
 audit history without loading individual JSON files.
 
@@ -17,7 +17,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import structlog
 
-from eedom.core.models import AdmissionDecision
+from eedom.core.models import ReviewDecision
 
 logger = structlog.get_logger(__name__)
 
@@ -56,8 +56,8 @@ SCHEMA = pa.schema(
 )
 
 
-def decision_to_row(decision: AdmissionDecision, run_id: str = "") -> dict:
-    """Flatten an AdmissionDecision into a parquet-ready dict."""
+def decision_to_row(decision: ReviewDecision, run_id: str = "") -> dict:
+    """Flatten an ReviewDecision into a parquet-ready dict."""
     req = decision.request
     pol = decision.policy_evaluation
 
@@ -101,7 +101,7 @@ def decision_to_row(decision: AdmissionDecision, run_id: str = "") -> dict:
 
 def append_decisions(
     evidence_root: Path,
-    decisions: list[AdmissionDecision],
+    decisions: list[ReviewDecision],
     run_id: str = "",
 ) -> Path | None:
     """Append decisions to the parquet file. Creates it if it doesn't exist.

--- a/src/data/pypi.py
+++ b/src/data/pypi.py
@@ -1,7 +1,7 @@
 """PyPI metadata enrichment client.
 # tested-by: tests/unit/test_pypi.py
 
-Fetches package metadata from the PyPI JSON API for use in admission
+Fetches package metadata from the PyPI JSON API for use in review
 decisions. All errors are absorbed and returned as structured dicts --
 this module never raises on HTTP or parse failures.
 """

--- a/src/eedom/agent/__init__.py
+++ b/src/eedom/agent/__init__.py
@@ -1,7 +1,7 @@
-"""GitHub Copilot Agent for dependency admission control and code review.
+"""GitHub Copilot Agent for dependency dependency review and code review.
 # tested-by: tests/unit/test_agent_main.py
 
 Reactive PR flow: triggers on lockfile/manifest changes, evaluates packages via
-the admission pipeline, runs Semgrep on changed files, and posts per-package
+the review pipeline, runs Semgrep on changed files, and posts per-package
 review comments with task-fit reasoning.
 """

--- a/src/eedom/agent/config.py
+++ b/src/eedom/agent/config.py
@@ -1,8 +1,8 @@
 """Agent-specific configuration for GATEKEEPER.
 # tested-by: tests/unit/test_agent_config.py
 
-Separate from AdmissionSettings — uses GATEKEEPER_ env prefix.
-The agent constructs an AdmissionSettings internally when calling the pipeline.
+Separate from EedomSettings — uses GATEKEEPER_ env prefix.
+The agent constructs an EedomSettings internally when calling the pipeline.
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ class AgentSettings(BaseSettings):
     pipeline_timeout: int = 300
     # TODO: replace with Optional[str] once no-DB mode is implemented.
     # Currently triggers NullRepository fallback in the pipeline.
-    # Removal condition: when AdmissionSettings.db_dsn becomes optional.
+    # Removal condition: when EedomSettings.db_dsn becomes optional.
     db_dsn: str = "postgresql://unused:unused@localhost/unused"
     policy_version: str = "1.0.0"
 

--- a/src/eedom/agent/main.py
+++ b/src/eedom/agent/main.py
@@ -132,7 +132,7 @@ class GatekeeperAgent:
         agent = GitHubCopilotAgent(
             instructions=system_prompt,
             name="gatekeeper",
-            description="Dependency admission control and code review agent",
+            description="Dependency dependency review and code review agent",
             tools=[
                 evaluate_change,
                 check_package,

--- a/src/eedom/agent/prompt.py
+++ b/src/eedom/agent/prompt.py
@@ -130,13 +130,13 @@ def build_system_prompt(
         alt_section = f"\n\nApproved alternative packages in this organization: {alt_list}"
 
     return f"""\
-You are GATEKEEPER, a dependency admission control and code review agent for a \
+You are GATEKEEPER, a dependency dependency review and code review agent for a \
 software engineering organization.
 
 Your job: when a pull request changes dependency manifests or source code, you \
 evaluate the changes and post clear, concise review comments. You have three tools:
 
-1. **evaluate_change** — runs the full admission pipeline (5 scanners + OPA policy) \
+1. **evaluate_change** — runs the full review pipeline (5 scanners + OPA policy) \
 on a PR diff. Call this for every PR with dependency changes.
 2. **check_package** — evaluates a single package via scanners + OPA. Use for \
 targeted lookups.

--- a/src/eedom/agent/tool_helpers.py
+++ b/src/eedom/agent/tool_helpers.py
@@ -132,12 +132,12 @@ def get_agent_settings() -> object:
 
 
 def make_pipeline_config() -> object:
-    """Build AdmissionSettings from AgentSettings."""
-    from eedom.core.config import AdmissionSettings
+    """Build EedomSettings from AgentSettings."""
+    from eedom.core.config import EedomSettings
     from eedom.core.models import OperatingMode
 
     agent_cfg = get_agent_settings()
-    return AdmissionSettings(
+    return EedomSettings(
         db_dsn=agent_cfg.db_dsn,
         operating_mode=OperatingMode.advise,
         evidence_path=str(agent_cfg.evidence_path),
@@ -209,13 +209,13 @@ def run_pipeline(
     team: str,
     repo_path: str,
 ) -> tuple[list, list[dict], dict]:
-    """Run the admission pipeline. Returns (decisions, sbom_changes, raw_sbom)."""
+    """Run the review pipeline. Returns (decisions, sbom_changes, raw_sbom)."""
     from eedom.core.models import OperatingMode
-    from eedom.core.pipeline import AdmissionPipeline
+    from eedom.core.pipeline import ReviewPipeline
     from eedom.core.sbom_diff import diff_sboms
 
     config = make_pipeline_config()
-    pipeline = AdmissionPipeline(config)
+    pipeline = ReviewPipeline(config)
 
     manifest_changes = detect_manifest_changes(diff_text)
     python_manifests = manifest_changes.pop("pypi", [])

--- a/src/eedom/agent/tools.py
+++ b/src/eedom/agent/tools.py
@@ -1,7 +1,7 @@
 """GATEKEEPER agent tool definitions.
 # tested-by: tests/unit/test_agent_tools.py
 
-Three @tool functions wrapping the admission pipeline and Semgrep.
+Three @tool functions wrapping the review pipeline and Semgrep.
 Internal helpers live in tool_helpers.py.
 """
 
@@ -23,14 +23,14 @@ from eedom.agent.tool_helpers import (
     run_pipeline,
     validate_paths,
 )
-from eedom.core.models import AdmissionDecision
+from eedom.core.models import ReviewDecision
 from eedom.plugins import get_default_registry
 
 logger = structlog.get_logger(__name__)
 
 
-def _serialize_decision(decision: AdmissionDecision) -> dict:
-    """Serialize an AdmissionDecision to a dict for the agent."""
+def _serialize_decision(decision: ReviewDecision) -> dict:
+    """Serialize an ReviewDecision to a dict for the agent."""
     findings_summary: dict[str, int] = {}
     for f in decision.findings:
         sev = f.severity.value
@@ -63,7 +63,7 @@ def _serialize_decision(decision: AdmissionDecision) -> dict:
 @tool(
     name="evaluate_change",
     description=(
-        "Run the full admission pipeline on a PR diff. Supports 18+ ecosystems "
+        "Run the full review pipeline on a PR diff. Supports 18+ ecosystems "
         "(Python, npm, Cargo, Go, Ruby, Maven, NuGet, Dart, PHP, Elixir, Swift, "
         "CocoaPods, and more). Executes 6 tools: Syft (SBOM), OSV-Scanner, "
         "Trivy, ScanCode (vulnerabilities + licenses) + OPA policy + Semgrep "
@@ -76,7 +76,7 @@ def evaluate_change(
     team: Annotated[str, "The team that owns the repository"],
     repo_path: Annotated[str, "Path to the repository root"],
 ) -> dict:
-    """Run full admission pipeline on a PR diff."""
+    """Run full review pipeline on a PR diff."""
     try:
         decisions, sbom_changes, raw_sbom = run_pipeline(
             diff_text,

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -1,4 +1,4 @@
-"""CLI entry point for the Admission Control pipeline."""
+"""CLI entry point for the Review pipeline."""
 
 # tested-by: tests/unit/test_cli.py
 
@@ -56,7 +56,7 @@ class DebounceTimer:
 
 @click.group()
 def cli() -> None:
-    """Agentic Dependency Admission Control — PoC CLI."""
+    """Agentic Dependency Dependency Review — PoC CLI."""
 
 
 @cli.command()
@@ -86,14 +86,14 @@ def evaluate(
     operating_mode: str,
     output_json: str | None,
 ) -> None:
-    """Run the full admission control pipeline on dependency changes."""
+    """Run the full review pipeline on dependency changes."""
     diff_text = _read_diff(diff)
     mode = OperatingMode(operating_mode)
 
     try:
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
-        config = AdmissionSettings()  # type: ignore[call-arg]
+        config = EedomSettings()  # type: ignore[call-arg]
     except Exception:
         logger.warning(
             "config_load_failed", msg="Pipeline skipped — config unavailable (fail-open)"
@@ -104,9 +104,9 @@ def evaluate(
     try:
         import orjson
 
-        from eedom.core.pipeline import AdmissionPipeline
+        from eedom.core.pipeline import ReviewPipeline
 
-        pipeline = AdmissionPipeline(config)
+        pipeline = ReviewPipeline(config)
         decisions = pipeline.evaluate(
             diff_text=diff_text,
             pr_url=pr_url,
@@ -156,9 +156,9 @@ def check_health() -> None:
     click.echo()
 
     try:
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
-        config = AdmissionSettings()  # type: ignore[call-arg]
+        config = EedomSettings()  # type: ignore[call-arg]
         from eedom.data.db import DecisionRepository
 
         db = DecisionRepository(dsn=config.db_dsn)
@@ -396,7 +396,7 @@ def query(question: str, db_path: str) -> None:
     \b
       eedom query "which functions have the highest fan-out?"
       eedom query "show me dead code"
-      eedom query "what depends on AdmissionPipeline"
+      eedom query "what depends on ReviewPipeline"
       eedom query "are there circular imports?"
     """
     from eedom.core.nl_query import TEMPLATES, query_code

--- a/src/eedom/core/config.py
+++ b/src/eedom/core/config.py
@@ -1,6 +1,6 @@
-"""Configuration module for Admission Control.
+"""Configuration module for eedom.
 
-All configuration is loaded from environment variables with the ADMISSION_ prefix.
+All configuration is loaded from environment variables with the EEDOM_ prefix.
 # tested-by: tests/unit/test_config.py
 Uses Pydantic BaseSettings for validation and type coercion.
 """
@@ -38,8 +38,8 @@ class _CommaSeparatedEnvSource(EnvSettingsSource):
             return value
 
 
-class AdmissionSettings(BaseSettings):
-    """Admission Control configuration loaded from ADMISSION_* env vars.
+class EedomSettings(BaseSettings):
+    """Eedom configuration loaded from EEDOM_* env vars.
 
     Required fields:
         db_dsn: PostgreSQL connection string — must be provided, no default.
@@ -48,7 +48,7 @@ class AdmissionSettings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="ADMISSION_",
+        env_prefix="EEDOM_",
         case_sensitive=False,
     )
 

--- a/src/eedom/core/decision.py
+++ b/src/eedom/core/decision.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     Finding,
     PolicyEvaluation,
     ScanResult,
@@ -14,14 +14,14 @@ from eedom.core.models import (
 
 
 def assemble_decision(
-    request: AdmissionRequest,
+    request: ReviewRequest,
     findings: list[Finding],
     scan_results: list[ScanResult],
     policy_evaluation: PolicyEvaluation,
     evidence_bundle_path: str | None,
     pipeline_duration: float,
-) -> AdmissionDecision:
-    return AdmissionDecision(
+) -> ReviewDecision:
+    return ReviewDecision(
         request=request,
         decision=policy_evaluation.decision,
         findings=findings,

--- a/src/eedom/core/diff.py
+++ b/src/eedom/core/diff.py
@@ -14,7 +14,7 @@ import structlog
 from packaging.version import InvalidVersion, Version  # noqa: F401
 
 from eedom.core.models import (
-    AdmissionRequest,
+    ReviewRequest,
     OperatingMode,
     RequestType,
 )
@@ -255,14 +255,14 @@ class DependencyDiffDetector:
         team: str,
         pr_url: str | None,
         operating_mode: OperatingMode,
-    ) -> list[AdmissionRequest]:
-        """Convert change dicts into AdmissionRequest objects.
+    ) -> list[ReviewRequest]:
+        """Convert change dicts into ReviewRequest objects.
 
         - added -> request_type=new_package
         - upgraded/downgraded -> request_type=upgrade (with current_version)
-        - removed -> skipped (no admission needed)
+        - removed -> skipped (no review needed)
         """
-        requests: list[AdmissionRequest] = []
+        requests: list[ReviewRequest] = []
 
         for change in changes:
             action = change["action"]
@@ -281,7 +281,7 @@ class DependencyDiffDetector:
             target_version = change["new_version"] or "unknown"
 
             requests.append(
-                AdmissionRequest(
+                ReviewRequest(
                     request_type=req_type,
                     ecosystem=ecosystem,
                     package_name=change["package"],

--- a/src/eedom/core/memo.py
+++ b/src/eedom/core/memo.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from eedom.core.models import (
-    AdmissionDecision,
+    ReviewDecision,
     DecisionVerdict,
     FindingSeverity,
     ScanResultStatus,
@@ -28,7 +28,7 @@ _STATUS_ICON: dict[ScanResultStatus, str] = {
 _MAX_MEMO_LENGTH = 3900
 
 
-def generate_memo(decision: AdmissionDecision) -> str:
+def generate_memo(decision: ReviewDecision) -> str:
     req = decision.request
     badge = _VERDICT_BADGE.get(decision.decision, str(decision.decision))
     parts: list[str] = []
@@ -108,7 +108,7 @@ def generate_memo(decision: AdmissionDecision) -> str:
 
     parts.append("---")
     parts.append(
-        f"*Admission Control PoC | Policy v{pol.policy_bundle_version} "
+        f"*eedom | Policy v{pol.policy_bundle_version} "
         f"| Pipeline: {decision.pipeline_duration_seconds:.1f}s*"
     )
 

--- a/src/eedom/core/models.py
+++ b/src/eedom/core/models.py
@@ -1,4 +1,4 @@
-"""Core data models for the Admission Control system.
+"""Core data models for the eedom.
 # tested-by: tests/unit/test_models.py
 
 All domain objects are Pydantic models with strict enum validation,
@@ -46,7 +46,7 @@ class ScanResultStatus(enum.StrEnum):
 
 
 class DecisionVerdict(enum.StrEnum):
-    """Final admission decision for a package request."""
+    """Final review decision for a package request."""
 
     approve = "approve"
     reject = "reject"
@@ -105,7 +105,7 @@ class FindingCategory(enum.StrEnum):
 
 
 class RequestType(enum.StrEnum):
-    """Type of admission request."""
+    """Type of review request."""
 
     new_package = "new_package"
     upgrade = "upgrade"
@@ -195,7 +195,7 @@ class ScanResult(BaseModel):
         )
 
 
-class AdmissionRequest(BaseModel):
+class ReviewRequest(BaseModel):
     """Inbound request to evaluate a dependency change."""
 
     model_config = _MODEL_CONFIG
@@ -255,13 +255,13 @@ def _compute_should_mark_unstable(operating_mode: OperatingMode, verdict: Decisi
     return verdict in (DecisionVerdict.reject, DecisionVerdict.needs_review)
 
 
-class AdmissionDecision(BaseModel):
-    """Aggregate root — the complete admission decision for a package request."""
+class ReviewDecision(BaseModel):
+    """Aggregate root — the complete review decision for a package request."""
 
     model_config = _MODEL_CONFIG
 
     decision_id: uuid.UUID = Field(default_factory=uuid.uuid4)
-    request: AdmissionRequest
+    request: ReviewRequest
     decision: DecisionVerdict
     findings: list[Finding]
     scan_results: list[ScanResult]
@@ -284,7 +284,7 @@ class AdmissionDecision(BaseModel):
 
 
 class BypassRecord(BaseModel):
-    """Record of a manual bypass of the admission decision."""
+    """Record of a manual bypass of the review decision."""
 
     model_config = _MODEL_CONFIG
 

--- a/src/eedom/core/pipeline.py
+++ b/src/eedom/core/pipeline.py
@@ -1,4 +1,4 @@
-"""Admission Control pipeline — orchestrates scanners, policy eval, and decision assembly.
+"""Review pipeline — orchestrates scanners, policy eval, and decision assembly.
 
 # tested-by: tests/unit/test_pipeline.py
 
@@ -14,12 +14,12 @@ from pathlib import Path
 import orjson
 import structlog
 
-from eedom.core.config import AdmissionSettings
+from eedom.core.config import EedomSettings
 from eedom.core.decision import assemble_decision
 from eedom.core.diff import DependencyDiffDetector
 from eedom.core.memo import generate_memo
 from eedom.core.models import (
-    AdmissionDecision,
+    ReviewDecision,
     DecisionVerdict,
     OperatingMode,
     PolicyEvaluation,
@@ -47,10 +47,10 @@ from eedom.data.scanners.trivy import TrivyScanner
 logger = structlog.get_logger()
 
 
-class AdmissionPipeline:
-    """End-to-end admission pipeline — stateless per call."""
+class ReviewPipeline:
+    """End-to-end review pipeline — stateless per call."""
 
-    def __init__(self, config: AdmissionSettings) -> None:
+    def __init__(self, config: EedomSettings) -> None:
         self._config = config
 
     def evaluate(
@@ -61,10 +61,10 @@ class AdmissionPipeline:
         mode: OperatingMode,
         repo_path: Path,
         commit_sha: str | None = None,
-    ) -> list[AdmissionDecision]:
-        """Run the full admission control pipeline on dependency changes.
+    ) -> list[ReviewDecision]:
+        """Run the full review pipeline on dependency changes.
 
-        Returns a list of AdmissionDecision objects (one per changed package).
+        Returns a list of ReviewDecision objects (one per changed package).
         Returns an empty list if no dependency changes are detected.
         """
         from datetime import UTC, datetime
@@ -138,7 +138,7 @@ class AdmissionPipeline:
             logger.warning("db_init_failed", msg="Falling back to NullRepository")
             db = NullRepository()
 
-        decisions: list[AdmissionDecision] = []
+        decisions: list[ReviewDecision] = []
 
         try:
             # Run scanners ONCE before the per-package loop (F-005)
@@ -215,7 +215,7 @@ class AdmissionPipeline:
                 except Exception:
                     logger.exception("package_evaluation_failed", package=req.package_name)
                     decisions.append(
-                        AdmissionDecision(
+                        ReviewDecision(
                             request=req,
                             decision=DecisionVerdict.needs_review,
                             findings=[],
@@ -254,14 +254,14 @@ class AdmissionPipeline:
         mode: OperatingMode,
         repo_path: Path,
         commit_sha: str | None = None,
-    ) -> list[AdmissionDecision]:
+    ) -> list[ReviewDecision]:
         """Evaluate dependency changes using SBOM diff. Ecosystem-agnostic.
 
         Diffs two CycloneDX SBOMs (before/after) to discover changed packages
         across any ecosystem Syft supports, then runs them through the same
         scanner → normalize → OPA → decision → memo pipeline as evaluate().
 
-        Returns a list of AdmissionDecision objects (one per changed package).
+        Returns a list of ReviewDecision objects (one per changed package).
         Returns an empty list when no dependency changes are found.
         """
         from datetime import UTC, datetime
@@ -327,7 +327,7 @@ class AdmissionPipeline:
             logger.warning("db_init_failed", msg="Falling back to NullRepository")
             db = NullRepository()
 
-        decisions: list[AdmissionDecision] = []
+        decisions: list[ReviewDecision] = []
 
         try:
             # Run scanners ONCE before the per-package loop (F-005)
@@ -405,7 +405,7 @@ class AdmissionPipeline:
                 except Exception:
                     logger.exception("package_evaluation_failed", package=req.package_name)
                     decisions.append(
-                        AdmissionDecision(
+                        ReviewDecision(
                             request=req,
                             decision=DecisionVerdict.needs_review,
                             findings=[],

--- a/src/eedom/core/pipeline_helpers.py
+++ b/src/eedom/core/pipeline_helpers.py
@@ -11,7 +11,7 @@ import structlog
 
 from eedom.core.diff import DependencyDiffDetector
 from eedom.core.models import (
-    AdmissionRequest,
+    ReviewRequest,
     OperatingMode,
     RequestType,
     ScanResult,
@@ -79,9 +79,9 @@ def sbom_changes_to_requests(
     team: str,
     pr_url: str | None,
     operating_mode: OperatingMode,
-) -> list[AdmissionRequest]:
-    """Convert SBOM diff change dicts into AdmissionRequest objects."""
-    requests: list[AdmissionRequest] = []
+) -> list[ReviewRequest]:
+    """Convert SBOM diff change dicts into ReviewRequest objects."""
+    requests: list[ReviewRequest] = []
 
     for change in changes:
         action = change["action"]
@@ -93,7 +93,7 @@ def sbom_changes_to_requests(
         target_version = change.get("new_version") or "unknown"
 
         requests.append(
-            AdmissionRequest(
+            ReviewRequest(
                 request_type=req_type,
                 ecosystem=change.get("ecosystem", "unknown"),
                 package_name=change["package"],

--- a/src/eedom/core/policy.py
+++ b/src/eedom/core/policy.py
@@ -1,7 +1,7 @@
 """OPA policy evaluation wrapper.
 # tested-by: tests/unit/test_policy.py
 
-Invokes OPA as a subprocess to evaluate the admission policy against
+Invokes OPA as a subprocess to evaluate the review policy against
 scanner findings and package metadata. Never raises -- all failures
 degrade gracefully to needs_review.
 """
@@ -93,7 +93,7 @@ def build_opa_input(
 
 
 class OpaEvaluator:
-    """Evaluates admission policy by invoking the OPA binary.
+    """Evaluates review policy by invoking the OPA binary.
 
     All failures degrade to needs_review -- this class never raises.
     """
@@ -107,7 +107,7 @@ class OpaEvaluator:
         findings: list[Finding],
         package_metadata: dict,
     ) -> PolicyEvaluation:
-        """Evaluate findings against the OPA admission policy.
+        """Evaluate findings against the OPA review policy.
 
         Args:
             findings: Scanner findings to evaluate.
@@ -166,7 +166,7 @@ class OpaEvaluator:
                 self._policy_path,
                 "-i",
                 tmp.name,
-                "data.admission",
+                "data.policy",
                 "--format",
                 "json",
             ]

--- a/src/eedom/core/taskfit.py
+++ b/src/eedom/core/taskfit.py
@@ -16,7 +16,7 @@ import httpx
 import structlog
 
 if TYPE_CHECKING:
-    from eedom.core.config import AdmissionSettings
+    from eedom.core.config import EedomSettings
 
 logger = structlog.get_logger(__name__)
 
@@ -24,7 +24,7 @@ _MAX_ADVISORY_LENGTH = 500
 _SUMMARY_MAX_LEN = 200
 
 _SYSTEM_PROMPT = """\
-You are a dependency admission control analyst for a software engineering organization.
+You are a dependency dependency review analyst for a software engineering organization.
 
 Your job is to evaluate whether a requested third-party package is appropriate, \
 proportionate, and safe for its stated use case. You are the last line of reasoning \
@@ -121,10 +121,10 @@ class TaskFitAdvisor:
     """Queries an OpenAI-compatible LLM for package proportionality advice.
 
     All failures are absorbed -- this class never raises and never blocks
-    the admission pipeline.
+    the review pipeline.
     """
 
-    def __init__(self, config: AdmissionSettings) -> None:
+    def __init__(self, config: EedomSettings) -> None:
         self._enabled = config.llm_enabled
         self._endpoint = config.llm_endpoint
         self._model = config.llm_model

--- a/src/eedom/data/db.py
+++ b/src/eedom/data/db.py
@@ -1,4 +1,4 @@
-"""Decision record repository -- persistence layer for admission decisions.
+"""Decision record repository -- persistence layer for review decisions.
 # tested-by: tests/unit/test_db.py
 
 Fail-open design: database failures are logged and absorbed, never raised.
@@ -16,8 +16,8 @@ import structlog
 from psycopg_pool import ConnectionPool
 
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     BypassRecord,
     PolicyEvaluation,
     ScanResult,
@@ -28,15 +28,15 @@ logger = structlog.get_logger(__name__)
 
 @runtime_checkable
 class RepositoryProtocol(Protocol):
-    """Structural contract for admission pipeline repository implementations."""
+    """Structural contract for review pipeline repository implementations."""
 
-    def save_request(self, request: AdmissionRequest) -> None: ...
+    def save_request(self, request: ReviewRequest) -> None: ...
     def save_scan_results(self, request_id: uuid.UUID, results: list[ScanResult]) -> None: ...
     def save_policy_evaluation(
         self, request_id: uuid.UUID, evaluation: PolicyEvaluation
     ) -> None: ...
-    def save_decision(self, request_id: uuid.UUID, decision: AdmissionDecision) -> None: ...
-    def get_decision_by_request_id(self, request_id: uuid.UUID) -> AdmissionDecision | None: ...
+    def save_decision(self, request_id: uuid.UUID, decision: ReviewDecision) -> None: ...
+    def get_decision_by_request_id(self, request_id: uuid.UUID) -> ReviewDecision | None: ...
     def save_bypass(self, record: BypassRecord) -> None: ...
     def close(self) -> None: ...
     def connect(self) -> bool: ...
@@ -64,10 +64,10 @@ def _safe_dsn(dsn: str) -> str:
 
 
 class DecisionRepository:
-    """Postgres-backed repository for admission pipeline records.
+    """Postgres-backed repository for review pipeline records.
 
     All methods absorb database errors -- they log the failure and return
-    gracefully so the admission pipeline is never blocked by storage issues.
+    gracefully so the review pipeline is never blocked by storage issues.
     """
 
     def __init__(self, dsn: str, query_timeout: int = 10, connect_timeout: int = 5) -> None:
@@ -106,8 +106,8 @@ class DecisionRepository:
             f"SET LOCAL statement_timeout = '{self._query_timeout * _QUERY_TIMEOUT_MS_MULTIPLIER}'"
         )
 
-    def save_request(self, request: AdmissionRequest) -> None:
-        """INSERT an admission request record."""
+    def save_request(self, request: ReviewRequest) -> None:
+        """INSERT an review request record."""
         if self._pool is None:
             logger.warning("save_request_skipped", reason="no_pool")
             return
@@ -118,7 +118,7 @@ class DecisionRepository:
                     cur.execute(self._timeout_sql())
                     cur.execute(
                         """
-                        INSERT INTO admission_requests (
+                        INSERT INTO review_requests (
                             request_id, request_type, ecosystem, package_name,
                             target_version, current_version, team, scope,
                             pr_url, pr_number, repo_name, commit_sha,
@@ -240,8 +240,8 @@ class DecisionRepository:
                 exc_info=True,
             )
 
-    def save_decision(self, request_id: uuid.UUID, decision: AdmissionDecision) -> None:
-        """INSERT a final admission decision record."""
+    def save_decision(self, request_id: uuid.UUID, decision: ReviewDecision) -> None:
+        """INSERT a final review decision record."""
         if self._pool is None:
             logger.warning("save_decision_skipped", reason="no_pool")
             return
@@ -254,7 +254,7 @@ class DecisionRepository:
                     cur.execute(self._timeout_sql())
                     cur.execute(
                         """
-                        INSERT INTO admission_decisions (
+                        INSERT INTO review_decisions (
                             decision_id, request_id, decision,
                             findings_summary, evidence_bundle_path,
                             memo_text, pipeline_duration_seconds,
@@ -288,7 +288,7 @@ class DecisionRepository:
                 exc_info=True,
             )
 
-    def get_decision_by_request_id(self, request_id: uuid.UUID) -> AdmissionDecision | None:
+    def get_decision_by_request_id(self, request_id: uuid.UUID) -> ReviewDecision | None:
         """SELECT a decision by request_id. Returns None if not found or on error."""
         if self._pool is None:
             logger.warning("get_decision_skipped", reason="no_pool")
@@ -310,8 +310,8 @@ class DecisionRepository:
                             r.repo_name, r.commit_sha, r.use_case,
                             r.operating_mode AS req_operating_mode,
                             r.created_at AS req_created_at
-                        FROM admission_decisions d
-                        JOIN admission_requests r ON r.request_id = d.request_id
+                        FROM review_decisions d
+                        JOIN review_requests r ON r.request_id = d.request_id
                         WHERE d.request_id = %s
                         ORDER BY d.created_at DESC
                         LIMIT 1
@@ -323,7 +323,7 @@ class DecisionRepository:
             if row is None:
                 return None
 
-            request = AdmissionRequest(
+            request = ReviewRequest(
                 request_id=uuid.UUID(row[8]),
                 request_type=row[9],
                 ecosystem=row[10],
@@ -343,7 +343,7 @@ class DecisionRepository:
 
             findings = orjson.loads(row[2]) if row[2] else []
 
-            return AdmissionDecision(
+            return ReviewDecision(
                 decision_id=uuid.UUID(row[0]),
                 request=request,
                 decision=row[1],
@@ -421,7 +421,7 @@ class NullRepository:
     def close(self) -> None:
         pass
 
-    def save_request(self, request: AdmissionRequest) -> None:
+    def save_request(self, request: ReviewRequest) -> None:
         pass
 
     def save_scan_results(self, request_id: uuid.UUID, results: list[ScanResult]) -> None:
@@ -430,10 +430,10 @@ class NullRepository:
     def save_policy_evaluation(self, request_id: uuid.UUID, evaluation: PolicyEvaluation) -> None:
         pass
 
-    def save_decision(self, request_id: uuid.UUID, decision: AdmissionDecision) -> None:
+    def save_decision(self, request_id: uuid.UUID, decision: ReviewDecision) -> None:
         pass
 
-    def get_decision_by_request_id(self, request_id: uuid.UUID) -> AdmissionDecision | None:
+    def get_decision_by_request_id(self, request_id: uuid.UUID) -> ReviewDecision | None:
         return None
 
     def save_bypass(self, record: BypassRecord) -> None:

--- a/src/eedom/data/parquet_writer.py
+++ b/src/eedom/data/parquet_writer.py
@@ -1,7 +1,7 @@
 """Parquet evidence writer — append-only columnar audit log.
 # tested-by: tests/unit/test_parquet_writer.py
 
-Writes admission decisions to a single append-only parquet file per
+Writes review decisions to a single append-only parquet file per
 evidence root. Enables DuckDB-powered analytics and LLM-queryable
 audit history without loading individual JSON files.
 
@@ -17,7 +17,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import structlog
 
-from eedom.core.models import AdmissionDecision
+from eedom.core.models import ReviewDecision
 
 logger = structlog.get_logger(__name__)
 
@@ -56,8 +56,8 @@ SCHEMA = pa.schema(
 )
 
 
-def decision_to_row(decision: AdmissionDecision, run_id: str = "") -> dict:
-    """Flatten an AdmissionDecision into a parquet-ready dict."""
+def decision_to_row(decision: ReviewDecision, run_id: str = "") -> dict:
+    """Flatten an ReviewDecision into a parquet-ready dict."""
     req = decision.request
     pol = decision.policy_evaluation
 
@@ -101,7 +101,7 @@ def decision_to_row(decision: AdmissionDecision, run_id: str = "") -> dict:
 
 def append_decisions(
     evidence_root: Path,
-    decisions: list[AdmissionDecision],
+    decisions: list[ReviewDecision],
     run_id: str = "",
 ) -> Path | None:
     """Append decisions to the parquet file. Creates it if it doesn't exist.

--- a/src/eedom/data/pypi.py
+++ b/src/eedom/data/pypi.py
@@ -1,7 +1,7 @@
 """PyPI metadata enrichment client.
 # tested-by: tests/unit/test_pypi.py
 
-Fetches package metadata from the PyPI JSON API for use in admission
+Fetches package metadata from the PyPI JSON API for use in review
 decisions. All errors are absorbed and returned as structured dicts --
 this module never raises on HTTP or parse failures.
 """

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end integration tests for the Admission Control pipeline.
+"""End-to-end integration tests for the Review pipeline.
 
 Tests the full pipeline from diff input through decision output, with all
 external dependencies mocked at system boundaries:
@@ -212,10 +212,10 @@ def _write_diff(tmp_path: Path, diff_text: str, name: str = "test.diff") -> Path
 
 def _base_env(tmp_path: Path) -> dict[str, str]:
     return {
-        "ADMISSION_DB_DSN": "postgresql://test:test@localhost:12432/test",
-        "ADMISSION_EVIDENCE_PATH": str(tmp_path / "evidence"),
-        "ADMISSION_ENABLED_SCANNERS": "syft,scancode",
-        "ADMISSION_OPA_POLICY_PATH": str(tmp_path / "policies"),
+        "EEDOM_DB_DSN": "postgresql://test:test@localhost:12432/test",
+        "EEDOM_EVIDENCE_PATH": str(tmp_path / "evidence"),
+        "EEDOM_ENABLED_SCANNERS": "syft,scancode",
+        "EEDOM_OPA_POLICY_PATH": str(tmp_path / "policies"),
     }
 
 

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -10,8 +10,8 @@ from unittest.mock import patch
 import pytest
 
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     DecisionVerdict,
     OperatingMode,
     PolicyEvaluation,
@@ -21,12 +21,12 @@ from eedom.core.models import (
 )
 
 
-def _make_decision(verdict: DecisionVerdict = DecisionVerdict.approve) -> AdmissionDecision:
-    """Build a minimal AdmissionDecision for testing."""
+def _make_decision(verdict: DecisionVerdict = DecisionVerdict.approve) -> ReviewDecision:
+    """Build a minimal ReviewDecision for testing."""
     from datetime import datetime
     from uuid import uuid4
 
-    req = AdmissionRequest(
+    req = ReviewRequest(
         request_id=uuid4(),
         request_type=RequestType.new_package,
         ecosystem="pypi",
@@ -48,7 +48,7 @@ def _make_decision(verdict: DecisionVerdict = DecisionVerdict.approve) -> Admiss
         findings=[],
         duration_seconds=1.5,
     )
-    return AdmissionDecision(
+    return ReviewDecision(
         decision_id=uuid4(),
         request=req,
         decision=verdict,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,7 +26,7 @@ class TestEvaluateNoDependencyChanges:
         """When the diff contains no dependency file changes, exit 0 with a message."""
         runner = CliRunner()
         env = {
-            "ADMISSION_DB_DSN": "postgresql://test:test@localhost/test",
+            "EEDOM_DB_DSN": "postgresql://test:test@localhost/test",
         }
 
         with runner.isolated_filesystem():
@@ -58,7 +58,7 @@ class TestEvaluateNoDependencyChanges:
         """An empty diff file exits 0 with no changes message."""
         runner = CliRunner()
         env = {
-            "ADMISSION_DB_DSN": "postgresql://test:test@localhost/test",
+            "EEDOM_DB_DSN": "postgresql://test:test@localhost/test",
         }
 
         with runner.isolated_filesystem():
@@ -121,7 +121,7 @@ class TestEvaluateAlwaysExitsZero:
     def test_evaluate_exits_zero_on_config_error(self) -> None:
         """Even with a broken config, evaluate exits 0 (fail-open)."""
         runner = CliRunner()
-        # No ADMISSION_DB_DSN set -- config will fail to load
+        # No EEDOM_DB_DSN set -- config will fail to load
         # The CLI should catch this and exit 0
 
         with runner.isolated_filesystem():
@@ -152,7 +152,7 @@ class TestEvaluateAlwaysExitsZero:
         """Evaluate accepts diff from stdin via '-'."""
         runner = CliRunner()
         env = {
-            "ADMISSION_DB_DSN": "postgresql://test:test@localhost/test",
+            "EEDOM_DB_DSN": "postgresql://test:test@localhost/test",
         }
 
         result = runner.invoke(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,44 +9,44 @@ import pytest
 from pydantic import ValidationError
 
 
-class TestAdmissionSettings:
-    """Test suite for AdmissionSettings configuration loading."""
+class TestEedomSettings:
+    """Test suite for EedomSettings configuration loading."""
 
     @staticmethod
     def _minimal_env() -> dict[str, str]:
         """Return the minimum required env vars for a valid config."""
         return {
-            "ADMISSION_DB_DSN": "postgresql://user:pass@localhost:5432/testdb",
+            "EEDOM_DB_DSN": "postgresql://user:pass@localhost:5432/testdb",
         }
 
     @staticmethod
     def _full_env() -> dict[str, str]:
         """Return a complete env var set with all fields specified."""
         return {
-            "ADMISSION_OPERATING_MODE": "advise",
-            "ADMISSION_DB_DSN": "postgresql://user:pass@localhost:5432/testdb",
-            "ADMISSION_EVIDENCE_PATH": "/tmp/evidence",
-            "ADMISSION_SCANNER_TIMEOUT": "90",
-            "ADMISSION_COMBINED_SCANNER_TIMEOUT": "200",
-            "ADMISSION_OPA_TIMEOUT": "15",
-            "ADMISSION_LLM_TIMEOUT": "45",
-            "ADMISSION_PIPELINE_TIMEOUT": "400",
-            "ADMISSION_OPA_POLICY_PATH": "/opt/policies",
-            "ADMISSION_ENABLED_SCANNERS": "syft,trivy",
-            "ADMISSION_LLM_ENABLED": "true",
-            "ADMISSION_LLM_ENDPOINT": "https://llm.example.com/v1",
-            "ADMISSION_LLM_MODEL": "gpt-4o",
-            "ADMISSION_LLM_API_KEY": "sk-test-key",
-            "ADMISSION_ALTERNATIVES_PATH": "/opt/alternatives.json",
+            "EEDOM_OPERATING_MODE": "advise",
+            "EEDOM_DB_DSN": "postgresql://user:pass@localhost:5432/testdb",
+            "EEDOM_EVIDENCE_PATH": "/tmp/evidence",
+            "EEDOM_SCANNER_TIMEOUT": "90",
+            "EEDOM_COMBINED_SCANNER_TIMEOUT": "200",
+            "EEDOM_OPA_TIMEOUT": "15",
+            "EEDOM_LLM_TIMEOUT": "45",
+            "EEDOM_PIPELINE_TIMEOUT": "400",
+            "EEDOM_OPA_POLICY_PATH": "/opt/policies",
+            "EEDOM_ENABLED_SCANNERS": "syft,trivy",
+            "EEDOM_LLM_ENABLED": "true",
+            "EEDOM_LLM_ENDPOINT": "https://llm.example.com/v1",
+            "EEDOM_LLM_MODEL": "gpt-4o",
+            "EEDOM_LLM_API_KEY": "sk-test-key",
+            "EEDOM_ALTERNATIVES_PATH": "/opt/alternatives.json",
         }
 
     def test_valid_config_loads_from_env(self) -> None:
         """Full env var set produces a correctly populated settings object."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         env = self._full_env()
         with patch.dict(os.environ, env, clear=True):
-            settings = AdmissionSettings()
+            settings = EedomSettings()
 
         assert settings.operating_mode.value == "advise"
         assert settings.db_dsn == "postgresql://user:pass@localhost:5432/testdb"
@@ -66,10 +66,10 @@ class TestAdmissionSettings:
 
     def test_missing_db_dsn_raises_validation_error(self) -> None:
         """Config without DB_DSN must fail with a clear validation error."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         with patch.dict(os.environ, {}, clear=True), pytest.raises(ValidationError) as exc_info:
-            AdmissionSettings()
+            EedomSettings()
 
         errors = exc_info.value.errors()
         field_names = [e["loc"][-1] for e in errors]
@@ -77,12 +77,12 @@ class TestAdmissionSettings:
 
     def test_invalid_operating_mode_raises_validation_error(self) -> None:
         """Operating mode must be restricted to 'monitor' and 'advise'."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         env = self._minimal_env()
-        env["ADMISSION_OPERATING_MODE"] = "enforce"
+        env["EEDOM_OPERATING_MODE"] = "enforce"
         with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError) as exc_info:
-            AdmissionSettings()
+            EedomSettings()
 
         errors = exc_info.value.errors()
         # The error should reference operating_mode
@@ -91,11 +91,11 @@ class TestAdmissionSettings:
 
     def test_default_values_are_correct(self) -> None:
         """When only required fields are provided, defaults match the architecture doc."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         env = self._minimal_env()
         with patch.dict(os.environ, env, clear=True):
-            settings = AdmissionSettings()
+            settings = EedomSettings()
 
         # Operating mode defaults to monitor
         assert settings.operating_mode.value == "monitor"
@@ -123,22 +123,22 @@ class TestAdmissionSettings:
 
     def test_minimal_config_loads_with_defaults(self) -> None:
         """Minimal config (just DB_DSN) loads successfully."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         env = self._minimal_env()
         with patch.dict(os.environ, env, clear=True):
-            settings = AdmissionSettings()
+            settings = EedomSettings()
 
         assert settings.db_dsn == "postgresql://user:pass@localhost:5432/testdb"
 
     def test_enabled_scanners_parsed_from_comma_separated(self) -> None:
         """Comma-separated scanner list is parsed into a Python list."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         env = self._minimal_env()
-        env["ADMISSION_ENABLED_SCANNERS"] = "syft,trivy,osv-scanner"
+        env["EEDOM_ENABLED_SCANNERS"] = "syft,trivy,osv-scanner"
         with patch.dict(os.environ, env, clear=True):
-            settings = AdmissionSettings()
+            settings = EedomSettings()
 
         assert settings.enabled_scanners == ["syft", "trivy", "osv-scanner"]
 
@@ -146,12 +146,12 @@ class TestAdmissionSettings:
         """F-021: llm_api_key must be a SecretStr, not a plain str."""
         from pydantic import SecretStr
 
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
 
         env = self._minimal_env()
-        env["ADMISSION_LLM_API_KEY"] = "sk-my-key"
+        env["EEDOM_LLM_API_KEY"] = "sk-my-key"
         with patch.dict(os.environ, env, clear=True):
-            settings = AdmissionSettings()
+            settings = EedomSettings()
 
         assert isinstance(settings.llm_api_key, SecretStr)
         # repr/str must not expose the value

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -6,8 +6,8 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     BypassRecord,
     DecisionVerdict,
     OperatingMode,
@@ -20,8 +20,8 @@ from eedom.core.models import (
 
 def _make_request(
     request_id: uuid.UUID | None = None,
-) -> AdmissionRequest:
-    return AdmissionRequest(
+) -> ReviewRequest:
+    return ReviewRequest(
         request_id=request_id or uuid.uuid4(),
         request_type=RequestType.new_package,
         ecosystem="pypi",
@@ -49,8 +49,8 @@ def _make_policy_evaluation() -> PolicyEvaluation:
     )
 
 
-def _make_decision(request: AdmissionRequest) -> AdmissionDecision:
-    return AdmissionDecision(
+def _make_decision(request: ReviewRequest) -> ReviewDecision:
+    return ReviewDecision(
         request=request,
         decision=DecisionVerdict.approve,
         findings=[],
@@ -98,7 +98,7 @@ class TestDecisionRepository:
         sql_text = insert_call[0][0]
         params = insert_call[0][1]
 
-        assert "INSERT INTO admission_requests" in sql_text
+        assert "INSERT INTO review_requests" in sql_text
         assert str(request.request_id) in params
         assert request.package_name in params
         assert request.ecosystem in params

--- a/tests/unit/test_decision.py
+++ b/tests/unit/test_decision.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from eedom.core.decision import assemble_decision
 from eedom.core.models import (
-    AdmissionRequest,
+    ReviewRequest,
     DecisionVerdict,
     Finding,
     FindingCategory,
@@ -21,8 +21,8 @@ from eedom.core.models import (
 # ---------------------------------------------------------------------------
 
 
-def _request(mode: str = "advise") -> AdmissionRequest:
-    return AdmissionRequest(
+def _request(mode: str = "advise") -> ReviewRequest:
+    return ReviewRequest(
         request_type=RequestType.new_package,
         ecosystem="npm",
         package_name="lodash",

--- a/tests/unit/test_memo.py
+++ b/tests/unit/test_memo.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from eedom.core.memo import generate_memo
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     DecisionVerdict,
     Finding,
     FindingCategory,
@@ -22,8 +22,8 @@ from eedom.core.models import (
 # ---------------------------------------------------------------------------
 
 
-def _request(mode: str = "advise") -> AdmissionRequest:
-    return AdmissionRequest(
+def _request(mode: str = "advise") -> ReviewRequest:
+    return ReviewRequest(
         request_type=RequestType.new_package,
         ecosystem="npm",
         package_name="lodash",
@@ -81,9 +81,9 @@ def _decision(
     constraints: list[str] | None = None,
     policy_version: str = "0.1.0",
     duration: float = 5.0,
-) -> AdmissionDecision:
+) -> ReviewDecision:
     request = _request()
-    return AdmissionDecision(
+    return ReviewDecision(
         request=request,
         decision=DecisionVerdict(verdict),
         findings=findings or [],

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -208,8 +208,8 @@ class TestScanResult:
         assert restored.duration_seconds == 45.3
 
 
-class TestAdmissionRequest:
-    """AdmissionRequest model with UUID auto-generation and datetime."""
+class TestReviewRequest:
+    """ReviewRequest model with UUID auto-generation and datetime."""
 
     @staticmethod
     def _make_request(**overrides: object) -> dict:
@@ -225,30 +225,30 @@ class TestAdmissionRequest:
         return defaults
 
     def test_uuid_auto_generated(self) -> None:
-        from eedom.core.models import AdmissionRequest
+        from eedom.core.models import ReviewRequest
 
-        req = AdmissionRequest.model_validate(self._make_request())
+        req = ReviewRequest.model_validate(self._make_request())
         assert isinstance(req.request_id, uuid.UUID)
 
     def test_created_at_auto_generated(self) -> None:
-        from eedom.core.models import AdmissionRequest
+        from eedom.core.models import ReviewRequest
 
-        req = AdmissionRequest.model_validate(self._make_request())
+        req = ReviewRequest.model_validate(self._make_request())
         assert isinstance(req.created_at, datetime)
         # Should be recent (within last 10 seconds)
         delta = datetime.now(UTC) - req.created_at
         assert delta.total_seconds() < 10
 
     def test_default_scope_is_runtime(self) -> None:
-        from eedom.core.models import AdmissionRequest
+        from eedom.core.models import ReviewRequest
 
-        req = AdmissionRequest.model_validate(self._make_request())
+        req = ReviewRequest.model_validate(self._make_request())
         assert req.scope == "runtime"
 
     def test_optional_fields_default_none(self) -> None:
-        from eedom.core.models import AdmissionRequest
+        from eedom.core.models import ReviewRequest
 
-        req = AdmissionRequest.model_validate(self._make_request())
+        req = ReviewRequest.model_validate(self._make_request())
         assert req.current_version is None
         assert req.pr_url is None
         assert req.pr_number is None
@@ -257,9 +257,9 @@ class TestAdmissionRequest:
         assert req.use_case is None
 
     def test_round_trip_json(self) -> None:
-        from eedom.core.models import AdmissionRequest
+        from eedom.core.models import ReviewRequest
 
-        req = AdmissionRequest.model_validate(
+        req = ReviewRequest.model_validate(
             self._make_request(
                 pr_url="https://github.com/org/repo/pull/42",
                 pr_number=42,
@@ -267,7 +267,7 @@ class TestAdmissionRequest:
             )
         )
         dumped = req.model_dump(mode="json")
-        restored = AdmissionRequest.model_validate(dumped)
+        restored = ReviewRequest.model_validate(dumped)
 
         assert restored.request_id == req.request_id
         assert restored.package_name == "requests"
@@ -310,8 +310,8 @@ class TestPolicyEvaluation:
         assert restored.constraints == ["Requires security team sign-off"]
 
 
-class TestAdmissionDecision:
-    """AdmissionDecision — the aggregate root with business logic."""
+class TestReviewDecision:
+    """ReviewDecision — the aggregate root with business logic."""
 
     @staticmethod
     def _make_decision(
@@ -354,22 +354,22 @@ class TestAdmissionDecision:
         }
 
     def test_uuid_auto_generated(self) -> None:
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(self._make_decision())
+        decision = ReviewDecision.model_validate(self._make_decision())
         assert isinstance(decision.decision_id, uuid.UUID)
 
     def test_created_at_auto_generated(self) -> None:
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(self._make_decision())
+        decision = ReviewDecision.model_validate(self._make_decision())
         assert isinstance(decision.created_at, datetime)
 
     def test_monitor_mode_never_comments_or_marks_unstable(self) -> None:
         """In monitor mode, the system logs only — no PR comment, no build unstable."""
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(
+        decision = ReviewDecision.model_validate(
             self._make_decision(operating_mode="monitor", verdict="reject")
         )
         assert decision.should_comment is False
@@ -377,9 +377,9 @@ class TestAdmissionDecision:
 
     def test_advise_mode_reject_comments_and_marks_unstable(self) -> None:
         """In advise mode with a reject verdict, both comment and mark unstable."""
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(
+        decision = ReviewDecision.model_validate(
             self._make_decision(operating_mode="advise", verdict="reject")
         )
         assert decision.should_comment is True
@@ -387,9 +387,9 @@ class TestAdmissionDecision:
 
     def test_advise_mode_approve_no_comment_no_unstable(self) -> None:
         """In advise mode with approve, no comment or unstable marking needed."""
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(
+        decision = ReviewDecision.model_validate(
             self._make_decision(operating_mode="advise", verdict="approve")
         )
         assert decision.should_comment is False
@@ -397,9 +397,9 @@ class TestAdmissionDecision:
 
     def test_advise_mode_needs_review_comments_and_marks_unstable(self) -> None:
         """In advise mode with needs_review, comment and mark unstable."""
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(
+        decision = ReviewDecision.model_validate(
             self._make_decision(operating_mode="advise", verdict="needs_review")
         )
         assert decision.should_comment is True
@@ -407,20 +407,20 @@ class TestAdmissionDecision:
 
     def test_advise_mode_approve_with_constraints_comments_no_unstable(self) -> None:
         """In advise mode with approve_with_constraints, comment but don't mark unstable."""
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(
+        decision = ReviewDecision.model_validate(
             self._make_decision(operating_mode="advise", verdict="approve_with_constraints")
         )
         assert decision.should_comment is True
         assert decision.should_mark_unstable is False
 
     def test_round_trip_json(self) -> None:
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(self._make_decision())
+        decision = ReviewDecision.model_validate(self._make_decision())
         dumped = decision.model_dump(mode="json")
-        restored = AdmissionDecision.model_validate(dumped)
+        restored = ReviewDecision.model_validate(dumped)
 
         assert restored.decision_id == decision.decision_id
         assert restored.decision.value == "reject"
@@ -428,9 +428,9 @@ class TestAdmissionDecision:
         assert restored.pipeline_duration_seconds == 25.0
 
     def test_default_optional_fields(self) -> None:
-        from eedom.core.models import AdmissionDecision
+        from eedom.core.models import ReviewDecision
 
-        decision = AdmissionDecision.model_validate(self._make_decision())
+        decision = ReviewDecision.model_validate(self._make_decision())
         assert decision.evidence_bundle_path is None
         assert decision.memo_text is None
 

--- a/tests/unit/test_nl_query.py
+++ b/tests/unit/test_nl_query.py
@@ -183,10 +183,10 @@ class TestParamExtraction:
 
     def test_extract_param_preserves_original_case(self) -> None:
         param = _extract_param(
-            "callers of AdmissionPipeline",
+            "callers of ReviewPipeline",
             [r"callers of (\w+)", r"of (\w+)"],
         )
-        assert param == "AdmissionPipeline"
+        assert param == "ReviewPipeline"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_parquet_writer.py
+++ b/tests/unit/test_parquet_writer.py
@@ -12,8 +12,8 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     DecisionVerdict,
     Finding,
     FindingCategory,
@@ -44,8 +44,8 @@ def _request(
     scope: str = "runtime",
     commit_sha: str | None = "abc123def456",
     pr_url: str | None = "https://github.com/org/repo/pull/42",
-) -> AdmissionRequest:
-    return AdmissionRequest(
+) -> ReviewRequest:
+    return ReviewRequest(
         request_type=RequestType.new_package,
         ecosystem=ecosystem,
         package_name=package_name,
@@ -111,10 +111,10 @@ def _decision(
     duration: float = 5.0,
     package_name: str = "requests",
     target_version: str = "2.31.0",
-) -> AdmissionDecision:
+) -> ReviewDecision:
     req = _request(mode=mode, package_name=package_name, target_version=target_version)
     pol = policy or _policy_eval(decision=verdict)
-    return AdmissionDecision(
+    return ReviewDecision(
         request=req,
         decision=DecisionVerdict(verdict),
         findings=findings or [],
@@ -165,9 +165,9 @@ _scan_result_st = st.builds(
 
 
 @st.composite
-def _decision_strategy(draw: st.DrawFn) -> AdmissionDecision:
+def _decision_strategy(draw: st.DrawFn) -> ReviewDecision:
     verdict = draw(_verdict_st)
-    req = AdmissionRequest(
+    req = ReviewRequest(
         request_type=draw(_request_type_st),
         ecosystem=draw(_safe_text),
         package_name=draw(_safe_text),
@@ -184,7 +184,7 @@ def _decision_strategy(draw: st.DrawFn) -> AdmissionDecision:
         constraints=draw(st.lists(_safe_text, max_size=3)),
         policy_bundle_version=draw(_safe_text),
     )
-    return AdmissionDecision(
+    return ReviewDecision(
         request=req,
         decision=verdict,
         findings=draw(st.lists(_finding_st, max_size=5)),
@@ -213,7 +213,7 @@ class TestDecisionToRow:
         )
         findings = [_finding(severity="critical", advisory_id="CVE-2024-999")]
         scans = [_scan_result(tool="osv-scanner", status="success")]
-        dec = AdmissionDecision(
+        dec = ReviewDecision(
             request=_request(
                 mode="advise",
                 commit_sha="abc123",
@@ -313,7 +313,7 @@ class TestDecisionToRow:
         """When commit_sha is None on request, row has empty string."""
         req = _request(commit_sha=None)
         pol = _policy_eval()
-        dec = AdmissionDecision(
+        dec = ReviewDecision(
             request=req,
             decision=DecisionVerdict.approve,
             findings=[],
@@ -328,7 +328,7 @@ class TestDecisionToRow:
         """When pr_url is None on request, row has empty string."""
         req = _request(pr_url=None)
         pol = _policy_eval()
-        dec = AdmissionDecision(
+        dec = ReviewDecision(
             request=req,
             decision=DecisionVerdict.approve,
             findings=[],
@@ -481,8 +481,8 @@ class TestAppendDecisions:
 
 @given(_decision_strategy())
 @settings(max_examples=50)
-def test_any_valid_decision_converts_to_row(decision: AdmissionDecision) -> None:
-    """decision_to_row never raises for any valid AdmissionDecision."""
+def test_any_valid_decision_converts_to_row(decision: ReviewDecision) -> None:
+    """decision_to_row never raises for any valid ReviewDecision."""
     row = decision_to_row(decision, run_id="hypothesis-run")
 
     # All SCHEMA field names must be present in the row

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,4 +1,4 @@
-"""Tests for eedom.core.pipeline — AdmissionPipeline."""
+"""Tests for eedom.core.pipeline — ReviewPipeline."""
 
 # tested-by: tests/unit/test_pipeline.py
 
@@ -30,10 +30,10 @@ index 000..111 100644
 
 
 def _make_config(tmp_path: Path):
-    """Build a minimal AdmissionSettings pointing at tmp_path."""
-    from eedom.core.config import AdmissionSettings
+    """Build a minimal EedomSettings pointing at tmp_path."""
+    from eedom.core.config import EedomSettings
 
-    return AdmissionSettings(
+    return EedomSettings(
         db_dsn="postgresql://test:test@localhost/test",
         evidence_path=str(tmp_path / "evidence"),
         opa_policy_path=str(tmp_path / "policies"),
@@ -43,15 +43,15 @@ def _make_config(tmp_path: Path):
     )
 
 
-class TestAdmissionPipelineNoDependencyChanges:
+class TestReviewPipelineNoDependencyChanges:
     """Pipeline returns empty list when no dependency files changed."""
 
     def test_no_dependency_changes_returns_empty_list(self, tmp_path: Path) -> None:
         """When the diff has no dependency files, evaluate returns []."""
-        from eedom.core.pipeline import AdmissionPipeline
+        from eedom.core.pipeline import ReviewPipeline
 
         config = _make_config(tmp_path)
-        pipeline = AdmissionPipeline(config)
+        pipeline = ReviewPipeline(config)
 
         decisions = pipeline.evaluate(
             diff_text=DIFF_NO_DEPS,
@@ -68,10 +68,10 @@ class TestAdmissionPipelineNoDependencyChanges:
     def test_empty_diff_returns_empty_list(self, tmp_path: Path) -> None:
         """An empty diff string returns no decisions."""
         from eedom.core.models import OperatingMode
-        from eedom.core.pipeline import AdmissionPipeline
+        from eedom.core.pipeline import ReviewPipeline
 
         config = _make_config(tmp_path)
-        pipeline = AdmissionPipeline(config)
+        pipeline = ReviewPipeline(config)
 
         decisions = pipeline.evaluate(
             diff_text="",
@@ -84,15 +84,15 @@ class TestAdmissionPipelineNoDependencyChanges:
         assert decisions == []
 
 
-class TestAdmissionPipelineConstruction:
-    """AdmissionPipeline can be constructed without raising."""
+class TestReviewPipelineConstruction:
+    """ReviewPipeline can be constructed without raising."""
 
     def test_constructor_does_not_raise(self, tmp_path: Path) -> None:
-        """Importing and constructing AdmissionPipeline with valid config raises nothing."""
-        from eedom.core.pipeline import AdmissionPipeline
+        """Importing and constructing ReviewPipeline with valid config raises nothing."""
+        from eedom.core.pipeline import ReviewPipeline
 
         config = _make_config(tmp_path)
-        pipeline = AdmissionPipeline(config)
+        pipeline = ReviewPipeline(config)
 
         assert pipeline is not None
 
@@ -118,16 +118,16 @@ class TestAdmissionPipelineConstruction:
         assert trivy.name == "trivy"
 
 
-class TestAdmissionPipelineTimeoutEnforcement:
+class TestReviewPipelineTimeoutEnforcement:
     """Pipeline breaks the per-package loop when pipeline_timeout is exceeded."""
 
     def test_timeout_breaks_loop(self, tmp_path: Path) -> None:
         """When pipeline_timeout=0, the loop exits before processing any package."""
-        from eedom.core.config import AdmissionSettings
+        from eedom.core.config import EedomSettings
         from eedom.core.models import OperatingMode
-        from eedom.core.pipeline import AdmissionPipeline
+        from eedom.core.pipeline import ReviewPipeline
 
-        config = AdmissionSettings(
+        config = EedomSettings(
             db_dsn="postgresql://test:test@localhost/test",
             evidence_path=str(tmp_path / "evidence"),
             opa_policy_path=str(tmp_path / "policies"),
@@ -136,7 +136,7 @@ class TestAdmissionPipelineTimeoutEnforcement:
             combined_scanner_timeout=180,
         )
 
-        pipeline = AdmissionPipeline(config)
+        pipeline = ReviewPipeline(config)
 
         # Patch orchestrator.run to return empty results quickly
         with patch(

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -52,7 +52,7 @@ def _opa_json_output(
                             "warn": warn or [],
                             "decision": decision,
                         },
-                        "text": "data.admission",
+                        "text": "data.policy",
                         "location": {"row": 1, "col": 1},
                     }
                 ]

--- a/tests/unit/test_properties.py
+++ b/tests/unit/test_properties.py
@@ -1,4 +1,4 @@
-"""Property-based tests for Admission Control invariants.
+"""Property-based tests for Dependency Review invariants.
 
 # tested-by: tests/unit/test_properties.py
 
@@ -14,8 +14,8 @@ from hypothesis import strategies as st
 from eedom.core.diff import _parse_requirements
 from eedom.core.memo import _MAX_MEMO_LENGTH, generate_memo
 from eedom.core.models import (
-    AdmissionDecision,
-    AdmissionRequest,
+    ReviewDecision,
+    ReviewRequest,
     DecisionVerdict,
     Finding,
     FindingCategory,
@@ -66,9 +66,9 @@ def _build_decision(
     findings: list[Finding],
     triggered_rules: list[str],
     scan_results: list[ScanResult] | None = None,
-) -> AdmissionDecision:
-    """Build a minimal AdmissionDecision for property testing."""
-    request = AdmissionRequest(
+) -> ReviewDecision:
+    """Build a minimal ReviewDecision for property testing."""
+    request = ReviewRequest(
         request_type=RequestType.new_package,
         ecosystem="pypi",
         package_name="test-pkg",
@@ -81,7 +81,7 @@ def _build_decision(
         triggered_rules=triggered_rules,
         policy_bundle_version="1.0.0",
     )
-    return AdmissionDecision(
+    return ReviewDecision(
         request=request,
         decision=verdict,
         findings=findings,

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -157,16 +157,16 @@ def _make_llm_config(
     llm_endpoint: str = "https://llm.example.com/v1",
     llm_model: str = "gpt-4o",
 ) -> object:
-    from eedom.core.config import AdmissionSettings
+    from eedom.core.config import EedomSettings
 
     env = {
-        "ADMISSION_DB_DSN": "postgresql://test:test@localhost/test",
-        "ADMISSION_LLM_ENABLED": str(llm_enabled).lower(),
-        "ADMISSION_LLM_ENDPOINT": llm_endpoint,
-        "ADMISSION_LLM_MODEL": llm_model,
+        "EEDOM_DB_DSN": "postgresql://test:test@localhost/test",
+        "EEDOM_LLM_ENABLED": str(llm_enabled).lower(),
+        "EEDOM_LLM_ENDPOINT": llm_endpoint,
+        "EEDOM_LLM_MODEL": llm_model,
     }
     with patch.dict(os.environ, env, clear=True):
-        return AdmissionSettings()
+        return EedomSettings()
 
 
 class TestLLMPromptInjection:

--- a/tests/unit/test_taskfit.py
+++ b/tests/unit/test_taskfit.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import httpx
 import respx
 
-from eedom.core.config import AdmissionSettings
+from eedom.core.config import EedomSettings
 from eedom.core.taskfit import TaskFitAdvisor
 
 # ---------------------------------------------------------------------------
@@ -24,22 +24,22 @@ def _make_config(
     llm_model: str | None = None,
     llm_api_key: str | None = None,
     llm_timeout: int = 30,
-) -> AdmissionSettings:
-    """Build an AdmissionSettings with controlled LLM fields."""
+) -> EedomSettings:
+    """Build an EedomSettings with controlled LLM fields."""
     env = {
-        "ADMISSION_DB_DSN": "postgresql://test:test@localhost/test",
-        "ADMISSION_LLM_ENABLED": str(llm_enabled).lower(),
-        "ADMISSION_LLM_TIMEOUT": str(llm_timeout),
+        "EEDOM_DB_DSN": "postgresql://test:test@localhost/test",
+        "EEDOM_LLM_ENABLED": str(llm_enabled).lower(),
+        "EEDOM_LLM_TIMEOUT": str(llm_timeout),
     }
     if llm_endpoint:
-        env["ADMISSION_LLM_ENDPOINT"] = llm_endpoint
+        env["EEDOM_LLM_ENDPOINT"] = llm_endpoint
     if llm_model:
-        env["ADMISSION_LLM_MODEL"] = llm_model
+        env["EEDOM_LLM_MODEL"] = llm_model
     if llm_api_key:
-        env["ADMISSION_LLM_API_KEY"] = llm_api_key
+        env["EEDOM_LLM_API_KEY"] = llm_api_key
 
     with patch.dict(os.environ, env, clear=True):
-        return AdmissionSettings()
+        return EedomSettings()
 
 
 SAMPLE_METADATA = {"summary": "A fast HTTP client library"}


### PR DESCRIPTION
## Summary

- Renamed all `ADMISSION_*` env vars → `EEDOM_*` (breaking change for existing deployments)
- Renamed Rego policy package `admission` → `policy`, files `admission.rego` → `policy.rego`
- Renamed Python classes: `AdmissionSettings` → `EedomSettings`, `AdmissionPipeline` → `ReviewPipeline`, `AdmissionDecision` → `ReviewDecision`, `AdmissionRequest` → `ReviewRequest`
- Renamed DB tables: `admission_requests` → `review_requests`, `admission_decisions` → `review_decisions`
- Scrubbed all "admission control" prose from docs, docstrings, comments, action.yml, docker-compose.yml, issue templates
- Renamed planning doc filenames: `agentic_dependency_admission_control_*.md` → `architecture-plan-v{1,2}.md`
- Added "Why This Exists" section + hero banner to elevator pitch and README

## Verification

- 972 Python tests pass (0 failures from this change)
- 17/17 OPA Rego policy tests pass
- `grep -rni admission` returns zero hits across the entire codebase

## Breaking Changes

Existing deployments need to update:
- Environment variables: `ADMISSION_*` → `EEDOM_*`
- DB table names if using PostgreSQL persistence
- Any CI scripts referencing `admission.rego` or `data.admission`

## Test plan

- [x] OPA policy tests pass with renamed package
- [x] Full Python test suite passes
- [x] Zero remaining "admission" references in codebase
- [ ] Verify GitHub Action workflow with updated env var names