### PR TITLE
chore: bump renderer version to 1.2.0

### DIFF
--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -1,0 +1,146 @@
+# Copilot Review Instructions
+
+## What eedom already covers — skip these
+
+Eagle Eyed Dom runs 15 deterministic plugins on every PR. Do not duplicate these checks — they are already enforced by the `GATEKEEPER Review` CI job and surfaced via the `dom:` label system.
+
+| Category | Covered by | What it catches |
+|----------|-----------|-----------------|
+| Vulnerabilities | OSV-Scanner, Trivy | Known CVEs across 18 ecosystems |
+| Licenses | ScanCode | GPL, AGPL, SSPL, forbidden license detection |
+| Secrets | Gitleaks | API keys, tokens, passwords (800+ patterns) |
+| Supply chain | Supply Chain plugin | Unpinned deps, missing lockfiles, package age < 30d, malware |
+| Complexity metrics | Lizard + Radon | Cyclomatic complexity, maintainability index |
+| Copy-paste | PMD CPD | Token-based duplication across 12 languages |
+| Spelling | cspell | Code-aware spell checking |
+| File naming | ls-lint | Naming convention enforcement |
+| K8s security | kube-linter | Resource limits, privileged containers, latest tags |
+| Code patterns | Semgrep | AST pattern matching with org rulesets |
+| Blast radius | Code graph | High fan-out, layer violations, dead code, stub detection |
+| Policy | OPA | 6 Rego rules: deny/warn/approve verdict |
+| SBOM | Syft | CycloneDX bill of materials |
+| Malware | ClamAV | Virus/malware scanning |
+
+**If you're about to comment on a CVE, a leaked secret, a license issue, unpinned deps, or cyclomatic complexity — stop. Dom already caught it or it's not there.**
+
+---
+
+## What to review — things that require judgment
+
+Focus your review on what deterministic tools cannot catch. Every comment should be something a scanner can't flag.
+
+### 1. Business logic correctness
+
+Does the code do what the PR description says it does? Are the calculations right? Does the state machine transition correctly? Are the edge cases handled?
+
+Look for:
+- Off-by-one errors in loops and slices
+- Incorrect boolean logic (De Morgan violations, inverted conditions)
+- Missing branches in match/switch statements
+- Null/None handling that produces silent wrong answers instead of errors
+- Time zone assumptions in date/time logic
+
+### 2. API and interface design
+
+Is this the right interface for callers? Will it be painful to use or extend?
+
+Look for:
+- Functions that take too many parameters (>5 is a smell)
+- Boolean parameters that control branching ("stringly typed" APIs)
+- Leaking internal types across module boundaries
+- Breaking changes to existing public interfaces without migration
+- Return types that force callers to do extra work (returning raw dicts when a typed object would be clearer)
+
+### 3. Concurrency and race conditions
+
+Deterministic scanners can't reason about runtime interleaving.
+
+Look for:
+- Shared mutable state without synchronization
+- Check-then-act patterns (TOCTOU)
+- Async code that blocks the event loop
+- Database operations that assume serializable isolation without enforcing it
+- Cache invalidation timing windows
+
+### 4. Error handling strategy
+
+Not "is there a try/catch" — eedom's semgrep rules catch missing timeouts and bare exception swallowing. Instead: is the error handling *correct for this context*?
+
+Look for:
+- Catching too broadly and masking the real error
+- Error recovery that leaves state inconsistent
+- Missing rollback/cleanup on partial failure
+- Error messages that leak internal details to external callers
+- Retry logic that can amplify failures (retry storms)
+
+### 5. Performance implications
+
+Algorithmic and architectural performance — not microbenchmarks.
+
+Look for:
+- N+1 query patterns (loop with a query inside)
+- Unbounded collection growth (lists/dicts that grow with input size without limits)
+- Quadratic or worse algorithms where linear exists
+- Missing pagination on list/search endpoints
+- Blocking I/O in hot paths
+- Large allocations in frequently called code
+
+### 6. Test quality
+
+Eedom checks that `# tested-by:` annotations exist and flags stub functions. But it can't tell whether the tests are *good*.
+
+Look for:
+- Tests that pass when the implementation is deleted (weak assertions)
+- Tests that only cover the happy path
+- Mocking the thing being tested instead of its dependencies
+- Tests coupled to implementation details rather than behavior
+- Missing edge case coverage (empty inputs, max values, unicode, concurrent access)
+
+### 7. Security logic
+
+Eedom catches secrets in code, known CVEs, and AST-level injection patterns. It cannot reason about authorization flows, authentication logic, or trust boundaries.
+
+Look for:
+- Missing authorization checks on new endpoints
+- Privilege escalation paths (user A can access user B's data)
+- Trust boundary violations (treating external input as trusted after a single check)
+- Session handling issues (fixation, insufficient expiry)
+- Audit logging gaps on sensitive operations
+
+### 8. Data model and migration safety
+
+Look for:
+- Schema changes that break backwards compatibility
+- Migrations that lock large tables
+- NOT NULL columns added without defaults on existing data
+- Index changes that affect query plans
+- Data type changes that lose precision (float→int, timestamp→date)
+
+### 9. Naming and readability
+
+Not syntactic naming (ls-lint covers conventions) — semantic clarity.
+
+Look for:
+- Names that mislead about what the code does
+- Abbreviations that aren't obvious to the team
+- Boolean variables/functions without clear true/false semantics
+- Functions named "process" or "handle" that do too many things
+- Comments that describe *what* instead of *why* (the code already says what)
+
+### 10. Backwards compatibility
+
+Look for:
+- Changed function signatures without updating all callers
+- Removed or renamed public exports
+- Changed serialization formats (JSON field names, protobuf field numbers)
+- Environment variable renames without migration support
+- Config file format changes without version detection
+
+---
+
+## How to comment
+
+- **Be specific.** "This might have a race condition" is noise. "Lines 42-47: the read and write to `_cache` aren't synchronized — concurrent requests can see stale data after the TTL check on L43 passes but before the write on L47 completes" is useful.
+- **Explain the impact.** Not just what's wrong, but what happens if it ships.
+- **Suggest a fix.** Or at least a direction. "Consider using a lock here" beats "this is unsafe."
+- **Skip nits.** If eedom or the formatter would catch it, don't comment on it. Your time is better spent on the 10 categories above.

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -74,7 +74,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dependencies
+      - name: Detect runtime
+        id: runtime
+        run: |
+          if command -v podman &>/dev/null; then
+            echo "engine=podman" >> "$GITHUB_OUTPUT"
+            echo "container=true" >> "$GITHUB_OUTPUT"
+          elif command -v docker &>/dev/null; then
+            echo "engine=docker" >> "$GITHUB_OUTPUT"
+            echo "container=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "engine=native" >> "$GITHUB_OUTPUT"
+            echo "container=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies (native)
+        if: steps.runtime.outputs.container == 'false'
         run: uv sync --group dev
 
       - name: Generate PR diff
@@ -86,12 +101,28 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run eedom review
-        id: review
+      - name: Run eedom review (container)
+        if: steps.runtime.outputs.container == 'true'
+        run: |
+          ENGINE="${{ steps.runtime.outputs.engine }}"
+          $ENGINE run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -v "$GITHUB_WORKSPACE/.temp:/workspace/.temp" \
+            eedom:latest \
+            sh -c "
+              uv run eedom review --repo-path /workspace --all --format sarif --output /workspace/.temp/review.sarif
+              uv run eedom review --repo-path /workspace --all --output /workspace/.temp/review.md || true
+            "
+
+      - name: Run eedom review (native)
+        if: steps.runtime.outputs.container == 'false'
         run: |
           uv run eedom review --repo-path . --all --format sarif --output .temp/review.sarif
           uv run eedom review --repo-path . --all --output .temp/review.md || true
 
+      - name: Compute verdict
+        id: verdict
+        run: |
           ERRORS=0
           WARNINGS=0
           if [ -f .temp/review.sarif ]; then
@@ -121,27 +152,28 @@ jobs:
             echo "verdict=approved" >> "$GITHUB_OUTPUT"
           fi
 
+          echo "Runtime: ${{ steps.runtime.outputs.engine }} | Errors: $ERRORS | Warnings: $WARNINGS"
+
       - name: Set dom label
         if: github.event_name == 'pull_request'
         run: |
-          # Remove any existing dom labels
           for LABEL in "dom: approved" "dom: warnings" "dom: blocked"; do
             gh issue edit "$PR_NUM" --remove-label "$LABEL" 2>/dev/null || true
           done
 
-          # Apply the verdict label
           gh issue edit "$PR_NUM" --add-label "dom: $VERDICT"
 
-          echo "## 🏷️ dom: $VERDICT" >> "$GITHUB_STEP_SUMMARY"
+          echo "## dom: $VERDICT" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Runtime:** ${{ steps.runtime.outputs.engine }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Errors (critical/high):** $ERRORS" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Warnings (medium):** $WARNINGS" >> "$GITHUB_STEP_SUMMARY"
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUM: ${{ github.event.pull_request.number }}
-          VERDICT: ${{ steps.review.outputs.verdict }}
-          ERRORS: ${{ steps.review.outputs.errors }}
-          WARNINGS: ${{ steps.review.outputs.warnings }}
+          VERDICT: ${{ steps.verdict.outputs.verdict }}
+          ERRORS: ${{ steps.verdict.outputs.errors }}
+          WARNINGS: ${{ steps.verdict.outputs.warnings }}
 
       - name: Post review comment
         if: github.event_name == 'pull_request'
@@ -181,6 +213,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
-          VERDICT: ${{ steps.review.outputs.verdict }}
-          ERRORS: ${{ steps.review.outputs.errors }}
-          WARNINGS: ${{ steps.review.outputs.warnings }}
+          VERDICT: ${{ steps.verdict.outputs.verdict }}
+          ERRORS: ${{ steps.verdict.outputs.errors }}
+          WARNINGS: ${{ steps.verdict.outputs.warnings }}

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -106,7 +106,7 @@ jobs:
         if: steps.runtime.outputs.container == 'true'
         run: |
           ENGINE="${{ steps.runtime.outputs.engine }}"
-          $ENGINE run --rm \
+          $ENGINE run --rm --entrypoint "" \
             -v "$GITHUB_WORKSPACE:/workspace:ro" \
             -v "$GITHUB_WORKSPACE/.temp:/workspace/.temp" \
             eedom:latest \

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -77,10 +77,11 @@ jobs:
       - name: Detect runtime
         id: runtime
         run: |
-          if command -v podman &>/dev/null; then
+          # Check podman is installed AND responsive (machine running, image pullable)
+          if command -v podman &>/dev/null && podman info &>/dev/null && podman image exists eedom:latest &>/dev/null; then
             echo "engine=podman" >> "$GITHUB_OUTPUT"
             echo "container=true" >> "$GITHUB_OUTPUT"
-          elif command -v docker &>/dev/null; then
+          elif command -v docker &>/dev/null && docker info &>/dev/null && docker image inspect eedom:latest &>/dev/null; then
             echo "engine=docker" >> "$GITHUB_OUTPUT"
             echo "container=true" >> "$GITHUB_OUTPUT"
           else

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -14,7 +14,7 @@ from eedom.core.plugin import PluginResult
 
 _MAX_COMMENT_LENGTH = 65536
 _DEFAULT_TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
-_VERSION = "0.1.0"
+_VERSION = "1.2.0"
 
 _SEVERITY_WEIGHTS: dict[str, int] = {
     "critical": 10,


### PR DESCRIPTION
## Summary

- Bump comment renderer version from 0.1.0 to 1.2.0 to match the current release

Minimal change to demo dom label management in CI.