### PR TITLE
feat: mypy/pyright plugin + container-only test enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,16 +10,17 @@ Eagle Eyed Dom — fully deterministic dependency and code review for CI. 15 plu
 
 ```bash
 uv sync --group dev                    # Install all deps
-uv run pytest tests/ -v                # Run all tests
-uv run pytest tests/unit/test_X.py -v  # Run one test file
+make test                              # Run tests in container (podman/docker)
+make test-host                         # Run tests on host (escape hatch)
 uv run ruff check src/ tests/          # Lint
 uv run black src/ tests/               # Format
 make quality-check                     # Format + lint
-make test                              # Run tests
 make dogfood                           # Self-scan with eedom review
 make preflight                         # Format + lint + test + dogfood
 opa test policies/                     # OPA Rego policy tests
 ```
+
+**Tests MUST run in a container.** `make test` handles this automatically. Bare `uv run pytest` will abort with an error unless `EEDOM_ALLOW_HOST_TESTS=1` is set.
 
 Container:
 ```bash

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,31 @@
+# Test image — installs eedom from source with dev deps.
+# Unlike the runtime Dockerfile, this always reflects the current checkout.
+#
+# Build:  podman build -f Dockerfile.test -t eedom-test:latest .
+# Run:    podman run --rm -v .:/workspace:ro -w /workspace eedom-test:latest python3 -m pytest tests/ -v
+
+FROM python:3.12-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /workspace
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --group dev
+
+COPY src/ src/
+COPY tests/ tests/
+COPY policies/ policies/
+
+RUN uv sync --frozen --group dev
+
+# mypy for the type-checking plugin tests
+RUN uv pip install mypy
+
+ENV EEDOM_ALLOW_GLOBAL=1
+
+ENTRYPOINT ["uv", "run"]

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,19 @@ lint:
 	@uv run ruff check src/ tests/
 	@echo "Linting complete"
 
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+
 test:
-	@uv run pytest tests/ -v
+	@$(CONTAINER_ENGINE) build -f Dockerfile.test -t eedom-test:latest .
+	@$(CONTAINER_ENGINE) run --rm \
+		-v "$(CURDIR):/workspace:ro" \
+		-w /workspace \
+		-e EEDOM_ALLOW_GLOBAL=1 \
+		eedom-test:latest \
+		python3 -m pytest tests/ -v
+
+test-host:
+	@EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/ -v
 
 dev:
 	@uv sync --group dev

--- a/src/eedom/plugins/mypy.py
+++ b/src/eedom/plugins/mypy.py
@@ -1,0 +1,187 @@
+"""Mypy/Pyright plugin — deterministic cross-file type checking.
+# tested-by: tests/unit/test_mypy_plugin.py
+
+Prefers pyright (faster, stricter) when available, falls back to mypy.
+Only error-level findings are reported — notes are excluded.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import structlog
+
+from eedom.core.errors import ErrorCode, error_msg
+from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
+
+logger = structlog.get_logger(__name__)
+
+_MYPY_LINE_RE = re.compile(
+    r"^(.+?):(\d+)(?::\d+)?:\s+(error|warning|note):\s+(.+?)(?:\s+\[(.+)\])?$"
+)
+
+_MYPY_SEVERITY_MAP = {"error": "high", "warning": "medium", "note": "info"}
+_PYRIGHT_SEVERITY_MAP = {"error": "high", "warning": "medium", "information": "low"}
+
+
+class MypyPlugin(ScannerPlugin):
+    def __init__(self) -> None:
+        self._tool: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "mypy"
+
+    @property
+    def description(self) -> str:
+        return "Cross-file type checking (mypy/pyright)"
+
+    @property
+    def category(self) -> PluginCategory:
+        return PluginCategory.code
+
+    def can_run(self, files: list[str], repo_path: Path) -> bool:
+        return any(Path(f).suffix == ".py" for f in files)
+
+    def _detect_tool(self) -> str | None:
+        if self._tool:
+            return self._tool
+        for tool in ("pyright", "mypy"):
+            if shutil.which(tool):
+                self._tool = tool
+                return tool
+        return None
+
+    def run(
+        self,
+        files: list[str],
+        repo_path: Path,
+        timeout: int = 60,
+    ) -> PluginResult:
+        tool = self._detect_tool()
+        if not tool:
+            return PluginResult(
+                plugin_name=self.name,
+                error=error_msg(ErrorCode.NOT_INSTALLED, "mypy/pyright"),
+            )
+
+        if tool == "pyright":
+            return self._run_pyright(files, repo_path, timeout)
+        return self._run_mypy(files, repo_path, timeout)
+
+    def _run_mypy(self, files: list[str], repo_path: Path, timeout: int) -> PluginResult:
+        py_files = [f for f in files if f.endswith(".py")]
+        if not py_files:
+            return PluginResult(plugin_name=self.name)
+
+        try:
+            r = subprocess.run(
+                ["mypy", "--no-error-summary", "--show-column-numbers", *py_files],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+                cwd=str(repo_path),
+            )
+        except subprocess.TimeoutExpired:
+            return PluginResult(
+                plugin_name=self.name,
+                error=error_msg(ErrorCode.TIMEOUT, "mypy", timeout=timeout),
+            )
+
+        findings = []
+        for line in r.stdout.splitlines():
+            m = _MYPY_LINE_RE.match(line)
+            if not m:
+                continue
+            severity = _MYPY_SEVERITY_MAP.get(m.group(3), "info")
+            if severity == "info":
+                continue
+            findings.append(
+                {
+                    "file": m.group(1),
+                    "line": int(m.group(2)),
+                    "severity": severity,
+                    "message": m.group(4),
+                    "rule": m.group(5) or "mypy",
+                    "category": "type-error",
+                }
+            )
+
+        return PluginResult(
+            plugin_name=self.name,
+            findings=findings,
+            summary={"errors": len(findings), "tool": "mypy"},
+        )
+
+    def _run_pyright(self, files: list[str], repo_path: Path, timeout: int) -> PluginResult:
+        py_files = [f for f in files if f.endswith(".py")]
+        if not py_files:
+            return PluginResult(plugin_name=self.name)
+
+        try:
+            r = subprocess.run(
+                ["pyright", "--outputjson", *py_files],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+                cwd=str(repo_path),
+            )
+        except subprocess.TimeoutExpired:
+            return PluginResult(
+                plugin_name=self.name,
+                error=error_msg(ErrorCode.TIMEOUT, "pyright", timeout=timeout),
+            )
+
+        try:
+            data = json.loads(r.stdout)
+        except json.JSONDecodeError:
+            return PluginResult(
+                plugin_name=self.name,
+                error=error_msg(ErrorCode.PARSE_ERROR, "pyright"),
+            )
+
+        findings = []
+        for diag in data.get("generalDiagnostics", []):
+            severity = _PYRIGHT_SEVERITY_MAP.get(diag.get("severity", ""), "info")
+            if severity == "info":
+                continue
+            line_num = diag.get("range", {}).get("start", {}).get("line", 0) + 1
+            findings.append(
+                {
+                    "file": diag.get("file", "?"),
+                    "line": line_num,
+                    "severity": severity,
+                    "message": diag.get("message", ""),
+                    "rule": diag.get("rule", "pyright"),
+                    "category": "type-error",
+                }
+            )
+
+        return PluginResult(
+            plugin_name=self.name,
+            findings=findings,
+            summary={"errors": len(findings), "tool": "pyright"},
+        )
+
+    def _render_inline(self, result: PluginResult) -> str:
+        if result.error:
+            return f"**mypy**: {result.error}"
+        if not result.findings:
+            return ""
+        tool = result.summary.get("tool", "mypy")
+        lines = [
+            "<details open>",
+            f"<summary>🔬 <b>Type Errors — {tool} ({len(result.findings)})</b></summary>\n",
+        ]
+        for f in result.findings:
+            icon = {"high": "🔴", "medium": "🟡"}.get(f["severity"], "🔵")
+            lines.append(f"{icon} **`{f['file']}:{f['line']}`** — `{f['rule']}`")
+            lines.append(f"> {f['message'][:200]}\n")
+        lines.append("</details>\n")
+        return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Global test configuration.
+# tested-by: (self — pytest infrastructure)
+
+Enforces that tests run inside a container (Docker/Podman).
+Set EEDOM_ALLOW_HOST_TESTS=1 to bypass (not recommended).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def pytest_configure(config: object) -> None:
+    in_container = Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
+    bypass = os.environ.get("EEDOM_ALLOW_HOST_TESTS") == "1"
+    if not in_container and not bypass:
+        raise SystemExit(
+            "\n\nERROR: eedom tests must run inside a container.\n"
+            "\n"
+            "  make test                            # uses podman/docker\n"
+            "  podman run --rm -v .:/workspace:ro eedom:latest pytest tests/ -v\n"
+            "\n"
+            "Set EEDOM_ALLOW_HOST_TESTS=1 to override (not recommended).\n"
+        )

--- a/tests/unit/test_mypy_plugin.py
+++ b/tests/unit/test_mypy_plugin.py
@@ -1,0 +1,172 @@
+"""Tests for mypy/pyright plugin — deterministic type checking.
+# tested-by: tests/unit/test_mypy_plugin.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from eedom.core.plugin import PluginCategory
+from eedom.plugins.mypy import MypyPlugin
+
+MYPY_OUTPUT = """\
+src/app.py:5: error: Argument 1 to "parse_tasks" has incompatible type "Path"; expected "str"  [arg-type]
+src/app.py:12: error: "Task" has no attribute "__getitem__"  [attr-defined]
+src/lib.py:30: note: Revealed type is "builtins.str"
+Found 2 errors in 2 files (checked 3 source files)
+"""
+
+MYPY_OUTPUT_WITH_COLUMNS = """\
+src/app.py:5:10: error: Argument 1 to "parse_tasks" has incompatible type "Path"; expected "str"  [arg-type]
+src/app.py:12:5: error: "Task" has no attribute "__getitem__"  [attr-defined]
+src/lib.py:30:1: note: Revealed type is "builtins.str"
+Found 2 errors in 2 files (checked 3 source files)
+"""
+
+PYRIGHT_OUTPUT = json.dumps(
+    {
+        "generalDiagnostics": [
+            {
+                "file": "src/app.py",
+                "severity": "error",
+                "message": 'Argument of type "Path" cannot be assigned to parameter of type "str"',
+                "range": {"start": {"line": 4, "character": 0}},
+                "rule": "reportArgumentType",
+            },
+            {
+                "file": "src/lib.py",
+                "severity": "warning",
+                "message": "Variable is not accessed",
+                "range": {"start": {"line": 10, "character": 0}},
+                "rule": "reportUnusedVariable",
+            },
+        ],
+        "summary": {"errorCount": 1, "warningCount": 1},
+    }
+)
+
+
+class TestMypyPlugin:
+    def test_name_and_category(self):
+        p = MypyPlugin()
+        assert p.name == "mypy"
+        assert p.category == PluginCategory.code
+
+    def test_can_run_with_python_files(self):
+        p = MypyPlugin()
+        assert p.can_run(["src/app.py", "tests/test_app.py"], Path(".")) is True
+
+    def test_can_run_false_without_python_files(self):
+        p = MypyPlugin()
+        assert p.can_run(["src/app.ts", "README.md"], Path(".")) is False
+
+    @patch("eedom.plugins.mypy.subprocess.run")
+    @patch(
+        "eedom.plugins.mypy.shutil.which",
+        side_effect=lambda t: "/usr/bin/mypy" if t == "mypy" else None,
+    )
+    def test_mypy_parses_errors(self, _which, mock_run):
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = MYPY_OUTPUT
+        mock_run.return_value.stderr = ""
+
+        p = MypyPlugin()
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        assert len(result.findings) == 2
+        assert result.findings[0]["file"] == "src/app.py"
+        assert result.findings[0]["line"] == 5
+        assert result.findings[0]["rule"] == "arg-type"
+        assert result.findings[0]["severity"] == "high"
+        assert "parse_tasks" in result.findings[0]["message"]
+
+    @patch("eedom.plugins.mypy.subprocess.run")
+    @patch(
+        "eedom.plugins.mypy.shutil.which",
+        side_effect=lambda t: "/usr/bin/mypy" if t == "mypy" else None,
+    )
+    def test_mypy_parses_column_number_format(self, _which, mock_run):
+        """Regression: --show-column-numbers adds file:line:col: format."""
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = MYPY_OUTPUT_WITH_COLUMNS
+        mock_run.return_value.stderr = ""
+
+        p = MypyPlugin()
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        assert len(result.findings) == 2
+        assert result.findings[0]["line"] == 5
+        assert result.findings[0]["rule"] == "arg-type"
+        assert result.findings[1]["line"] == 12
+
+    @patch("eedom.plugins.mypy.subprocess.run")
+    @patch("eedom.plugins.mypy.shutil.which", return_value="/usr/bin/pyright")
+    def test_pyright_parses_json(self, _which, mock_run):
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = PYRIGHT_OUTPUT
+        mock_run.return_value.stderr = ""
+
+        p = MypyPlugin()
+        p._tool = "pyright"
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        assert len(result.findings) == 2
+        assert result.findings[0]["severity"] == "high"
+        assert result.findings[0]["rule"] == "reportArgumentType"
+        assert result.findings[1]["severity"] == "medium"
+
+    @patch("eedom.plugins.mypy.subprocess.run")
+    @patch(
+        "eedom.plugins.mypy.shutil.which",
+        side_effect=lambda t: "/usr/bin/mypy" if t == "mypy" else None,
+    )
+    def test_clean_scan(self, _which, mock_run):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "Success: no issues found in 3 source files\n"
+        mock_run.return_value.stderr = ""
+
+        p = MypyPlugin()
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        assert result.error == ""
+        assert len(result.findings) == 0
+
+    @patch("eedom.plugins.mypy.shutil.which", return_value=None)
+    def test_not_installed(self, _which):
+        p = MypyPlugin()
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        assert "NOT_INSTALLED" in result.error
+
+    @patch("eedom.plugins.mypy.subprocess.run")
+    @patch(
+        "eedom.plugins.mypy.shutil.which",
+        side_effect=lambda t: "/usr/bin/mypy" if t == "mypy" else None,
+    )
+    def test_timeout(self, _which, mock_run):
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="mypy", timeout=60)
+
+        p = MypyPlugin()
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        assert "TIMEOUT" in result.error
+
+    @patch("eedom.plugins.mypy.subprocess.run")
+    @patch(
+        "eedom.plugins.mypy.shutil.which",
+        side_effect=lambda t: "/usr/bin/mypy" if t == "mypy" else None,
+    )
+    def test_notes_excluded_from_findings(self, _which, mock_run):
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = MYPY_OUTPUT
+        mock_run.return_value.stderr = ""
+
+        p = MypyPlugin()
+        result = p.run(["src/app.py"], Path("/workspace"))
+
+        for f in result.findings:
+            assert f["severity"] != "info"


### PR DESCRIPTION
## Summary
- **New plugin:** `MypyPlugin` — deterministic cross-file type checking
  - Prefers pyright (faster, stricter), falls back to mypy
  - Parses mypy text output and pyright `--outputjson` into eedom findings
  - error → high, warning → medium, notes excluded
  - Auto-discovered by plugin registry, same pattern as semgrep/gitleaks
- **Container-only test enforcement:**
  - `conftest.py` aborts pytest if not running in Docker/Podman
  - `EEDOM_ALLOW_HOST_TESTS=1` escape hatch
  - `make test` runs via container, `make test-host` for bypass
  - Prevents host environment leaks (installed tools, stale caches)

## Test plan
- [x] 9 new tests: mypy parsing, pyright parsing, clean scan, not-installed, timeout, notes excluded
- [x] conftest guard blocks bare `uv run pytest` on host
- [x] `EEDOM_ALLOW_HOST_TESTS=1` bypass works
- [x] 939 passed, 4 skipped (full suite with bypass)

Closes #37