### PR TITLE
ci: trigger Copilot review on dom: approved label

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,21 @@
+name: Request Copilot Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  request-copilot:
+    if: github.event.label.name == 'dom: approved'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot code review
+        run: |
+          gh pr edit "$PR_NUM" --repo "$REPO" --add-reviewer @copilot
+          echo "Copilot review requested on PR #$PR_NUM"
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_REVIEWER_PAT }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -260,12 +260,7 @@ jobs:
             gh pr comment "$PR_NUM" --body "$HANDOFF"
           fi
 
-          if gh pr edit "$PR_NUM" --add-reviewer @copilot 2>/dev/null; then
-            gh issue edit "$PR_NUM" --remove-label "dom: needs-copilot" 2>/dev/null || true
-          else
-            gh issue edit "$PR_NUM" --add-label "dom: needs-copilot"
-            gh pr comment "$PR_NUM" --body "⚠️ **Could not request Copilot review.** The workflow token lacks permission to add reviewers. Run manually: \`gh pr edit $PR_NUM --add-reviewer @copilot\`"
-          fi
+          # Copilot review is requested by copilot-review.yml when dom: approved label is applied
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- New `copilot-review.yml` workflow fires on `pull_request: [labeled]`
- Only triggers when the label is `dom: approved` — Copilot doesn't waste cycles on failing PRs
- Uses `COPILOT_REVIEWER_PAT` secret instead of `GITHUB_TOKEN` (which can't add reviewers)
- Removes the inline `--add-reviewer @copilot` attempt and `dom: needs-copilot` fallback from gatekeeper.yml
- Handoff comment with context for Copilot stays in gatekeeper.yml

## Flow
```
PR opened → gatekeeper runs → dom: approved label applied
                                    ↓
                          copilot-review.yml fires
                                    ↓
                          gh pr edit --add-reviewer @copilot
```

## Setup required
Add a `COPILOT_REVIEWER_PAT` repo secret — fine-grained PAT with `pull-requests: write` on eedom.

## Test plan
- [ ] Create PAT, add as repo secret
- [ ] Open a test PR, verify gatekeeper applies `dom: approved`
- [ ] Verify `copilot-review.yml` fires and Copilot review appears