### PR TITLE
fix: repair double-word stutters from admission rename

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Dependency Dependency Review'
+name: 'Dependency Review'
 description: 'Evaluate dependency changes for security, license, and policy compliance'
 
 inputs:
@@ -95,7 +95,7 @@ runs:
         MARKER="<!-- eedom-result -->"
         COMMENT_BODY="$MARKER
         <details>
-        <summary>Dependency Dependency Review</summary>
+        <summary>Dependency Review</summary>
 
         $(cat "$MEMO_FILE")
 
@@ -122,4 +122,4 @@ runs:
       if: inputs.operating-mode == 'advise' && steps.evaluate.outputs.decision == 'reject'
       shell: bash
       run: |
-        echo "::warning::Dependency dependency review: REJECT — see PR comment for details"
+        echo "::warning::Dependency review: REJECT — see PR comment for details"

--- a/docs/architecture-plan-v1.md
+++ b/docs/architecture-plan-v1.md
@@ -1,4 +1,4 @@
-# Agentic Dependency Dependency Review
+# Agentic Dependency Review
 
 ## OSS Architecture, Operating Model, and Epic-Level Implementation Packet
 
@@ -6,7 +6,7 @@
 
 # 1. Executive Summary
 
-This document defines a **platform-agnostic, event-driven dependency dependency review system** for governing how third-party software packages and version upgrades are approved for use.
+This document defines a **platform-agnostic, event-driven dependency review system** for governing how third-party software packages and version upgrades are approved for use.
 
 The core objective is to move dependency security from a **reactive scanning model** to a **proactive eedom model**.
 
@@ -129,7 +129,7 @@ The target state is a system where:
 
 # 4. Core Concept
 
-## 4.1 Dependency Dependency Review
+## 4.1 Dependency Review
 
 The closest conceptual analogue is **Kubernetes Dependency Review**.
 
@@ -145,7 +145,7 @@ This system applies the same mental model to software dependencies.
 | Allow / deny / mutate               | Approve / reject / constrain              |
 | Cluster state                       | Internal artifact availability state      |
 
-The result is a **Dependency Dependency Reviewler**.
+The result is a **Eagle Eyed Dom**.
 
 ## 4.2 Why this is different from standard scanning
 
@@ -329,7 +329,7 @@ Recommended characteristics:
 
 ## 9.1 Closest Conceptual Prior Art
 
-### Kubernetes dependency reviewlers
+### Kubernetes admission controllers
 
 Examples:
 
@@ -384,7 +384,7 @@ These establish provenance and evidence but do not independently solve contextua
 ### Largely uncovered and differentiated
 
 - task-fit / intent-aware dependency reasoning
-- centralized, event-driven dependency dependency review
+- centralized, event-driven dependency review
 - upgrade risk delta analysis as a first-class workflow
 - explainable, unified decision control plane that composes scanners and policy
 
@@ -2128,7 +2128,7 @@ This is the architectural shift.
 
 The design is fully achievable with open-source technology.
 
-What does not exist off the shelf is not the scanning layer, the workflow layer, or even the policy layer. Those all exist. The core work is composing them into a coherent **dependency dependency review system** with:
+What does not exist off the shelf is not the scanning layer, the workflow layer, or even the policy layer. Those all exist. The core work is composing them into a coherent **dependency review system** with:
 
 - strong event handling
 - durable workflows

--- a/docs/architecture-plan-v2.md
+++ b/docs/architecture-plan-v2.md
@@ -1,4 +1,4 @@
-# Agentic Dependency Dependency Review — v2
+# Agentic Dependency Review — v2
 
 ## OSS Architecture, Operating Model, and Phased Implementation Plan
 
@@ -6,7 +6,7 @@
 
 # 1. Executive Summary
 
-This document defines a **platform-agnostic, event-driven dependency dependency review system** for governing how third-party software packages and version upgrades are approved for use.
+This document defines a **platform-agnostic, event-driven dependency review system** for governing how third-party software packages and version upgrades are approved for use.
 
 The core objective is to move dependency security from a **reactive scanning model** to a **proactive eedom model**.
 
@@ -99,7 +99,7 @@ The target state is a system where:
 
 # 4. Core Concept
 
-## 4.1 Dependency Dependency Review
+## 4.1 Dependency Review
 
 The closest conceptual analogue is **Kubernetes Dependency Review**.
 
@@ -115,7 +115,7 @@ This system applies the same mental model to software dependencies.
 | Allow / deny / mutate               | Approve / reject / constrain              |
 | Cluster state                       | Internal artifact availability state      |
 
-The result is a **Dependency Dependency Reviewler**.
+The result is a **Eagle Eyed Dom**.
 
 ## 4.2 Why this is different from standard scanning
 
@@ -235,7 +235,7 @@ These capabilities exist in mature, well-maintained open-source tools. We should
 | Capability | Market Status |
 |---|---|
 | Task-fit / intent-aware dependency reasoning | No existing solution |
-| Centralized, event-driven dependency dependency review plane | No turnkey OSS solution |
+| Centralized, event-driven dependency review plane | No turnkey OSS solution |
 | Upgrade risk delta analysis as a first-class workflow | No unified solution |
 | Explainable decision memos composing scanner + policy + context | No existing solution |
 | Three-mode (monitor/advise/enforce) progressive rollout | No existing solution |
@@ -309,7 +309,7 @@ The following are assumed to exist before product development begins. If they do
 
 ## 9.1 Closest Conceptual Prior Art
 
-### Kubernetes dependency reviewlers
+### Kubernetes admission controllers
 
 Examples: OPA Gatekeeper, Kyverno
 
@@ -345,7 +345,7 @@ These establish provenance and evidence but do not independently solve contextua
 ### Largely uncovered and differentiated
 
 - task-fit / intent-aware dependency reasoning
-- centralized, event-driven dependency dependency review
+- centralized, event-driven dependency review
 - upgrade risk delta analysis as a first-class workflow
 - explainable, unified decision control plane that composes scanners and policy
 - progressive rollout with monitor/advise/enforce modes

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,4 +1,4 @@
-"""GitHub Copilot Agent for dependency dependency review and code review.
+"""GitHub Copilot Agent for dependency review and code review.
 # tested-by: tests/unit/test_agent_main.py
 
 Reactive PR flow: triggers on lockfile/manifest changes, evaluates packages via

--- a/src/agent/main.py
+++ b/src/agent/main.py
@@ -132,7 +132,7 @@ class GatekeeperAgent:
         agent = GitHubCopilotAgent(
             instructions=system_prompt,
             name="gatekeeper",
-            description="Dependency dependency review and code review agent",
+            description="Dependency review and code review agent",
             tools=[
                 evaluate_change,
                 check_package,

--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -130,7 +130,7 @@ def build_system_prompt(
         alt_section = f"\n\nApproved alternative packages in this organization: {alt_list}"
 
     return f"""\
-You are GATEKEEPER, a dependency dependency review and code review agent for a \
+You are GATEKEEPER, a dependency review and code review agent for a \
 software engineering organization.
 
 Your job: when a pull request changes dependency manifests or source code, you \

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -56,7 +56,7 @@ class DebounceTimer:
 
 @click.group()
 def cli() -> None:
-    """Agentic Dependency Dependency Review — PoC CLI."""
+    """Agentic Dependency Review — PoC CLI."""
 
 
 @cli.command()

--- a/src/eedom/agent/__init__.py
+++ b/src/eedom/agent/__init__.py
@@ -1,4 +1,4 @@
-"""GitHub Copilot Agent for dependency dependency review and code review.
+"""GitHub Copilot Agent for dependency review and code review.
 # tested-by: tests/unit/test_agent_main.py
 
 Reactive PR flow: triggers on lockfile/manifest changes, evaluates packages via

--- a/src/eedom/agent/main.py
+++ b/src/eedom/agent/main.py
@@ -132,7 +132,7 @@ class GatekeeperAgent:
         agent = GitHubCopilotAgent(
             instructions=system_prompt,
             name="gatekeeper",
-            description="Dependency dependency review and code review agent",
+            description="Dependency review and code review agent",
             tools=[
                 evaluate_change,
                 check_package,

--- a/src/eedom/agent/prompt.py
+++ b/src/eedom/agent/prompt.py
@@ -130,7 +130,7 @@ def build_system_prompt(
         alt_section = f"\n\nApproved alternative packages in this organization: {alt_list}"
 
     return f"""\
-You are GATEKEEPER, a dependency dependency review and code review agent for a \
+You are GATEKEEPER, a dependency review and code review agent for a \
 software engineering organization.
 
 Your job: when a pull request changes dependency manifests or source code, you \

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -56,7 +56,7 @@ class DebounceTimer:
 
 @click.group()
 def cli() -> None:
-    """Agentic Dependency Dependency Review — PoC CLI."""
+    """Agentic Dependency Review — PoC CLI."""
 
 
 @cli.command()

--- a/src/eedom/core/taskfit.py
+++ b/src/eedom/core/taskfit.py
@@ -24,7 +24,7 @@ _MAX_ADVISORY_LENGTH = 500
 _SUMMARY_MAX_LEN = 200
 
 _SYSTEM_PROMPT = """\
-You are a dependency dependency review analyst for a software engineering organization.
+You are a dependency review analyst for a software engineering organization.
 
 Your job is to evaluate whether a requested third-party package is appropriate, \
 proportionate, and safe for its stated use case. You are the last line of reasoning \


### PR DESCRIPTION
## Summary

- Fixed "Dependency Dependency Review" → "Dependency Review" stutters across action.yml, source, and docs
- Fixed "Dependency Reviewler" → restored "Kubernetes admission controllers" (K8s concept, not our branding)
- 12 files, 972 tests pass

Cleanup from PR #5's bulk rename.