### PR TITLE
fix: templates in wheel + gitleaks custom config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,13 @@ dependencies = [
 [project.scripts]
 eedom = "eedom.cli.main:cli"
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/eedom"]
+
 [tool.uv]
 package = true
 

--- a/src/eedom/plugins/gitleaks.py
+++ b/src/eedom/plugins/gitleaks.py
@@ -45,18 +45,24 @@ class GitleaksPlugin(ScannerPlugin):
         repo_path: Path,
         timeout: int = 60,
     ) -> PluginResult:
+        cmd = [
+            "gitleaks",
+            "dir",
+            str(repo_path),
+            "--report-format",
+            "json",
+            "--report-path",
+            "/dev/stdout",
+            "--no-banner",
+        ]
+        custom_config = repo_path / ".eedom" / "gitleaks.toml"
+        if custom_config.is_file():
+            cmd.extend(["--config", str(custom_config)])
+            logger.info("gitleaks.custom_config", path=str(custom_config))
+
         try:
             r = subprocess.run(
-                [
-                    "gitleaks",
-                    "dir",
-                    str(repo_path),
-                    "--report-format",
-                    "json",
-                    "--report-path",
-                    "/dev/stdout",
-                    "--no-banner",
-                ],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=timeout,

--- a/tests/unit/test_gitleaks_plugin.py
+++ b/tests/unit/test_gitleaks_plugin.py
@@ -8,9 +8,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from eedom.plugins.gitleaks import GitleaksPlugin
-
 from eedom.core.plugin import PluginCategory
+from eedom.plugins.gitleaks import GitleaksPlugin
 
 LEAK_OUTPUT = json.dumps(
     [
@@ -117,3 +116,31 @@ class TestGitleaksPlugin:
         p = GitleaksPlugin()
         result = PluginResult(plugin_name="gitleaks", error="not installed")
         assert "not installed" in p.render(result)
+
+    @patch("eedom.plugins.gitleaks.subprocess.run")
+    def test_custom_config_passed_when_present(self, mock_run, tmp_path):
+        config_dir = tmp_path / ".eedom"
+        config_dir.mkdir()
+        config_file = config_dir / "gitleaks.toml"
+        config_file.write_text('title = "custom"\n')
+
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = CLEAN_OUTPUT
+
+        p = GitleaksPlugin()
+        p.run(["app.py"], tmp_path)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--config" in cmd
+        assert str(config_file) in cmd
+
+    @patch("eedom.plugins.gitleaks.subprocess.run")
+    def test_no_config_flag_when_absent(self, mock_run):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = CLEAN_OUTPUT
+
+        p = GitleaksPlugin()
+        p.run(["app.py"], Path("/nonexistent"))
+
+        cmd = mock_run.call_args[0][0]
+        assert "--config" not in cmd


### PR DESCRIPTION
## Summary

- **Fixes #14**: Added `[build-system]` with hatchling + `[tool.hatch.build]` to `pyproject.toml`. Templates are now included in the wheel — `uv tool install eedom` works.
- **Fixes #23**: Gitleaks plugin auto-detects `.eedom/gitleaks.toml` and passes `--config` when present. Default behavior unchanged.

## Test plan

- [x] `uv build --wheel` includes all 6 `.j2` templates, no duplicates
- [x] 11 gitleaks tests pass (2 new: config present + config absent)
- [x] Ruff clean