### PR TITLE
fix: include .j2 templates in wheel (closes #14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/eedom"]
+artifacts = ["*.j2"]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
One line: `artifacts = ["*.j2"]` in hatch wheel config. Templates now ship in the wheel — `uv tool install eedom` works without the CI workaround.