### PR TITLE
docs: enterprise and cloud architecture assessments

### DIFF
--- a/docs/architecture-cloud.md
+++ b/docs/architecture-cloud.md
@@ -1,0 +1,604 @@
+# Cloud SaaS Architecture Assessment
+
+Evaluation of eedom for cloud-native SaaS deployment.
+
+Based on: `ARCHITECTURE.md`, `src/eedom/core/config.py`, `src/eedom/core/pipeline.py`,
+`src/eedom/core/orchestrator.py`, `src/eedom/data/db.py`, `src/eedom/data/catalog.py`,
+`src/eedom/data/evidence.py`, `src/eedom/data/parquet_writer.py`, `Dockerfile`,
+`docker-compose.yml`, and `.github/workflows/`.
+
+---
+
+## 1. Current State vs. SaaS Requirements
+
+| SaaS Requirement | Current State | Gap |
+|-----------------|---------------|-----|
+| Webhook-driven execution | GitHub Action on self-hosted runner (`gatekeeper.yml`) | No HTTP listener, no GitHub App, no webhook receiver |
+| Queue-based async processing | `scan_queue` table exists (`002_package_catalog.sql`), no worker | Need worker process, dead-letter queue, retry |
+| Object storage for evidence | Local filesystem (`evidence.py:37`, `root_path: str`) | Need S3/GCS adapter |
+| Multi-tenant data isolation | Zero tenant awareness anywhere | Need tenant isolation at every layer |
+| REST API | CLI only (`cli/main.py`) | Need HTTP API surface |
+| Horizontal scaling | Single-process `ThreadPoolExecutor` (`orchestrator.py:50`) | Need distributed task execution |
+| Billing/metering | None | Need usage tracking per tenant |
+| Dashboard | Parquet file on disk (`parquet_writer.py`) | Need queryable analytics API |
+
+---
+
+## 2. GitHub App Webhook Model vs. Self-Hosted Runner
+
+### Current: Self-Hosted Runner
+
+The `gatekeeper.yml` workflow triggers on `pull_request` events matching dependency and source file paths. It runs on a `self-hosted` runner, checks out the repo, generates a diff, and executes eedom inline.
+
+**Limitations for SaaS:**
+- Requires customers to configure self-hosted runners
+- No centralized control plane
+- Each customer installation is independent
+- No shared scanning cache across customers
+
+### Target: GitHub App Webhook Model
+
+```
+[GitHub.com]
+    |
+    | installation webhook (pull_request.opened/synchronize)
+    v
+[API Gateway (ALB / Cloud Run)] --> [Webhook Handler]
+    |
+    | validate signature, extract metadata
+    v
+[Message Queue (SQS / Cloud Tasks)]
+    |
+    | fan out per repo
+    v
+[Scanner Workers (ECS Fargate / Cloud Run Jobs)]
+    |
+    | clone repo, run pipeline, write results
+    v
+[Results Writer]
+    |
+    +---> [Postgres (RDS / Cloud SQL)] -- decisions, catalog
+    +---> [Object Storage (S3 / GCS)] -- evidence bundles
+    +---> [GitHub API] -- PR comment, check run status
+```
+
+**GitHub App permissions needed:**
+- `contents: read` (clone repo)
+- `pull_requests: write` (post comments)
+- `checks: write` (create check runs with SARIF)
+- `statuses: write` (set commit status)
+
+**Webhook handler implementation:**
+
+| File | Purpose |
+|------|---------|
+| New: `src/eedom/api/webhook.py` | Receives `pull_request` events, validates `X-Hub-Signature-256`, extracts repo/PR metadata |
+| New: `src/eedom/api/github_app.py` | Manages installation tokens (JWT -> installation access token), repo cloning |
+| New: `src/eedom/api/queue_publisher.py` | Publishes scan jobs to SQS/Cloud Tasks |
+
+The existing `ReviewPipeline.evaluate()` (`pipeline.py:73`) remains unchanged -- the webhook handler is a new presentation-tier entry point alongside CLI and GATEKEEPER agent.
+
+---
+
+## 3. Serverless Scanning
+
+### Option A: AWS Lambda + ECS Fargate
+
+Lambda is unsuitable for eedom scanning due to:
+- 15-minute max execution time (pipeline timeout is 300s, but scanner binary startup + DB writes can exceed this under load)
+- 10 GB max container image size (eedom image with all binaries is ~2 GB, but Lambda cold starts with large images are 10-30 seconds)
+- 512 MB `/tmp` limit (Trivy DB alone is ~500 MB)
+- No persistent local storage for incremental code graph rebuilds (`blast-radius` plugin uses SQLite at `repo/.eedom/code_graph.sqlite`)
+
+**Recommended: ECS Fargate tasks** (AWS) or **Cloud Run Jobs** (GCP)
+
+```
+SQS Queue --> ECS Fargate Task (eedom container)
+                |
+                +-- Clone repo from GitHub (installation token)
+                +-- Run ReviewPipeline.evaluate() or registry.run_all()
+                +-- Write evidence to S3
+                +-- Write decisions to RDS
+                +-- Post PR comment via GitHub API
+                +-- Task exits (pay per second)
+```
+
+| AWS Service | Role | Config |
+|------------|------|--------|
+| SQS (Standard) | Scan job queue | Visibility timeout: 600s, DLQ after 3 failures |
+| ECS Fargate | Scanner execution | 4 vCPU, 8 GB RAM, 200 GB ephemeral storage |
+| RDS PostgreSQL | Decisions + catalog | db.r6g.large, Multi-AZ, pgvector extension |
+| S3 | Evidence storage | Bucket per tenant, SSE-S3 encryption, lifecycle policy |
+| ECR | Container registry | eedom image, immutable tags |
+| ALB | Webhook ingress | HTTPS termination, WAF for rate limiting |
+| Secrets Manager | GitHub App private key, DB credentials | Rotated every 90 days |
+| CloudWatch | Logging + metrics | structlog JSON -> CloudWatch Logs |
+
+### Option B: GCP Cloud Run + Cloud Tasks
+
+| GCP Service | Role | Config |
+|------------|------|--------|
+| Cloud Tasks | Scan job queue | Max dispatch rate: 500/s, retry with backoff |
+| Cloud Run Jobs | Scanner execution | 4 vCPU, 8 GiB RAM, 300s timeout |
+| Cloud SQL PostgreSQL | Decisions + catalog | db-custom-4-16384, HA, pgvector |
+| GCS | Evidence storage | Bucket per tenant, CMEK encryption |
+| Artifact Registry | Container registry | eedom image |
+| Cloud Load Balancing | Webhook ingress | HTTPS, Cloud Armor for WAF |
+| Secret Manager | GitHub App private key, DB credentials | Automatic rotation |
+| Cloud Logging | Logging | structlog JSON -> Cloud Logging |
+
+### Scanner Binary Considerations
+
+The current `Dockerfile` installs scanner binaries (Syft, Trivy, OSV-Scanner, OPA, Gitleaks) as static Go binaries. These work unchanged in Fargate/Cloud Run since the container image is the same. No repackaging needed.
+
+Trivy and OSV-Scanner need vulnerability database access:
+- **Trivy:** Use `TRIVY_DB_REPOSITORY` env var to point to an internal OCI registry mirror. In serverless, pre-warm the DB in a shared EFS/Filestore mount.
+- **OSV-Scanner:** API mode (default) requires outbound HTTPS. For isolated networks, use `--experimental-local-db`.
+
+---
+
+## 4. Object Storage for Evidence
+
+### Current: Local Filesystem
+
+`EvidenceStore` (`evidence.py:21`) writes to `Path(root_path) / key / artifact_name` using atomic temp-file + rename. The atomic rename guarantee relies on POSIX same-filesystem semantics.
+
+### Target: S3/GCS with Local Cache
+
+| File | Change |
+|------|--------|
+| New: `data/evidence_s3.py` | `S3EvidenceStore` implementing same interface as `EvidenceStore`. Uses `boto3` S3 PutObject with `ContentMD5` for integrity. |
+| New: `data/evidence_gcs.py` | `GCSEvidenceStore` using `google-cloud-storage`. |
+| `data/evidence.py` | Extract `EvidenceStoreProtocol` from current implementation. Add factory: `create_evidence_store(config) -> EvidenceStoreProtocol` |
+| `core/config.py` | Add `evidence_backend: str = "filesystem"` (filesystem/s3/gcs), `evidence_bucket: str | None`, `evidence_prefix: str = ""` |
+| `core/pipeline.py` | No change -- already uses `EvidenceStore` through constructor injection |
+
+**S3 layout per tenant:**
+
+```
+s3://eedom-evidence-{region}/
+  {tenant_id}/
+    {short_sha}/{YYYYMMDDHHmm}/
+      {package_name}/
+        decision.json
+        memo.md
+      seal.json
+    decisions/
+      year=2026/month=04/
+        decisions-{run_id}.parquet
+```
+
+**Seal chain adaptation:** `create_seal()` (`core/seal.py`) currently walks the local filesystem. For S3, the seal must be computed locally from the objects being uploaded, then the seal itself uploaded. `find_previous_seal_hash()` needs an S3 list + download of the most recent `seal.json`.
+
+---
+
+## 5. Queue-Based Processing
+
+### Architecture
+
+```
+Webhook Handler
+    |
+    v
+[Scan Job Queue]  <-- SQS Standard / Cloud Tasks
+    |
+    | Message: { tenant_id, repo, pr_number, commit_sha, installation_id }
+    v
+[Scanner Worker Pool]  <-- ECS Fargate / Cloud Run Jobs
+    |
+    | 1. Acquire GitHub installation token
+    | 2. Clone repo (shallow, specific SHA)
+    | 3. Check PackageCatalog for cached results
+    | 4. Run ScanOrchestrator for uncached packages
+    | 5. Update PackageCatalog
+    | 6. Run OPA policy evaluation
+    | 7. Write evidence to S3
+    | 8. Write decision to RDS
+    | 9. Post PR comment
+    v
+[Dead Letter Queue]  <-- failures after 3 retries
+    |
+    v
+[DLQ Processor]  <-- alert + create incident
+```
+
+### Idempotency
+
+The pipeline must be idempotent -- the same webhook delivered twice should not produce duplicate PR comments or corrupt evidence.
+
+**Current idempotency gaps:**
+- `db.py:save_request()` does a blind INSERT. Re-processing the same PR event creates duplicate rows.
+- `evidence.py:store()` overwrites existing files (atomic rename). This is accidentally idempotent.
+- `parquet_writer.py:append_decisions()` appends without dedup. Re-processing creates duplicate rows.
+- PR comment posting in `gatekeeper.yml` does check for an existing comment marker (`<!-- eedom-review -->`) and updates it -- this is idempotent.
+
+**Fixes needed:**
+
+| File | Change |
+|------|--------|
+| `data/db.py` | Change `save_request()` to `INSERT ... ON CONFLICT (request_id) DO NOTHING` |
+| `data/parquet_writer.py` | Add `run_id` dedup: skip append if `run_id` already exists in the file |
+| New: `core/idempotency.py` | Idempotency key = `sha256(tenant_id + repo + pr_number + head_sha)`. Check before processing. |
+
+### Dead Letter Queue
+
+Messages that fail 3 times go to DLQ. A DLQ processor:
+1. Logs the failure with full context
+2. Creates an internal incident
+3. Posts a "scan failed" comment on the PR so the developer knows
+4. Fires a webhook to the tenant's configured alerting endpoint
+
+---
+
+## 6. Multi-Region
+
+### Data Residency
+
+| Data Type | Residency Requirement | Storage |
+|-----------|----------------------|---------|
+| Source code (cloned repos) | Ephemeral, never persisted | Worker ephemeral storage, deleted after scan |
+| Evidence bundles | Must stay in tenant's chosen region | S3/GCS bucket per region |
+| Decisions + catalog | Must stay in tenant's chosen region | RDS/Cloud SQL per region |
+| Parquet audit logs | Must stay in tenant's chosen region | S3/GCS per region |
+
+### Multi-Region Architecture
+
+```
+                    [Global API Gateway]
+                    (Route53 / Cloud DNS)
+                         |
+              +----------+----------+
+              |                     |
+        [us-east-1]           [eu-west-1]
+              |                     |
+    +----+----+----+      +----+----+----+
+    |    |         |      |    |         |
+   ALB  SQS   RDS(primary)  ALB  SQS   RDS(primary)
+    |    |         |      |    |         |
+  Fargate Workers  S3   Fargate Workers  GCS
+```
+
+Each region is a fully independent deployment. No cross-region data flow. Tenant signup assigns a home region. The global API gateway routes webhooks to the correct region based on tenant mapping.
+
+**Postgres cross-region:** Do NOT use cross-region replication for tenant data. Each region has its own RDS instance. The `package_catalog` table can be replicated read-only across regions since vulnerability data is not tenant-specific.
+
+---
+
+## 7. Billing and Metering
+
+### Usage Dimensions
+
+| Dimension | Source | Metering Point |
+|-----------|--------|---------------|
+| Repos scanned | Webhook handler | Count unique `repo` per billing period |
+| Scans executed | Worker completion | Count `scan_queue.status = 'completed'` per tenant |
+| Plugins used per scan | `PluginResult` list length | Sum of active plugins across all scans |
+| Evidence storage (GB) | S3/GCS bucket metrics | Per-tenant bucket size |
+| Seats (users with access) | Auth system | Count unique `user_id` per tenant |
+
+### Implementation
+
+| File | Change |
+|------|--------|
+| New: `data/metering.py` | `MeteringClient` that records events to a metering backend (Stripe Billing, Lago, or custom) |
+| New: `migrations/006_metering.sql` | `usage_events` table: `(tenant_id, event_type, quantity, timestamp)` |
+| `core/pipeline.py` | After pipeline completes, emit `scan_completed` metering event |
+| Worker | Emit `repo_scanned` event on each webhook processed |
+
+**Billing tiers:**
+
+| Tier | Repos | Scans/month | Evidence retention | Price signal |
+|------|-------|-------------|-------------------|-------------|
+| Free | 3 | 100 | 7 days | $0 |
+| Team | 25 | 2,500 | 90 days | Low |
+| Business | 100 | 25,000 | 1 year | Medium |
+| Enterprise | Unlimited | Unlimited | Custom | Custom |
+
+Evidence retention is enforced via S3 lifecycle policies per tenant. `EedomSettings` gains `evidence_retention_days: int = 90`.
+
+---
+
+## 8. Tenant Isolation for Code Scanning
+
+### Threat Model
+
+Eedom clones and scans customer source code. A SaaS deployment must guarantee:
+1. No cross-tenant code access
+2. Scanned code is ephemeral (deleted after scan)
+3. Scanner plugins cannot exfiltrate code to external endpoints
+4. Workers cannot access other tenants' evidence or database rows
+
+### Isolation Strategy
+
+**Compute isolation:** Each scan runs in its own Fargate task or Cloud Run job. No shared filesystem between tasks. Ephemeral storage is destroyed when the task exits.
+
+**Network isolation:** Workers run in a private subnet with:
+- Egress only to: GitHub API (for cloning + PR comments), PyPI API (for metadata), vulnerability databases (Trivy/OSV), internal RDS, internal S3
+- No egress to arbitrary internet endpoints
+- Network policy / security group enforces the allowlist
+- Semgrep plugin must NOT phone home to Semgrep servers (use `--metrics=off`)
+
+**Data isolation:**
+- RLS on all database tables (see enterprise doc Section 2)
+- S3 bucket policy restricts each worker's IAM role to the current tenant's prefix
+- Workers receive a short-lived IAM role scoped to one tenant via STS AssumeRole
+
+**Code lifecycle:**
+
+```
+1. Worker starts
+2. Clone repo to ephemeral storage (--depth=1 --single-branch)
+3. Run pipeline
+4. Write evidence to tenant's S3 prefix
+5. Delete clone from ephemeral storage
+6. Worker exits, ephemeral storage destroyed
+```
+
+The current `orchestrator.py` uses `ThreadPoolExecutor` to run scanners in parallel within a single process. In the SaaS model, this is fine -- the scanner binaries operate on a local clone that exists only in the worker's ephemeral storage.
+
+---
+
+## 9. REST API Surface
+
+### Endpoints
+
+| Method | Path | Purpose | Auth |
+|--------|------|---------|------|
+| POST | `/webhooks/github` | Receive GitHub App webhooks | HMAC signature |
+| GET | `/api/v1/repos` | List repos for tenant | Bearer token |
+| GET | `/api/v1/repos/{repo}/decisions` | List decisions for a repo | Bearer token |
+| GET | `/api/v1/repos/{repo}/decisions/{id}` | Get decision detail | Bearer token |
+| GET | `/api/v1/catalog` | Search package catalog | Bearer token |
+| GET | `/api/v1/catalog/{ecosystem}/{name}/{version}` | Package detail | Bearer token |
+| POST | `/api/v1/repos/{repo}/scan` | Trigger manual scan | Bearer token |
+| GET | `/api/v1/policies` | List org policies | Bearer token (admin) |
+| PUT | `/api/v1/policies/{id}` | Update policy | Bearer token (admin) |
+| POST | `/api/v1/bypasses` | Create verdict override | Bearer token (approver) |
+| GET | `/api/v1/usage` | Billing usage for tenant | Bearer token |
+| GET | `/api/v1/health` | Health check | None |
+
+### Implementation
+
+| File | Purpose |
+|------|---------|
+| New: `src/eedom/api/app.py` | FastAPI application, middleware (auth, tenant context, CORS) |
+| New: `src/eedom/api/routes/webhooks.py` | GitHub webhook handler |
+| New: `src/eedom/api/routes/decisions.py` | Decision CRUD endpoints |
+| New: `src/eedom/api/routes/catalog.py` | Catalog search + detail |
+| New: `src/eedom/api/routes/policies.py` | Policy management |
+| New: `src/eedom/api/routes/bypasses.py` | Verdict override endpoint |
+| New: `src/eedom/api/routes/usage.py` | Metering data |
+| New: `src/eedom/api/auth.py` | JWT validation, tenant extraction |
+
+The API is a third presentation-tier entry point alongside `cli/` and `agent/`. It delegates to the same `core/` logic -- no business rules in the API layer.
+
+---
+
+## 10. Dashboard Data
+
+### Analytics Backend
+
+The current `decisions.parquet` file is designed for DuckDB analytics. For SaaS, this becomes a data lake:
+
+```
+s3://eedom-analytics-{region}/
+  {tenant_id}/
+    decisions/
+      year=2026/month=04/day=24/
+        decisions-{run_id}.parquet
+```
+
+**Query engine options:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| DuckDB (in-process) | Zero infrastructure, fast on small data | Single-node, no concurrent queries at scale |
+| Amazon Athena | Serverless, scales to PB | Cold start 2-5s, per-query cost |
+| BigQuery | Serverless, fast, columnar | GCP-only |
+| ClickHouse Cloud | Real-time analytics, fast dashboards | Additional infrastructure |
+
+**Recommendation:** Start with Athena/BigQuery for the analytics backend. The Parquet schema in `parquet_writer.py:26-56` is already optimized for columnar queries.
+
+### Dashboard Queries
+
+| Dashboard Widget | Query Pattern |
+|-----------------|---------------|
+| Decision trend (approve/reject/needs_review over time) | `GROUP BY date_trunc('day', timestamp), decision` |
+| Top vulnerable packages | `GROUP BY package_name ORDER BY SUM(vuln_critical + vuln_high) DESC` |
+| Mean pipeline duration | `AVG(pipeline_duration_seconds) GROUP BY date_trunc('hour', timestamp)` |
+| Policy violation rate | `COUNT(*) FILTER (WHERE decision = 'reject') / COUNT(*)` |
+| Scanner reliability | `UNNEST(scanner_names, scanner_statuses) GROUP BY tool, status` |
+| Triggered rules heatmap | `UNNEST(triggered_rules) GROUP BY rule, date_trunc('week', timestamp)` |
+
+All of these work directly against the existing Parquet schema with zero schema changes.
+
+---
+
+## 11. Service Decomposition
+
+### What Becomes a Microservice
+
+| Service | Current Location | Why Split |
+|---------|-----------------|-----------|
+| **Webhook Ingress** | N/A (new) | Must handle bursty traffic independently; scale to 0 when idle |
+| **Scanner Worker** | `core/pipeline.py` + `core/orchestrator.py` | CPU/memory intensive; scales independently; runs in ephemeral compute |
+| **API Server** | N/A (new) | Serves dashboard + REST API; always-on; different scaling profile than workers |
+| **Policy Engine** | `core/policy.py` (OPA subprocess) | Deploy OPA as HTTP service; shared across all workers; policy hot-reload |
+
+### What Stays Monolithic (Shared Library)
+
+| Component | Current Location | Why Keep Together |
+|-----------|-----------------|-------------------|
+| **Core logic** | `core/models.py`, `core/normalizer.py`, `core/decision.py`, `core/memo.py`, `core/seal.py` | Pure functions with no I/O; shared by all services as a library |
+| **Plugin system** | `core/plugin.py`, `core/registry.py`, `plugins/` | Tightly coupled to scanner execution; splitting adds IPC overhead with no benefit |
+| **Data layer** | `data/db.py`, `data/catalog.py`, `data/evidence.py` | Shared repository pattern; each service imports what it needs |
+| **Renderer** | `core/renderer.py`, `core/sarif.py`, `templates/` | Pure rendering functions; no state |
+
+### Service Architecture
+
+```
+                        [GitHub]
+                           |
+                           v
++--[Webhook Ingress]--+  (Cloud Run / ALB + Lambda)
+|  - Validate webhook  |
+|  - Extract metadata   |
+|  - Publish to queue   |
++-----------+-----------+
+            |
+            v
++--[Scan Queue]--------+  (SQS / Cloud Tasks)
+|  - Priority ordering  |
+|  - DLQ after 3 retries|
++-----------+-----------+
+            |
+            v
++--[Scanner Worker]----+  (ECS Fargate / Cloud Run Jobs)
+|  - Clone repo         |
+|  - Run pipeline       |  Uses: core/*, data/*, plugins/*
+|  - Write evidence     |
+|  - Post PR comment    |
++-----------+-----------+
+            |
+            v
++--[Postgres]-----------+  (RDS / Cloud SQL)
+|  - Decisions           |
+|  - Catalog             |
+|  - Scan queue          |
+|  - RBAC                |
++------------------------+
+            |
++--[Object Storage]-----+  (S3 / GCS)
+|  - Evidence bundles    |
+|  - Parquet audit logs  |
++------------------------+
+
++--[API Server]---------+  (ECS Service / Cloud Run)
+|  - REST API            |  Uses: core/*, data/*
+|  - Dashboard data      |
+|  - Policy management   |
+|  - Bypass workflow     |
++------------------------+
+
++--[OPA Service]--------+  (Sidecar or standalone)
+|  - Policy evaluation   |
+|  - Bundle server       |
+|  - Hot reload          |
++------------------------+
+```
+
+### Shared Library: `eedom-core`
+
+The `src/eedom/core/` and `src/eedom/data/` packages become a shared Python library installed in every service's container. The `pyproject.toml` already defines eedom as an installable package. Each service imports what it needs:
+
+```python
+# Webhook Ingress
+from eedom.api.webhook import handle_github_event
+
+# Scanner Worker
+from eedom.core.pipeline import ReviewPipeline
+from eedom.core.orchestrator import ScanOrchestrator
+
+# API Server
+from eedom.data.db import DecisionRepository
+from eedom.data.catalog import PackageCatalog
+```
+
+No code duplication. Services share the library; they differ only in their entry point and scaling profile.
+
+---
+
+## 12. Phased Migration Path
+
+### Phase 1: API + Webhook (Weeks 1-6)
+
+**Goal:** GitHub App receiving webhooks, scan jobs enqueued, existing pipeline runs as worker.
+
+| Task | Files | AWS/GCP Service | Effort |
+|------|-------|-----------------|--------|
+| GitHub App registration | GitHub Developer Settings | N/A | 1 day |
+| Webhook handler (FastAPI) | New: `src/eedom/api/webhook.py`, `src/eedom/api/github_app.py` | ALB + Fargate / Cloud Run | 5 days |
+| Queue publisher | New: `src/eedom/api/queue_publisher.py` | SQS / Cloud Tasks | 2 days |
+| Scanner worker (pulls from queue, runs pipeline) | New: `src/eedom/worker/main.py` | ECS Fargate / Cloud Run Jobs | 5 days |
+| S3 evidence store | New: `data/evidence_s3.py` | S3 / GCS | 3 days |
+| Evidence store factory + config | `data/evidence.py`, `core/config.py` | N/A | 2 days |
+| RDS/Cloud SQL setup | Infrastructure (Terraform/Pulumi) | RDS Multi-AZ / Cloud SQL HA | 3 days |
+| Idempotency layer | New: `core/idempotency.py`, changes in `data/db.py` | N/A | 3 days |
+| DLQ + alerting | Infrastructure | SQS DLQ + CloudWatch Alarm / Cloud Monitoring | 2 days |
+
+### Phase 2: Multi-Tenancy + API (Weeks 7-12)
+
+**Goal:** Tenant isolation, REST API for external consumption, basic dashboard data.
+
+| Task | Files | AWS/GCP Service | Effort |
+|------|-------|-----------------|--------|
+| Tenant data model + RLS | `migrations/003_multi_tenancy.sql` | N/A | 3 days |
+| Auth middleware (JWT + tenant) | New: `src/eedom/api/auth.py` | Cognito / Firebase Auth | 5 days |
+| REST API routes | New: `src/eedom/api/routes/*.py` | N/A | 8 days |
+| API server deployment | `src/eedom/api/app.py` | ECS Service / Cloud Run | 3 days |
+| Partitioned Parquet writes to S3 | `data/parquet_writer.py` | S3 / GCS | 2 days |
+| Analytics query layer | New: `src/eedom/api/analytics.py` | Athena / BigQuery | 3 days |
+| Network isolation (VPC/security groups) | Infrastructure | VPC + NACLs + SGs | 3 days |
+| IAM role per tenant (STS scoping) | Infrastructure | IAM + STS | 3 days |
+
+### Phase 3: Scale + Billing (Weeks 13-18)
+
+**Goal:** Auto-scaling, metering, billing integration, multi-region foundation.
+
+| Task | Files | AWS/GCP Service | Effort |
+|------|-------|-----------------|--------|
+| Auto-scaling worker pool | Infrastructure | ECS Auto Scaling / Cloud Run concurrency | 3 days |
+| OPA as HTTP service | `core/policy.py` refactor | ECS sidecar / Cloud Run | 3 days |
+| Metering system | New: `data/metering.py`, `migrations/006_metering.sql` | N/A | 5 days |
+| Stripe/billing integration | New: `src/eedom/api/billing.py` | Stripe API | 5 days |
+| Usage dashboards | New: API + frontend | N/A | 8 days |
+| Second region deployment | Infrastructure duplication | Full stack in eu-west-1 / europe-west1 | 5 days |
+| Global DNS routing | Infrastructure | Route53 / Cloud DNS | 2 days |
+| Load testing (1000 concurrent scans) | New: `tests/load/` | N/A | 5 days |
+
+### Phase 4: Polish + Enterprise Features (Weeks 19-24)
+
+**Goal:** SSO, policy management UI, advanced analytics, SOC 2 readiness.
+
+| Task | Files | Effort |
+|------|-------|--------|
+| SAML/OIDC SSO | New: `src/eedom/auth/` | 8 days |
+| Policy management UI | Frontend + API routes | 10 days |
+| RBAC for verdict overrides | `core/authz.py`, `data/db.py` | 5 days |
+| Advanced analytics (trend detection, anomaly alerts) | Analytics layer | 8 days |
+| SOC 2 Type II evidence collection | Ops + docs | 10 days |
+| Penetration testing (cross-tenant isolation) | External engagement | 5 days |
+| Public documentation + API docs (OpenAPI) | Docs | 5 days |
+
+---
+
+## 13. Cost Estimation (AWS, 100 Tenants)
+
+| Component | Service | Monthly Cost Estimate |
+|-----------|---------|----------------------|
+| Webhook ingress | ALB + Fargate (0.25 vCPU, 0.5 GB, always-on) | $15 |
+| Scanner workers | Fargate Spot (4 vCPU, 8 GB, ~5000 tasks/month x 3 min avg) | $250 |
+| Database | RDS db.r6g.large Multi-AZ (2 vCPU, 16 GB) | $400 |
+| Evidence storage | S3 Standard (estimated 500 GB, 100K PUTs) | $15 |
+| Queue | SQS (5000 messages/month) | $1 |
+| Container registry | ECR (5 GB) | $1 |
+| Secrets | Secrets Manager (10 secrets) | $5 |
+| Logging | CloudWatch Logs (50 GB/month) | $25 |
+| DNS + SSL | Route53 + ACM | $5 |
+| **Total** | | **~$720/month** |
+
+At 1000 tenants with proportional scaling: ~$3,500/month (workers scale sub-linearly due to catalog cache hits).
+
+---
+
+## 14. Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| GitHub App token compromise exposes customer repos | Critical | Short-lived installation tokens (1 hour), minimal permissions, token never stored |
+| Cross-tenant data leak via RLS bypass | Critical | Automated RLS tests, penetration testing, separate DB option for regulated tenants |
+| Scanner worker exfiltrates source code | High | VPC egress allowlist, no internet access except approved endpoints |
+| Parquet corruption during concurrent S3 writes | High | One Parquet file per run (no append), idempotency keys |
+| Trivy/OSV DB staleness in serverless (cold cache) | Medium | Pre-warm DB on shared EFS/Filestore, refresh every 6 hours |
+| Webhook flood (DDoS via forged webhooks) | Medium | HMAC signature validation, rate limiting at ALB/WAF |
+| Cost runaway from large monorepo scans | Medium | Per-scan timeout enforcement (already 300s), per-tenant monthly scan cap |

--- a/docs/architecture-enterprise.md
+++ b/docs/architecture-enterprise.md
@@ -1,0 +1,472 @@
+# Enterprise Architecture Assessment
+
+Evaluation of eedom for self-hosted, business, and enterprise deployment models.
+
+Based on: `ARCHITECTURE.md`, `src/eedom/core/config.py`, `src/eedom/core/pipeline.py`,
+`src/eedom/data/db.py`, `src/eedom/data/catalog.py`, `src/eedom/data/evidence.py`,
+`Dockerfile`, `docker-compose.yml`, `.github/workflows/`, and `migrations/`.
+
+---
+
+## 1. Current State Summary
+
+Eedom is a single-tenant CLI tool designed for individual repo scanning. Key observations:
+
+- **Single Postgres database** with a connection pool (`min_size=1, max_size=10`) in `data/db.py:85`. No tenant isolation at any layer.
+- **File-based evidence** written to a local `./evidence` directory (`core/config.py:62`). No object storage integration.
+- **Flat configuration** via `EEDOM_*` environment variables in `EedomSettings` (`core/config.py:41`). No per-tenant or per-repo config hierarchy.
+- **Synchronous pipeline** executed inline by the CLI or GitHub Action (`core/pipeline.py:73`). No queue-based async processing.
+- **Single container image** (`Dockerfile`) packages all 15 plugins, all scanner binaries, and the full Python stack into one image. No service decomposition.
+- **docker-compose.yml** defines only a single Postgres instance. No Redis, no queue broker, no separate workers.
+- **Scan queue table** exists (`migrations/002_package_catalog.sql:85`) but has no worker implementation pulling from it.
+- **GATEKEEPER workflow** (`gatekeeper.yml`) runs on `self-hosted` runners and executes scanning synchronously within the workflow job.
+
+---
+
+## 2. Multi-Tenancy
+
+### Current: Zero Isolation
+
+All tables in `migrations/001_initial_schema.sql` and `002_package_catalog.sql` are flat. No `tenant_id` column exists on any table. `DecisionRepository` (`data/db.py:66`) connects to a single DSN with a single pool. `PackageCatalog` (`data/catalog.py:78`) shares the entire `package_catalog` table across all queries.
+
+### Option A: Postgres Row-Level Security (RLS)
+
+Add a `tenant_id UUID NOT NULL` column to every table. Apply RLS policies that filter rows based on `current_setting('app.tenant_id')`.
+
+**Changes required:**
+
+| File | Change |
+|------|--------|
+| `migrations/003_multi_tenancy.sql` | New migration: add `tenant_id` to all tables, create RLS policies, add composite indexes |
+| `data/db.py` | Set `app.tenant_id` via `SET LOCAL` after acquiring connection (alongside existing `SET LOCAL statement_timeout` at line 106) |
+| `data/catalog.py` | Same `SET LOCAL` pattern needed in every method |
+| `core/config.py` | Add `tenant_id: str` field to `EedomSettings` |
+| `core/pipeline.py` | Pass tenant context through to DB layer |
+
+**Pros:** Single database, simpler ops, shared `package_catalog` benefits all tenants.
+**Cons:** One bad migration can expose cross-tenant data. RLS performance degrades on large tables without proper indexing. pgvector HNSW index (`idx_catalog_embedding`) is global and cannot be partitioned by tenant.
+
+**Recommendation:** RLS is viable for up to ~50 tenants sharing one Postgres instance. Beyond that, query planning overhead on the `package_catalog` table (which has a global HNSW index) becomes a bottleneck.
+
+### Option B: Separate Database Per Tenant
+
+Each tenant gets its own Postgres database (or schema). `DecisionRepository.__init__` already accepts a `dsn` parameter -- a tenant router resolves `tenant_id` to the correct DSN.
+
+**Changes required:**
+
+| File | Change |
+|------|--------|
+| New: `data/tenant_router.py` | Maps `tenant_id -> dsn`. Could be backed by a control-plane DB or config file |
+| `data/db.py` | Accept DSN from router instead of `EedomSettings.db_dsn` |
+| `data/catalog.py` | Loses cross-tenant package sharing (each tenant has its own catalog) |
+| `Dockerfile` | No change -- routing is runtime config |
+
+**Pros:** Hard isolation, simpler security audit, each tenant can be on a different Postgres version.
+**Cons:** Loses the shared `package_catalog` -- the same package is scanned N times across N tenants. Ops complexity grows linearly with tenant count.
+
+**Recommendation:** Separate DBs for regulated customers (FedRAMP, financial services). RLS for the general multi-tenant case.
+
+---
+
+## 3. Scalability
+
+### What Breaks at 100 Repos
+
+| Bottleneck | Location | Symptom |
+|-----------|----------|---------|
+| Connection pool exhaustion | `db.py:85` — `max_size=10` | Concurrent pipelines block waiting for connections |
+| Parquet append contention | `parquet_writer.py:122-128` — read-entire-file + write | Two concurrent runs on the same evidence root corrupt the file |
+| Evidence directory growth | `evidence.py` — one dir per `<sha>/<timestamp>` | 100 repos x 10 PRs/day = 1000 dirs/day, inode exhaustion on ext4 |
+| Scanner binary contention | `orchestrator.py:50` — ThreadPoolExecutor per run | 100 concurrent runs x 4 scanners = 400 threads per node |
+| Single OPA subprocess | `core/policy.py` — `subprocess.run()` per evaluation | OPA cold-starts are ~200ms each; 100 concurrent evals = serial bottleneck |
+
+### What Breaks at 1000 Repos
+
+All of the above, plus:
+- The `package_catalog` table becomes the hot path. `vuln_scanned_at` expiry checks (`catalog.py:48-64`) run per-request without caching.
+- `scan_queue` table (`002_package_catalog.sql:85`) has no worker implementation. At 1000 repos, you cannot rely on synchronous scanning per PR.
+- `decisions.parquet` becomes a single multi-GB file that must be fully read on every append (`parquet_writer.py:123`).
+- HNSW index rebuild on `description_embedding` blocks writes during vacuum.
+
+### Distributed Scanning via scan_queue
+
+The schema is already there:
+
+```sql
+-- migrations/002_package_catalog.sql:85
+CREATE TABLE IF NOT EXISTS scan_queue (
+    queue_id UUID PRIMARY KEY,
+    scan_type TEXT CHECK (scan_type IN ('full', 'vuln_only', 'rescan')),
+    priority INTEGER NOT NULL DEFAULT 0,
+    status TEXT CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    ...
+);
+```
+
+And `PackageCatalog.queue_scan()` (`catalog.py:289`) already inserts into it. What is missing:
+
+| Missing piece | What to build |
+|--------------|---------------|
+| Worker process | New `src/eedom/worker/scanner_worker.py` that polls `scan_queue WHERE status='pending' ORDER BY priority DESC, created_at ASC` with `SELECT ... FOR UPDATE SKIP LOCKED` |
+| Result writer | Worker runs `ScanOrchestrator.run()` then calls `catalog.upsert()` with findings |
+| Status callback | Worker updates `scan_queue.status` to `completed`/`failed` and sets `completed_at` |
+| Pipeline integration | `ReviewPipeline.evaluate()` checks catalog freshness before running scanners. If fresh, skip scanners and use cached findings |
+| Heartbeat | Worker sets `started_at` on pickup; a reaper marks stale `processing` rows as `failed` after 10 minutes |
+
+This converts eedom from "scan per PR" to "scan per unique package version, cache results." At 1000 repos, most PRs hit the cache and complete in <1 second instead of 60-180 seconds.
+
+### Parquet Partitioning
+
+Replace the single `decisions.parquet` with partitioned writes:
+
+```
+evidence/
+  decisions/
+    year=2026/month=04/
+      decisions-20260424T1430.parquet   # one file per run
+```
+
+**Change in `parquet_writer.py`:** Instead of read-all + append + write-all, write a new Parquet file per run into a partitioned directory. DuckDB queries work identically with `read_parquet('evidence/decisions/**/*.parquet')`.
+
+---
+
+## 4. High Availability
+
+### Current: Single Points of Failure
+
+| Component | SPOF | Impact |
+|-----------|------|--------|
+| Postgres | Single instance in `docker-compose.yml` | All persistence lost; pipeline falls back to `NullRepository` (fail-open) |
+| Evidence directory | Local filesystem | If the node dies, evidence for in-flight runs is lost |
+| Self-hosted runner | Single runner in `gatekeeper.yml` | PRs queue up until the runner recovers |
+| OPA binary | Local subprocess | Policy evaluations degrade to `needs_review` (fail-open) |
+
+### HA Architecture
+
+**Postgres:** Deploy a streaming replication cluster (Patroni + etcd, or AWS RDS Multi-AZ). `db.py` already uses psycopg3 connection pooling -- point the DSN at a PgBouncer or HAProxy that routes to the current primary. Read replicas can serve `PackageCatalog.lookup()` and `search_semantic()`.
+
+**Evidence storage:** Move from local filesystem to a shared filesystem (NFS/EFS) or object storage (S3/GCS). `EvidenceStore` (`evidence.py:37`) takes a `root_path` string -- pointing this at an NFS mount requires zero code changes. Object storage requires a new `ObjectEvidenceStore` implementation behind `EvidenceStoreProtocol`.
+
+**Runners:** Use a runner pool (3+ self-hosted runners with the same label). The `gatekeeper.yml` workflow already uses `runs-on: self-hosted` -- adding more runners with that label provides automatic HA.
+
+**OPA:** Deploy OPA as a sidecar or daemon (HTTP mode). Replace `subprocess.run()` calls in `core/policy.py` with HTTP POST to `localhost:8181/v1/data/policy`. Eliminates cold-start latency and supports warm standby.
+
+---
+
+## 5. Centralized Policy Management
+
+### Current State
+
+OPA policies live in `policies/policy.rego` and are baked into the container image (`Dockerfile` line 204: `COPY --from=builder /opt/eedom/policies/ /opt/eedom/policies/`). The `opa_policy_path` config (`config.py:72`) defaults to `./policies`.
+
+Per-repo configuration uses `.eagle-eyed-dom.yaml` for plugin enable/disable and thresholds (`core/repo_config.py`). There is no centralized policy hierarchy.
+
+### Enterprise Policy Hierarchy
+
+```
+org-level policy (enforced, cannot be overridden)
+  |
+  v
+team-level policy (can relax org defaults for specific teams)
+  |
+  v
+repo-level policy (.eagle-eyed-dom.yaml — can relax team defaults)
+```
+
+**Implementation:**
+
+| File | Change |
+|------|--------|
+| New: `migrations/003_policy_management.sql` | `org_policies` table: `(org_id, policy_rego TEXT, forbidden_licenses JSONB, min_package_age_days INT, ...)` |
+| New: `core/policy_hierarchy.py` | Merge logic: org policy sets floor, team/repo can only relax within bounds |
+| `core/policy.py` | `OpaEvaluator` fetches merged policy from DB instead of reading from filesystem |
+| `core/config.py` | Add `org_id: str | None` and `team_id: str | None` to `EedomSettings` |
+| `core/repo_config.py` | `load_repo_config()` merges repo-level YAML with DB-backed team/org policy |
+
+**OPA bundle server:** For large deployments, run an OPA bundle server that distributes policy bundles. Each eedom instance pulls its merged policy bundle at startup and on a polling interval. This eliminates the need to bake policies into the container image.
+
+---
+
+## 6. RBAC for Verdict Overrides
+
+### Current State
+
+The `bypass_records` table (`migrations/001_initial_schema.sql:66`) stores overrides with `invoked_by` and `reason` fields. `DecisionRepository.save_bypass()` (`db.py:370`) writes these records. There is no authorization check -- anyone who can call the CLI can bypass.
+
+### RBAC Model
+
+```
+Role: viewer    — read decisions, evidence
+Role: operator  — run scans, view results
+Role: approver  — override verdicts (reject -> approve)
+Role: admin     — manage policies, manage users, all of the above
+```
+
+**Implementation:**
+
+| File | Change |
+|------|--------|
+| New: `migrations/003_rbac.sql` | `roles`, `user_roles`, `role_permissions` tables |
+| New: `core/authz.py` | `check_permission(user_id, action, resource)` -- called before `save_bypass()`, policy writes |
+| `data/db.py` | `save_bypass()` calls `check_permission(invoked_by, 'verdict.override', request_id)` |
+| `core/config.py` | Add `auth_provider: str` (local, OIDC, SAML) |
+| New: `src/eedom/auth/` | OIDC/SAML adapter for SSO integration |
+
+**Audit trail:** Every bypass already creates a `bypass_records` row. Add `approved_by`, `approval_chain` (for multi-party approval), and `expires_at` (time-boxed overrides).
+
+---
+
+## 7. Compliance
+
+### SOC 2
+
+| Control | Current Status | Gap |
+|---------|---------------|-----|
+| CC6.1 — Access control | No RBAC | Need auth + RBAC (Section 6) |
+| CC6.2 — Logical access | CLI trusts caller identity | Need OIDC/SAML SSO |
+| CC7.1 — System monitoring | structlog everywhere | Need centralized log aggregation (ELK/Datadog) |
+| CC7.2 — Anomaly detection | None | Need alerting on bypass frequency, policy override patterns |
+| CC8.1 — Change management | Release Please workflow | Need approval gates on policy changes |
+| A1.1 — Availability | Single instance | Need HA (Section 4) |
+
+**Evidence chain** is strong: SHA-256 sealed evidence bundles (`core/seal.py`) with append-only Parquet audit log (`data/parquet_writer.py`). The `verify_seal()` function can detect tampering. This directly supports SOC 2 CC8.1 change management controls.
+
+### ISO 27001
+
+Annex A controls requiring attention:
+
+| Control | Gap |
+|---------|-----|
+| A.5.15 — Access control | No RBAC |
+| A.8.9 — Configuration management | Policies in files, not centrally managed |
+| A.8.15 — Logging | structlog present but not centrally aggregated |
+| A.8.24 — Cryptography | Evidence seals use SHA-256; consider adding HMAC with a key management service for non-repudiation |
+
+### FedRAMP
+
+FedRAMP requires:
+
+| Requirement | Current | Required Change |
+|-------------|---------|-----------------|
+| FIPS 140-2 crypto | SHA-256 (compliant algorithm) | Must use FIPS-validated module (OpenSSL FIPS provider) |
+| Boundary definition | None | Document system boundary, all data flows |
+| Continuous monitoring | None | Deploy to FedRAMP-authorized infrastructure (AWS GovCloud, Azure Gov) |
+| Air-gapped operation | Container image downloads binaries at build time | Pre-build and sign images in a connected environment, transfer to air-gapped |
+| Data residency | Evidence on local filesystem | Must stay within authorization boundary |
+
+**Air-gapped deployment considerations:**
+
+The `Dockerfile` downloads scanner binaries from GitHub at build time. In an air-gapped environment:
+1. Build the image in a connected staging environment
+2. Export with `podman save eedom:latest > eedom.tar`
+3. Transfer to air-gapped network
+4. Load with `podman load < eedom.tar`
+5. All vulnerability databases (Trivy, OSV) must be mirrored internally
+
+**OPA policies** must be bundled into the image or served from an internal bundle server. The current `COPY policies/` approach works for air-gapped.
+
+**ClamAV signatures** (`Dockerfile` line 215: `RUN mkdir -p /var/lib/clamav`) are not baked in -- they must be provided via an internal mirror or volume mount.
+
+---
+
+## 8. Integrations
+
+### SIEM (Splunk, Sentinel, Elastic)
+
+Eedom uses structlog throughout. To integrate:
+
+| Approach | Change |
+|----------|--------|
+| Log-based | Configure structlog JSON renderer -> ship via Fluentd/Vector to SIEM. Zero code change. |
+| Event-based | New: `data/siem_client.py` — HTTP POST to SIEM REST API on every `ReviewDecision`. Called from `pipeline.py` after `db.save_decision()` |
+| Parquet export | SIEM ingests `decisions.parquet` on a schedule (DuckDB -> CSV -> SIEM bulk import) |
+
+The Parquet schema in `parquet_writer.py:26-56` already contains all fields a SIEM needs: decision, severity counts, triggered rules, advisory IDs, timestamps.
+
+### Jira
+
+Create a Jira ticket on `reject` verdicts:
+
+| File | Change |
+|------|--------|
+| New: `data/jira_client.py` | httpx POST to Jira REST API v3 |
+| `core/pipeline.py` | After `assemble_decision()`, if verdict is `reject`, call `jira_client.create_issue()` |
+| `core/config.py` | Add `jira_url`, `jira_project`, `jira_api_token: SecretStr` |
+
+### Slack
+
+Notify channels on policy violations:
+
+| File | Change |
+|------|--------|
+| New: `data/slack_client.py` | httpx POST to Slack webhook URL |
+| `core/pipeline.py` | After `generate_memo()`, if `should_comment`, call `slack_client.post_message()` |
+| `core/config.py` | Add `slack_webhook_url: SecretStr | None` |
+
+### Webhook (Generic)
+
+For maximum flexibility, add a generic webhook system:
+
+| File | Change |
+|------|--------|
+| New: `data/webhook_client.py` | POST `ReviewDecision` JSON to configured URLs with HMAC signing |
+| `core/config.py` | Add `webhook_urls: list[str]`, `webhook_secret: SecretStr | None` |
+| `core/pipeline.py` | Fire webhooks after evidence is sealed |
+
+---
+
+## 9. Deployment Models
+
+### On-Premise (Self-Hosted Runner)
+
+This is the current model. The `gatekeeper.yml` workflow runs on `self-hosted` runners.
+
+**Architecture:**
+```
+[GitHub.com] --webhook--> [Self-hosted runner] --scan--> [Repo checkout]
+                               |
+                               v
+                          [eedom container]
+                               |
+                               v
+                          [Postgres (on-prem)]
+                               |
+                               v
+                          [Evidence (NFS/local)]
+```
+
+**Sizing per runner:**
+- CPU: 4 cores minimum (4 scanner binaries run in parallel via `ThreadPoolExecutor`)
+- RAM: 8 GB (Trivy DB + Semgrep rules + Python runtime)
+- Disk: 20 GB base + 1 GB per 100 repos of evidence
+- Network: Outbound to GitHub API (for PR comments), PyPI (for metadata), vulnerability databases
+
+### Private Cloud (Kubernetes)
+
+Deploy eedom as a Kubernetes workload:
+
+```yaml
+# eedom-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eedom-worker
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: eedom
+        image: ghcr.io/<org>/eedom:latest
+        resources:
+          requests: { cpu: "2", memory: "4Gi" }
+          limits:   { cpu: "4", memory: "8Gi" }
+        env:
+        - name: EEDOM_DB_DSN
+          valueFrom:
+            secretKeyRef: { name: eedom-secrets, key: db-dsn }
+```
+
+**Required additions:**
+- Kubernetes CronJob for `mark_vuln_stale()` (weekly cache invalidation)
+- PersistentVolumeClaim or S3 for evidence storage
+- Postgres operator (CloudNativePG or Zalando) for HA database
+- Network policies to restrict egress to known endpoints
+
+### Air-Gapped
+
+No internet access. All external dependencies pre-loaded:
+
+| Dependency | Air-Gap Strategy |
+|-----------|-----------------|
+| Scanner binaries | Baked into container image (already done in `Dockerfile`) |
+| Trivy vulnerability DB | Internal mirror, volume-mounted at `/opt/trivy-db/` |
+| OSV database | Internal mirror, pass `--local-db-path` to osv-scanner |
+| ClamAV signatures | Internal mirror, volume-mounted at `/var/lib/clamav/` |
+| PyPI metadata | Internal PyPI mirror (devpi/Artifactory), configure `EEDOM_PYPI_URL` |
+| OPA policies | Bundled in image or served from internal bundle server |
+| Container image | Transferred via `podman save`/`podman load` or internal registry |
+
+**New config fields needed in `core/config.py`:**
+```python
+pypi_base_url: str = "https://pypi.org"  # override for internal mirror
+trivy_db_path: str | None = None         # local DB path
+osv_db_path: str | None = None           # local DB path
+clamav_db_path: str = "/var/lib/clamav"  # signature directory
+```
+
+---
+
+## 10. Phased Implementation Plan
+
+### Phase 1: Foundation (Weeks 1-4)
+
+**Goal:** Multi-tenancy + distributed scanning + HA Postgres
+
+| Task | Files | Effort |
+|------|-------|--------|
+| Add `tenant_id` to all tables with RLS | New: `migrations/003_multi_tenancy.sql` | 3 days |
+| Set `app.tenant_id` in DB sessions | `data/db.py`, `data/catalog.py` | 2 days |
+| Add `tenant_id` to `EedomSettings` | `core/config.py` | 1 day |
+| Implement scan queue worker | New: `src/eedom/worker/scanner_worker.py` | 5 days |
+| Integrate catalog cache into pipeline | `core/pipeline.py` | 3 days |
+| Partition Parquet writes | `data/parquet_writer.py` | 2 days |
+| Deploy HA Postgres (Patroni or RDS) | Infrastructure | 3 days |
+| Move evidence to shared storage (NFS/EFS) | `core/config.py` (evidence_path) | 1 day |
+
+### Phase 2: Access Control (Weeks 5-8)
+
+**Goal:** RBAC + SSO + audit trail improvements
+
+| Task | Files | Effort |
+|------|-------|--------|
+| RBAC schema + migration | New: `migrations/004_rbac.sql` | 2 days |
+| Authorization module | New: `core/authz.py` | 3 days |
+| SSO adapter (OIDC) | New: `src/eedom/auth/oidc.py` | 5 days |
+| Bypass approval workflow | `data/db.py` (extend `save_bypass`) | 3 days |
+| Centralized policy DB table | New: `migrations/005_policy_management.sql` | 2 days |
+| Policy hierarchy merge logic | New: `core/policy_hierarchy.py` | 3 days |
+| Integrate with OPA evaluator | `core/policy.py` | 2 days |
+
+### Phase 3: Integrations + Compliance (Weeks 9-12)
+
+**Goal:** SIEM, Jira, Slack, compliance documentation
+
+| Task | Files | Effort |
+|------|-------|--------|
+| Generic webhook client | New: `data/webhook_client.py` | 3 days |
+| Jira integration | New: `data/jira_client.py` | 3 days |
+| Slack integration | New: `data/slack_client.py` | 2 days |
+| SIEM log shipping (structlog -> Fluentd) | Infrastructure config | 2 days |
+| SOC 2 evidence documentation | Docs | 5 days |
+| Air-gapped deployment guide | Docs + config changes in `core/config.py` | 3 days |
+| FedRAMP boundary documentation | Docs | 5 days |
+| FIPS 140-2 OpenSSL configuration | `core/seal.py`, container image | 2 days |
+
+### Phase 4: Scale (Weeks 13-16)
+
+**Goal:** Kubernetes deployment, 1000-repo readiness
+
+| Task | Files | Effort |
+|------|-------|--------|
+| Kubernetes manifests | New: `deploy/k8s/` | 3 days |
+| Helm chart | New: `deploy/helm/eedom/` | 5 days |
+| Horizontal pod autoscaler for workers | Kubernetes config | 2 days |
+| Connection pool scaling (PgBouncer) | Infrastructure | 2 days |
+| OPA daemon mode (HTTP instead of subprocess) | `core/policy.py` | 3 days |
+| Monitoring dashboards (Grafana) | Infrastructure | 3 days |
+| Load testing (100/1000 concurrent pipelines) | New: `tests/load/` | 5 days |
+| Separate DB per tenant option | New: `data/tenant_router.py` | 3 days |
+
+---
+
+## 11. Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| RLS misconfiguration exposes cross-tenant data | Critical | Automated RLS tests in CI; penetration testing |
+| Parquet corruption under concurrent writes | High | Partition by run_id (Phase 1) |
+| Scanner binary supply chain compromise | High | SHA-256 verification already in Dockerfile; add Sigstore/cosign |
+| Air-gapped vulnerability DB staleness | Medium | Automated weekly sync job with alerting on age |
+| HNSW index rebuild blocks writes | Medium | Schedule `REINDEX CONCURRENTLY` during maintenance windows |
+| Connection pool exhaustion under load | Medium | PgBouncer + connection limit monitoring (Phase 4) |


### PR DESCRIPTION
## Summary

Two architecture analysis documents evaluating eedom for scale deployment:

### Enterprise (472 lines)
Self-hosted, on-prem, air-gapped. Covers multi-tenancy (Postgres RLS), distributed scanning via scan_queue, centralized policy hierarchy, RBAC, compliance (SOC2/ISO/FedRAMP), integrations (SIEM/Jira/Slack), Helm/operator packaging. 4-phase plan.

### Cloud (604 lines)  
SaaS deployment. GitHub App webhook model, ECS Fargate workers, S3 evidence, queue-based processing, tenant isolation, REST API (14 endpoints), billing/metering, multi-region, dashboard. 4-phase migration from CLI to cloud. 

Both docs are specific about file paths, module changes, and service names — no hand-waving.