### PR TITLE
feat: validate SARIF lines against diff hunks + SMART comments

### DIFF
--- a/src/eedom/core/pr_review.py
+++ b/src/eedom/core/pr_review.py
@@ -9,12 +9,31 @@ go in a collapsed section in the summary body.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from dataclasses import dataclass, field
 
 import structlog
 
 logger = structlog.get_logger(__name__)
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", re.MULTILINE)
+
+
+def parse_hunk_ranges(patch: str) -> list[tuple[int, int]]:
+    """Extract (start, end) line ranges from a unified diff patch string."""
+    ranges: list[tuple[int, int]] = []
+    for m in _HUNK_RE.finditer(patch):
+        start = int(m.group(1))
+        length = int(m.group(2)) if m.group(2) is not None else 1
+        end = start + length - 1 if length > 0 else start
+        ranges.append((start, end))
+    return ranges
+
+
+def line_in_hunks(line: int, hunks: list[tuple[int, int]]) -> bool:
+    """Return True if line falls within any of the hunk ranges."""
+    return any(start <= line <= end for start, end in hunks)
 
 
 @dataclass
@@ -33,11 +52,33 @@ class PRReview:
     outside_diff: list[dict] = field(default_factory=list)
 
 
-def sarif_to_review(sarif: dict, diff_files: set[str]) -> PRReview:
+def _build_smart_comment(rule_id: str, level: str, msg: str, result: dict) -> str:
+    """Build a SMART inline comment: Specific, Measurable, Actionable, Relevant, Targeted."""
+    icon = {"error": "🔴", "warning": "🟡", "note": "🔵"}.get(level, "⚪")
+    parts = [f"{icon} **{rule_id}** (`{level}`)"]
+    parts.append("")
+    parts.append(msg)
+
+    fixes = result.get("fixes", [])
+    if fixes:
+        fix_text = fixes[0].get("description", {}).get("text", "")
+        if fix_text:
+            parts.append("")
+            parts.append(f"**Fix:** {fix_text}")
+
+    return "\n".join(parts)
+
+
+def sarif_to_review(
+    sarif: dict,
+    diff_files: set[str],
+    diff_hunks: dict[str, list[tuple[int, int]]] | None = None,
+) -> PRReview:
     """Convert SARIF findings into a PRReview with inline comments.
 
-    Findings on files in the PR diff become inline comments.
-    Findings on files outside the diff go in the summary body.
+    Findings on files in the PR diff become inline comments, but only when
+    the finding's line falls within an actual diff hunk (when diff_hunks is
+    provided). Findings outside hunks or outside the diff go in the summary.
     """
     comments: list[ReviewComment] = []
     outside: list[dict] = []
@@ -66,10 +107,14 @@ def sarif_to_review(sarif: dict, diff_files: set[str]) -> PRReview:
                 file_path = phys.get("artifactLocation", {}).get("uri", "")
                 line_num = phys.get("region", {}).get("startLine", 1)
 
-            icon = {"error": "🔴", "warning": "🟡", "note": "🔵"}.get(level, "⚪")
-            comment_body = f"{icon} **{rule_id}** ({level})\n\n{msg}"
+            comment_body = _build_smart_comment(rule_id, level, msg, result)
 
-            if file_path and file_path in diff_files:
+            in_diff = file_path and file_path in diff_files
+            in_hunk = True
+            if in_diff and diff_hunks and file_path in diff_hunks:
+                in_hunk = line_in_hunks(line_num, diff_hunks[file_path])
+
+            if in_diff and in_hunk:
                 comments.append(
                     ReviewComment(
                         path=file_path,
@@ -131,8 +176,6 @@ def sarif_to_review(sarif: dict, diff_files: set[str]) -> PRReview:
 
 def detect_gh_repo() -> str | None:
     """Auto-detect GitHub owner/repo from git remote."""
-    import re
-
     try:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
@@ -172,6 +215,37 @@ def get_pr_diff_files(repo: str, pr_number: int) -> set[str]:
         stderr = result.stderr.strip()
         raise RuntimeError(f"Failed to fetch PR diff files for {repo}#{pr_number}: {stderr[:200]}")
     return {f.strip() for f in result.stdout.strip().split("\n") if f.strip()}
+
+
+def get_pr_diff_hunks(repo: str, pr_number: int) -> dict[str, list[tuple[int, int]]]:
+    """Fetch per-file hunk ranges from a PR via gh CLI.
+
+    Returns {filename: [(start, end), ...]} for each file with a patch.
+    """
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/files",
+            "--paginate",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError(f"Failed to fetch PR diff hunks for {repo}#{pr_number}: {stderr[:200]}")
+
+    hunks: dict[str, list[tuple[int, int]]] = {}
+    for file_entry in json.loads(result.stdout):
+        filename = file_entry.get("filename", "")
+        patch = file_entry.get("patch", "")
+        if filename and patch:
+            ranges = parse_hunk_ranges(patch)
+            if ranges:
+                hunks[filename] = ranges
+    return hunks
 
 
 def post_review(repo: str, pr_number: int, review: PRReview) -> bool:

--- a/tests/unit/test_pr_review.py
+++ b/tests/unit/test_pr_review.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from eedom.core.pr_review import sarif_to_review
+from eedom.core.pr_review import line_in_hunks, parse_hunk_ranges, sarif_to_review
 
 
 def _sarif(results: list[dict], tool: str = "test-tool") -> dict:
@@ -119,3 +119,116 @@ class TestSarifToReview:
 
         assert len(review.comments) == 0
         assert review.event == "COMMENT"
+
+
+class TestParseHunkRanges:
+    def test_single_hunk(self):
+        patch = "@@ -1,3 +1,5 @@\n+added\n context\n"
+        ranges = parse_hunk_ranges(patch)
+        assert ranges == [(1, 5)]
+
+    def test_multiple_hunks(self):
+        patch = "@@ -1,3 +1,4 @@\n context\n+added\n@@ -20,3 +21,6 @@\n context\n+more\n"
+        ranges = parse_hunk_ranges(patch)
+        assert ranges == [(1, 4), (21, 26)]
+
+    def test_no_hunks(self):
+        assert parse_hunk_ranges("") == []
+        assert parse_hunk_ranges("no hunks here") == []
+
+    def test_single_line_hunk(self):
+        patch = "@@ -5,0 +5 @@\n+single line\n"
+        ranges = parse_hunk_ranges(patch)
+        assert ranges == [(5, 5)]
+
+
+class TestLineInHunks:
+    def test_line_inside_hunk(self):
+        assert line_in_hunks(3, [(1, 5)]) is True
+
+    def test_line_at_hunk_boundary(self):
+        assert line_in_hunks(1, [(1, 5)]) is True
+        assert line_in_hunks(5, [(1, 5)]) is True
+
+    def test_line_outside_hunk(self):
+        assert line_in_hunks(6, [(1, 5)]) is False
+        assert line_in_hunks(0, [(1, 5)]) is False
+
+    def test_line_in_second_hunk(self):
+        assert line_in_hunks(25, [(1, 5), (20, 30)]) is True
+
+    def test_empty_hunks(self):
+        assert line_in_hunks(1, []) is False
+
+
+class TestSarifToReviewWithHunks:
+    def test_finding_on_valid_hunk_line_becomes_inline(self):
+        sarif = _sarif([_finding(file="src/app.py", line=3, level="error")])
+        diff_hunks = {"src/app.py": [(1, 10)]}
+        review = sarif_to_review(sarif, diff_files={"src/app.py"}, diff_hunks=diff_hunks)
+
+        assert len(review.comments) == 1
+        assert review.comments[0].line == 3
+
+    def test_finding_outside_hunk_goes_to_summary(self):
+        sarif = _sarif([_finding(file="src/app.py", line=50, level="error")])
+        diff_hunks = {"src/app.py": [(1, 10)]}
+        review = sarif_to_review(sarif, diff_files={"src/app.py"}, diff_hunks=diff_hunks)
+
+        assert len(review.comments) == 0
+        assert len(review.outside_diff) == 1
+
+    def test_no_hunks_provided_falls_back_to_file_check(self):
+        sarif = _sarif([_finding(file="src/app.py", line=50, level="error")])
+        review = sarif_to_review(sarif, diff_files={"src/app.py"})
+
+        assert len(review.comments) == 1
+
+    def test_smart_comment_has_rule_and_action(self):
+        sarif = _sarif(
+            [
+                _finding(
+                    file="src/app.py",
+                    line=5,
+                    level="error",
+                    rule="sql-injection",
+                    msg="User input concatenated into SQL query",
+                )
+            ]
+        )
+        diff_hunks = {"src/app.py": [(1, 10)]}
+        review = sarif_to_review(sarif, diff_files={"src/app.py"}, diff_hunks=diff_hunks)
+
+        body = review.comments[0].body
+        assert "sql-injection" in body
+        assert "error" in body
+        assert "User input concatenated" in body
+
+    def test_smart_comment_includes_fix_hint_when_available(self):
+        sarif_data = _sarif(
+            [
+                {
+                    "ruleId": "hardcoded-secret",
+                    "level": "error",
+                    "message": {"text": "Hardcoded password detected"},
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "src/app.py"},
+                                "region": {"startLine": 5},
+                            }
+                        }
+                    ],
+                    "fixes": [
+                        {
+                            "description": {"text": "Use environment variable instead"},
+                        }
+                    ],
+                }
+            ]
+        )
+        diff_hunks = {"src/app.py": [(1, 10)]}
+        review = sarif_to_review(sarif_data, diff_files={"src/app.py"}, diff_hunks=diff_hunks)
+
+        body = review.comments[0].body
+        assert "environment variable" in body.lower()


### PR DESCRIPTION
## Summary
- Validates SARIF finding line numbers against actual PR diff hunk ranges before posting inline review comments — prevents GitHub from rejecting comments on lines not in the diff
- Findings on files in the diff but outside hunk ranges now go to the collapsed summary table instead of failing as inline comments
- Inline comments are now SMART: Specific rule ID with backtick severity, Measurable finding details, Actionable fix hints extracted from SARIF `fixes` array, Relevant context from the scanner message, Targeted to the exact diff line
- Adds `get_pr_diff_hunks()` for callers to fetch hunk data from the GitHub API
- Fully backward compatible — omitting `diff_hunks` preserves existing file-only behavior

## Test plan
- [x] `parse_hunk_ranges` — single hunk, multiple hunks, no hunks, single-line hunk
- [x] `line_in_hunks` — inside, boundary, outside, second hunk, empty
- [x] `sarif_to_review` with hunks — inline when in hunk, summary when outside hunk, fallback without hunks
- [x] SMART comment format — rule + severity + message present, fix hint included when SARIF has fixes
- [x] All 7 existing tests still pass (backward compat)

Closes #26