### PR TITLE
feat: separate security and quality scores (closes #49)

### DIFF
--- a/docs/plugins/quality.md
+++ b/docs/plugins/quality.md
@@ -1,0 +1,73 @@
+# Quality Plugins
+
+These plugins are **advisory** — they never block a merge. They surface signals that help reviewers make informed decisions.
+
+---
+
+## blast-radius
+
+Counts how many symbols depend on a given function, surfacing the change surface before a reviewer has to guess.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | 20+ dependents |
+| High | 10–19 dependents |
+| Info | < 10 dependents |
+
+> Note: test fixtures routinely have high blast radius — that is healthy coupling, not a smell.
+
+Even advisory, this tells a reviewer whether a one-line change touches 2 callers or 40.
+
+---
+
+## complexity
+
+Measures cyclomatic complexity and maintainability index, grading each unit A–F.
+
+| Severity | Condition |
+|----------|-----------|
+| Warning | Grade C — consider refactoring |
+| High | Grade D — refactor recommended |
+| Critical | Grade F — significant complexity debt |
+
+Grade C or below is a prompt to simplify, not a hard stop.
+
+Complexity debt compounds silently; surfacing it early costs nothing and saves the next engineer from a maze.
+
+---
+
+## cpd
+
+Detects copy-paste duplication — the same logic repeated across multiple locations.
+
+| Severity | Condition |
+|----------|-----------|
+| High | 20+ duplicated lines across 3+ sites |
+| Warning | 10–19 duplicated lines |
+
+Duplicate code is a quality signal: it is unlikely to pass a thorough human review, and advisory flagging makes that conversation easier to start.
+
+---
+
+## cspell
+
+Spell-checks identifiers and comments throughout the codebase.
+
+| Severity | Condition |
+|----------|-----------|
+| Warning | Misspelled identifier or symbol name |
+| Info | Typo in a comment |
+
+Misspelled names are harder to grep, autocomplete, and explain in code review — a small fix with compounding payoff.
+
+---
+
+## ls-lint
+
+Enforces file and directory naming conventions across the project tree.
+
+| Severity | Condition |
+|----------|-----------|
+| Warning | File or directory name does not match the configured pattern |
+
+Consistent naming makes navigation predictable and removes the cognitive load of guessing whether a file is `UserService`, `user-service`, or `user_service`.

--- a/docs/plugins/security.md
+++ b/docs/plugins/security.md
@@ -1,0 +1,138 @@
+# Security Plugins
+
+These plugins gate merges. Any finding at **Critical** or **High** blocks the PR.
+
+---
+
+## gitleaks
+
+Scans diffs and history for secrets and credentials using 800+ built-in patterns; supports custom rules via `.eedom/gitleaks.toml` for org-specific PII patterns.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | Hardcoded API key, password, or token with high-confidence pattern match |
+| High | Potential secret — pattern match with lower confidence |
+
+Blocks because a leaked credential is an immediate, irreversible blast radius — the key is already in git history the moment the commit lands.
+
+---
+
+## semgrep
+
+Runs AST-based code pattern analysis to catch injection flaws, insecure APIs, and missing error handling without executing the code.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | SQL injection, OS command injection |
+| High | XSS, insecure deserialization |
+| Warning | Deprecated API usage, missing error handling |
+
+Blocks because injection vulnerabilities are exploitable in production and cannot be mitigated after merge without a targeted patch.
+
+---
+
+## trivy
+
+Scans container images and filesystems for known CVEs, matching against NVD and vendor advisories.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | CVE with a public exploit or CVSS 9+ |
+| High | CVSS >= 7.0 |
+| Medium | CVSS 4.0–6.9 |
+
+Blocks because shipping a Critical or High CVE into production creates a documented, weaponizable attack surface.
+
+---
+
+## osv-scanner
+
+Checks declared and transitive dependencies against the [OSV.dev](https://osv.dev) vulnerability database.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | CVE with public exploit in a direct or transitive package |
+| High | CVSS >= 7.0 in any resolved package |
+| Medium | CVSS 4.0–6.9 |
+
+Blocks for the same reason as trivy: a known vulnerable package in the dependency graph is an open door that only grows harder to close after merge.
+
+---
+
+## clamav
+
+Scans committed files for malware signatures using the ClamAV engine and signature database.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | Any positive malware signature match |
+
+Blocks unconditionally — a malware detection in source code or bundled assets means the commit must not land under any circumstances.
+
+---
+
+## supply-chain
+
+Validates package provenance: rejects newly published packages, unpinned versions, and missing lockfiles before they enter the dependency graph.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | Package published < 30 days ago (typosquatting / takeover window) |
+| High | Lockfile missing for a package manager with lock support |
+| Warning | Unpinned dependency (range or `latest`) |
+
+Blocks because a brand-new or unpinned package is the primary vector for supply-chain compromise — the risk window is widest in the first 30 days after publication.
+
+---
+
+## opa
+
+Evaluates commits and PR metadata against custom Rego policies defined by the team.
+
+| Severity | Condition |
+|----------|-----------|
+| Varies | Determined entirely by the policy definition |
+
+Blocks when a policy explicitly sets `deny` with a Critical or High severity — policies encode org-specific invariants (compliance rules, deploy gates, required approvals) that no generic scanner can capture.
+
+---
+
+## scancode
+
+Identifies SPDX license identifiers in source files and dependency manifests to enforce license compatibility.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | GPL / AGPL / SSPL found in a proprietary codebase |
+| High | License is unrecognized or absent |
+| Warning | Weak copyleft (LGPL, MPL) requiring attention |
+
+Blocks because a GPL file in a proprietary repo creates an immediate legal obligation to open-source the product — that cannot be undone by a follow-up PR.
+
+---
+
+## kube-linter
+
+Lints Kubernetes manifests for security misconfigurations before they reach a cluster.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | Container running as root, no CPU/memory limits |
+| High | Missing liveness/readiness probes, privileged container |
+| Warning | Missing recommended labels |
+
+Blocks because root containers and unlimited resources are trivially exploitable for node breakout and denial-of-service; fixing them post-deploy requires a rolling restart under live traffic.
+
+---
+
+## mypy
+
+Runs strict type checking to catch type contract violations at API boundaries before runtime.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | Wrong argument type passed at a public API or service boundary |
+| High | Incompatible method override breaks the base class contract |
+| Warning | Missing type annotation on a public function |
+
+Blocks because a type mismatch at a boundary produces silent data corruption or runtime crashes in callers — catching it statically is always cheaper than tracing it in production.

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -24,16 +24,61 @@ _SEVERITY_WEIGHTS: dict[str, int] = {
     "info": 0,
 }
 
+_SECURITY_PLUGINS: set[str] = {
+    "gitleaks",
+    "semgrep",
+    "trivy",
+    "osv-scanner",
+    "clamav",
+    "supply-chain",
+    "opa",
+    "scancode",
+    "kube-linter",
+    "mypy",
+}
+
+_QUALITY_PLUGINS: set[str] = {
+    "blast-radius",
+    "complexity",
+    "cpd",
+    "cspell",
+    "ls-lint",
+}
+
+
+def _plugin_is_security(plugin_name: str) -> bool:
+    normalized = plugin_name.lower().replace("_", "-")
+    return normalized in _SECURITY_PLUGINS
+
 
 def calculate_severity_score(results: list[PluginResult]) -> float:
-    """Return a 0-100 health score across all plugin findings.
+    """Return a 0-100 health score based on security plugin findings only.
 
-    Formula: max(0, 100 - sum(weight(severity) for each finding))
+    Quality plugins (blast-radius, complexity, cpd, cspell, ls-lint) are
+    excluded from the score — they are advisory, not merge-blocking.
+
+    Formula: max(0, 100 - sum(weight(severity) for each security finding))
     Weights: critical=10, high=5, medium=2, low=1, info=0.
-    Unknown or missing severity keys are treated as info (weight 0).
     """
     total_weight = 0
     for result in results:
+        if not _plugin_is_security(result.plugin_name):
+            continue
+        for finding in result.findings:
+            sev = str(finding.get("severity", "")).lower()
+            total_weight += _SEVERITY_WEIGHTS.get(sev, 0)
+    return max(0.0, min(100.0, 100.0 - total_weight))
+
+
+def calculate_quality_score(results: list[PluginResult]) -> float:
+    """Return a 0-100 quality score based on quality plugin findings only.
+
+    Advisory — does not gate merges. Reported alongside the security score.
+    """
+    total_weight = 0
+    for result in results:
+        if _plugin_is_security(result.plugin_name):
+            continue
         for finding in result.findings:
             sev = str(finding.get("severity", "")).lower()
             total_weight += _SEVERITY_WEIGHTS.get(sev, 0)
@@ -75,6 +120,7 @@ def _build_monorepo_sections(
     for pkg_root, pkg_results in packages.items():
         pkg_verdict, pkg_rows, pkg_finding_sections = _build_sections(pkg_results, plugin_renderers)
         pkg_score = calculate_severity_score(pkg_results)
+        pkg_quality = calculate_quality_score(pkg_results)
 
         if _verdict_rank(pkg_verdict) > _verdict_rank(overall_verdict):
             overall_verdict = pkg_verdict
@@ -82,7 +128,7 @@ def _build_monorepo_sections(
         header = pkg_root if pkg_root else "(root)"
         pkg_lines: list[str] = [
             f"## {header}",
-            f"> Score: {int(pkg_score)}/100",
+            f"> Security: {int(pkg_score)}/100 · Quality: {int(pkg_quality)}/100",
             "",
             "| Plugin | Findings |",
             "|--------|----------|",
@@ -96,7 +142,12 @@ def _build_monorepo_sections(
                 pkg_lines.append(fs)
 
         sections.append("\n".join(pkg_lines))
-        summary_rows.append((header, f"{pkg_verdict.upper()} (Score: {int(pkg_score)}/100)"))
+        summary_rows.append(
+            (
+                header,
+                f"{pkg_verdict.upper()} (Sec: {int(pkg_score)} · Qual: {int(pkg_quality)})",
+            )
+        )
 
     return overall_verdict, summary_rows, sections
 
@@ -124,6 +175,7 @@ def render_comment(
         verdict, summary_rows, sections = _build_sections(results, plugin_renderers)
 
     severity_score = calculate_severity_score(results)
+    quality_score = calculate_quality_score(results)
     mi_grade, mi_score, mi_icon, avg_ccn, hi_ccn, mi_c_count = _extract_mi(results)
 
     footer_parts = []
@@ -144,6 +196,7 @@ def render_comment(
         summary_rows=summary_rows,
         sections=sections,
         severity_score=severity_score,
+        quality_score=quality_score,
         mi_grade=mi_grade,
         mi_score=mi_score,
         mi_icon=mi_icon,

--- a/src/eedom/templates/comment.md.j2
+++ b/src/eedom/templates/comment.md.j2
@@ -11,8 +11,8 @@
 > 🟢 **ALL CLEAR**
 {% endif %}
 
-{% if severity_score is not none and severity_score < 100 %}
-> **Health Score: {{ severity_score | int }}/100**
+{% if severity_score is not none %}
+> **Security: {{ severity_score | int }}/100** · Quality: {{ quality_score | int }}/100
 {% endif %}
 {% if mi_grade %}
 > **Maintainability: {{ mi_icon }} {{ mi_grade }} ({{ mi_score }}/100)** · CCN avg {{ avg_ccn }}{% if hi_ccn %} · ⚠️ {{ hi_ccn }} high-complexity{% endif %}{% if mi_c_count %} · 🔴 {{ mi_c_count }} grade-C{% endif %}

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -332,7 +332,20 @@ class TestCalculateSeverityScore:
         ]
         assert calculate_severity_score(results) == 100.0
 
-    def test_score_shown_in_comment_when_below_100(self):
+    def test_quality_plugins_excluded_from_security_score(self):
+        results = [
+            PluginResult(
+                plugin_name="blast-radius",
+                findings=[{"severity": "critical"} for _ in range(100)],
+            ),
+            PluginResult(
+                plugin_name="complexity",
+                findings=[{"severity": "high"} for _ in range(50)],
+            ),
+        ]
+        assert calculate_severity_score(results) == 100.0
+
+    def test_score_shown_in_comment_with_security_and_quality(self):
         results = [
             PluginResult(
                 plugin_name="osv-scanner",
@@ -340,9 +353,10 @@ class TestCalculateSeverityScore:
             )
         ]
         md = render_comment(results, repo="org/repo", pr_num=1, title="test")
-        assert "Health Score: 90/100" in md
+        assert "Security: 90/100" in md
+        assert "Quality:" in md
 
-    def test_score_not_shown_in_comment_when_100(self):
+    def test_score_shown_even_when_100(self):
         results = [PluginResult(plugin_name="osv-scanner", findings=[])]
         md = render_comment(results, repo="org/repo", pr_num=1, title="test")
-        assert "Health Score" not in md
+        assert "Security: 100/100" in md


### PR DESCRIPTION
## Summary

Security plugins gate merges. Quality plugins advise.

### Security (gates merges)
gitleaks, semgrep, trivy, osv-scanner, clamav, supply-chain, opa, scancode, kube-linter, mypy

### Quality (advisory)
blast-radius, complexity, cpd, cspell, ls-lint

### Changes
- `calculate_severity_score()` now only counts security plugin findings
- New `calculate_quality_score()` for quality plugins
- Template shows both: "Security: 90/100 · Quality: 45/100"
- A repo with 0 security findings no longer scores BLOCKED because of blast-radius counts

### Tests
- 24 passed including new `test_quality_plugins_excluded_from_security_score`

🤖 Generated with [Claude Code](https://claude.com/claude-code)