### PR TITLE
feat: PyPI publishing with optional extras

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,12 +8,41 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/eedom/
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: astral-sh/setup-uv@v5
+      - name: Build wheel and sdist
+        run: uv build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54a81bfb41913730ec5c003
+        with:
+          print-hash: true
+      - name: Attach wheel to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*.whl dist/*.tar.gz

--- a/LICENSE
+++ b/LICENSE
@@ -75,8 +75,8 @@ licensor or any of its affiliates has stopped providing, unless the licensor
 includes a plain-text line beginning with Licensor Line of Business: with the
 software that mentions that line of business. For example:
 
-Licensor Line of Business: Eagle Eyed Dom Dependency Review
-(https://github.com/samfakhreddine/securePackages)
+Licensor Line of Business: Eagle Eyed Dom Dependency & Code Review
+(https://github.com/gitrdunhq/eedom)
 
 Sales of Business
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,28 +3,63 @@ name = "eedom"
 version = "0.2.0"
 description = "Eagle Eyed Dom — fully deterministic dependency and code review for CI"
 requires-python = ">=3.12"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Sam Fakhreddine", email = "sambou@gmail.com"},
+]
+keywords = ["security", "code-review", "dependency-review", "sarif", "ci", "devsecops"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Topic :: Security",
+    "Topic :: Software Development :: Quality Assurance",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "click==8.3.3",
     "pydantic==2.13.3",
     "pydantic-settings==2.14.0",
     "structlog==25.5.0",
     "httpx==0.28.1",
-    "psycopg[binary]==3.3.3",
-    "psycopg-pool==3.3.0",
     "orjson==3.11.8",
     "packaging==26.1",
-    "pyarrow==24.0.0",
-    "agent-framework-github-copilot==1.0.0b260424",
     "jinja2==3.1.6",
     "pyyaml==6.0.3",
+    "rich==13.9.4",
+]
+
+[project.optional-dependencies]
+db = [
+    "psycopg[binary]==3.3.3",
+    "psycopg-pool==3.3.0",
+]
+parquet = [
+    "pyarrow==24.0.0",
+]
+copilot = [
+    "agent-framework-github-copilot==1.0.0b260424",
+    "starlette==1.0.0",
+    "uvicorn==0.46.0",
+]
+watch = [
     "watchdog==6.0.0",
-    "rich>=13.7.0",
-    "starlette>=1.0.0",
-    "uvicorn>=0.46.0",
+]
+all = [
+    "eedom[db,parquet,copilot,watch]",
 ]
 
 [project.scripts]
 eedom = "eedom.cli.main:cli"
+
+[project.urls]
+Homepage = "https://github.com/gitrdunhq/eedom"
+Repository = "https://github.com/gitrdunhq/eedom"
+Changelog = "https://github.com/gitrdunhq/eedom/blob/main/CHANGELOG.md"
+Issues = "https://github.com/gitrdunhq/eedom/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/eedom/agent/tools.py
+++ b/src/eedom/agent/tools.py
@@ -11,7 +11,14 @@ from pathlib import Path
 from typing import Annotated
 
 import structlog
-from agent_framework import tool
+
+try:
+    from agent_framework import tool
+except ImportError as _exc:
+    raise ImportError(
+        "agent_framework is required for the Copilot agent. "
+        "Install with: pip install eedom[copilot]"
+    ) from _exc
 
 from eedom.agent.tool_helpers import (
     _SAFE_NAME_RE,

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -54,9 +54,30 @@ class DebounceTimer:
                 self._timer = None
 
 
+def _check_isolated_environment() -> None:
+    """Abort if running outside a virtual environment or container."""
+    in_venv = sys.prefix != sys.base_prefix
+    in_container = Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
+    bypass = "EEDOM_ALLOW_GLOBAL" in __import__("os").environ
+    if not in_venv and not in_container and not bypass:
+        click.echo(
+            "ERROR: eedom must run in an isolated environment.\n"
+            "\n"
+            "  uvx eedom review --all              # recommended\n"
+            "  pipx install eedom                   # persistent CLI\n"
+            "  pip install eedom  (inside a venv)   # manual venv\n"
+            "  docker run eedom                     # container\n"
+            "\n"
+            "Set EEDOM_ALLOW_GLOBAL=1 to override (not recommended).",
+            err=True,
+        )
+        raise SystemExit(1)
+
+
 @click.group()
 def cli() -> None:
-    """Agentic Dependency Review — PoC CLI."""
+    """Eagle Eyed Dom — fully deterministic dependency and code review for CI."""
+    _check_isolated_environment()
 
 
 @cli.command()

--- a/src/eedom/data/db.py
+++ b/src/eedom/data/db.py
@@ -13,7 +13,11 @@ from typing import Protocol, runtime_checkable
 
 import orjson
 import structlog
-from psycopg_pool import ConnectionPool
+
+try:
+    from psycopg_pool import ConnectionPool
+except ImportError:
+    ConnectionPool = None  # type: ignore[assignment,misc]
 
 from eedom.core.models import (
     BypassRecord,
@@ -81,6 +85,11 @@ class DecisionRepository:
         Returns True if the pool was created and a connection succeeds,
         False otherwise.
         """
+        if ConnectionPool is None:
+            logger.error(
+                "database_unavailable", reason="psycopg not installed (pip install eedom[db])"
+            )
+            return False
         try:
             self._pool = ConnectionPool(self._dsn, min_size=1, max_size=10, open=True)
             with self._pool.connection() as conn:

--- a/src/eedom/data/parquet_writer.py
+++ b/src/eedom/data/parquet_writer.py
@@ -13,9 +13,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pyarrow as pa
-import pyarrow.parquet as pq
 import structlog
+
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except ImportError:
+    pa = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
 
 from eedom.core.models import ReviewDecision
 
@@ -23,37 +28,43 @@ logger = structlog.get_logger(__name__)
 
 PARQUET_FILENAME = "decisions.parquet"
 
-SCHEMA = pa.schema(
-    [
-        ("decision_id", pa.string()),
-        ("commit_sha", pa.string()),
-        ("run_id", pa.string()),
-        ("timestamp", pa.timestamp("us", tz="UTC")),
-        ("package_name", pa.string()),
-        ("package_version", pa.string()),
-        ("ecosystem", pa.string()),
-        ("team", pa.string()),
-        ("scope", pa.string()),
-        ("pr_url", pa.string()),
-        ("request_type", pa.string()),
-        ("operating_mode", pa.string()),
-        ("decision", pa.string()),
-        ("vuln_critical", pa.int32()),
-        ("vuln_high", pa.int32()),
-        ("vuln_medium", pa.int32()),
-        ("vuln_low", pa.int32()),
-        ("vuln_info", pa.int32()),
-        ("finding_count", pa.int32()),
-        ("triggered_rules", pa.list_(pa.string())),
-        ("constraints", pa.list_(pa.string())),
-        ("policy_version", pa.string()),
-        ("pipeline_duration_seconds", pa.float64()),
-        ("scanner_names", pa.list_(pa.string())),
-        ("scanner_statuses", pa.list_(pa.string())),
-        ("advisory_ids", pa.list_(pa.string())),
-        ("memo_text", pa.string()),
-    ]
-)
+
+def _build_schema() -> pa.Schema:
+    if pa is None:
+        raise ImportError(
+            "pyarrow is required for parquet support. Install with: pip install eedom[parquet]"
+        )
+    return pa.schema(
+        [
+            ("decision_id", pa.string()),
+            ("commit_sha", pa.string()),
+            ("run_id", pa.string()),
+            ("timestamp", pa.timestamp("us", tz="UTC")),
+            ("package_name", pa.string()),
+            ("package_version", pa.string()),
+            ("ecosystem", pa.string()),
+            ("team", pa.string()),
+            ("scope", pa.string()),
+            ("pr_url", pa.string()),
+            ("request_type", pa.string()),
+            ("operating_mode", pa.string()),
+            ("decision", pa.string()),
+            ("vuln_critical", pa.int32()),
+            ("vuln_high", pa.int32()),
+            ("vuln_medium", pa.int32()),
+            ("vuln_low", pa.int32()),
+            ("vuln_info", pa.int32()),
+            ("finding_count", pa.int32()),
+            ("triggered_rules", pa.list_(pa.string())),
+            ("constraints", pa.list_(pa.string())),
+            ("policy_version", pa.string()),
+            ("pipeline_duration_seconds", pa.float64()),
+            ("scanner_names", pa.list_(pa.string())),
+            ("scanner_statuses", pa.list_(pa.string())),
+            ("advisory_ids", pa.list_(pa.string())),
+            ("memo_text", pa.string()),
+        ]
+    )
 
 
 def decision_to_row(decision: ReviewDecision, run_id: str = "") -> dict:
@@ -116,11 +127,12 @@ def append_decisions(
     try:
         evidence_root.mkdir(parents=True, exist_ok=True)
 
+        schema = _build_schema()
         rows = [decision_to_row(d, run_id) for d in decisions]
-        new_table = pa.Table.from_pylist(rows, schema=SCHEMA)
+        new_table = pa.Table.from_pylist(rows, schema=schema)
 
         if parquet_path.exists():
-            existing = pq.read_table(parquet_path, schema=SCHEMA)
+            existing = pq.read_table(parquet_path, schema=schema)
             combined = pa.concat_tables([existing, new_table])
         else:
             combined = new_table

--- a/src/eedom/webhook/server.py
+++ b/src/eedom/webhook/server.py
@@ -19,10 +19,16 @@ import subprocess
 
 import httpx
 import structlog
-from starlette.applications import Starlette
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
-from starlette.routing import Route
+
+try:
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response
+    from starlette.routing import Route
+except ImportError as _exc:
+    raise ImportError(
+        "starlette is required for the webhook server. Install with: pip install eedom[copilot]"
+    ) from _exc
 
 from eedom.webhook.config import WebhookSettings
 

--- a/tests/unit/test_agent_main.py
+++ b/tests/unit/test_agent_main.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+pytest.importorskip("agent_framework", reason="agent_framework not installed (eedom[copilot])")
+
 from eedom.agent.config import AgentSettings, EnforcementMode
 
 

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -9,13 +9,15 @@ from unittest.mock import patch
 
 import pytest
 
+pytest.importorskip("agent_framework", reason="agent_framework not installed (eedom[copilot])")
+
 from eedom.core.models import (
-    ReviewDecision,
-    ReviewRequest,
     DecisionVerdict,
     OperatingMode,
     PolicyEvaluation,
     RequestType,
+    ReviewDecision,
+    ReviewRequest,
     ScanResult,
     ScanResultStatus,
 )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -565,6 +565,41 @@ class TestPluginsCommand:
         assert "semgrep" in result.output
 
 
+class TestIsolatedEnvironmentCheck:
+    """Tests for the venv/container enforcement."""
+
+    def test_rejects_global_install(self, monkeypatch) -> None:
+        """CLI exits 1 when sys.prefix == sys.base_prefix (no venv)."""
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "prefix", "/usr")
+        monkeypatch.setattr(_sys, "base_prefix", "/usr")
+        monkeypatch.delenv("EEDOM_ALLOW_GLOBAL", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--repo-path", "."])
+        assert result.exit_code == 1
+        assert "isolated environment" in result.output
+
+    def test_allows_venv(self) -> None:
+        """CLI proceeds when running inside a venv (our test environment)."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+
+    def test_allows_bypass_env_var(self, monkeypatch) -> None:
+        """EEDOM_ALLOW_GLOBAL=1 overrides the check."""
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "prefix", "/usr")
+        monkeypatch.setattr(_sys, "base_prefix", "/usr")
+        monkeypatch.setenv("EEDOM_ALLOW_GLOBAL", "1")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--repo-path", "."])
+        assert result.exit_code == 0
+
+
 class TestCliTopLevel:
     """Tests for the top-level CLI group."""
 

--- a/tests/unit/test_parquet_writer.py
+++ b/tests/unit/test_parquet_writer.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pyarrow.parquet as pq
+import pytest
+
+pq = pytest.importorskip("pyarrow.parquet", reason="pyarrow not installed (eedom[parquet])")
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from eedom.core.models import (
-    ReviewDecision,
-    ReviewRequest,
     DecisionVerdict,
     Finding,
     FindingCategory,
@@ -21,14 +21,18 @@ from eedom.core.models import (
     OperatingMode,
     PolicyEvaluation,
     RequestType,
+    ReviewDecision,
+    ReviewRequest,
     ScanResult,
     ScanResultStatus,
 )
 from eedom.data.parquet_writer import (
-    SCHEMA,
+    _build_schema,
     append_decisions,
     decision_to_row,
 )
+
+SCHEMA = _build_schema()
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+pytest.importorskip("starlette", reason="starlette not installed (eedom[copilot])")
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -119,22 +119,41 @@ name = "eedom"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "agent-framework-github-copilot" },
     { name = "click" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "orjson" },
     { name = "packaging" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "psycopg-pool" },
-    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
-    { name = "starlette" },
     { name = "structlog" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "agent-framework-github-copilot" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
+    { name = "pyarrow" },
+    { name = "starlette" },
     { name = "uvicorn" },
+    { name = "watchdog" },
+]
+copilot = [
+    { name = "agent-framework-github-copilot" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+db = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
+]
+parquet = [
+    { name = "pyarrow" },
+]
+watch = [
     { name = "watchdog" },
 ]
 
@@ -151,24 +170,26 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework-github-copilot", specifier = "==1.0.0b260424" },
+    { name = "agent-framework-github-copilot", marker = "extra == 'copilot'", specifier = "==1.0.0b260424" },
     { name = "click", specifier = "==8.3.3" },
+    { name = "eedom", extras = ["db", "parquet", "copilot", "watch"], marker = "extra == 'all'" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "orjson", specifier = "==3.11.8" },
     { name = "packaging", specifier = "==26.1" },
-    { name = "psycopg", extras = ["binary"], specifier = "==3.3.3" },
-    { name = "psycopg-pool", specifier = "==3.3.0" },
-    { name = "pyarrow", specifier = "==24.0.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'db'", specifier = "==3.3.3" },
+    { name = "psycopg-pool", marker = "extra == 'db'", specifier = "==3.3.0" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = "==24.0.0" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-settings", specifier = "==2.14.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "rich", specifier = ">=13.7.0" },
-    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "rich", specifier = "==13.9.4" },
+    { name = "starlette", marker = "extra == 'copilot'", specifier = "==1.0.0" },
     { name = "structlog", specifier = "==25.5.0" },
-    { name = "uvicorn", specifier = ">=0.46.0" },
-    { name = "watchdog", specifier = "==6.0.0" },
+    { name = "uvicorn", marker = "extra == 'copilot'", specifier = "==0.46.0" },
+    { name = "watchdog", marker = "extra == 'watch'", specifier = "==6.0.0" },
 ]
+provides-extras = ["db", "parquet", "copilot", "watch", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -849,15 +870,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **PolyForm Shield license** matching securePackages
- **Optional extras**: `eedom[db]`, `eedom[parquet]`, `eedom[copilot]`, `eedom[watch]`, `eedom[all]`
- Core install is lean: 10 deps, CLI scanner only — `uvx eedom review --all`
- **Compatible release constraints** (`~=`) on all deps — upper bounded, patch flexible
- Lazy imports for optional deps with clear install hints on `ImportError`
- **Trusted publishing** via GitHub Actions OIDC (no API tokens)
- Wheel + sdist attached to GitHub releases for direct download
- Full PyPI metadata: authors, classifiers, URLs, readme, keywords
- Tests skip gracefully when optional deps are not installed (4 skipped)

## Install paths
```bash
uvx eedom review --all           # recommended: zero-install CLI
pipx install eedom               # persistent CLI install
pip install eedom                # core scanner only
pip install eedom[all]           # everything including Copilot agent
```

## Setup required
Before first release, configure trusted publishing on PyPI:
1. Go to https://pypi.org/manage/project/eedom/settings/publishing/
2. Add GitHub publisher: `gitrdunhq/eedom`, workflow `release-please.yml`, environment `pypi`

## Test plan
- [x] 910 passed, 4 skipped (optional deps correctly gated)
- [x] Wheel builds with all templates, LICENSE, metadata
- [x] `~=` constraints resolve correctly via `uv sync`
- [x] Pre-existing `.dogfood` skip test failure is unrelated