### PR TITLE
feat: cfn-nag + cdk-nag plugins — AWS CloudFormation/CDK security

### DIFF
--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -324,7 +324,7 @@ def review(
                             files.append(str(full))
             return files
         files = []
-        for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml"):
+        for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json"):
             files.extend(
                 str(p)
                 for p in repo.rglob(ext)

--- a/src/eedom/plugins/_runners/cdk_nag_runner.py
+++ b/src/eedom/plugins/_runners/cdk_nag_runner.py
@@ -24,7 +24,8 @@ def run_cdk_nag(
     """Run cdk-nag against a CDK project.
 
     Two-step process:
-    1. If ``cdk.out/`` doesn't exist, run ``cdk synth --quiet`` to generate templates.
+    1. Always run ``cdk synth --quiet`` to generate fresh templates. Stale
+       ``cdk.out/`` is never used — new code changes would be silently missed.
     2. Scan all ``*.template.json`` files in ``cdk.out/`` using ``cfn_nag_scan``.
     """
     from eedom.core.errors import ErrorCode, error_msg
@@ -32,31 +33,30 @@ def run_cdk_nag(
     rp = Path(repo_path)
     cdk_out = rp / "cdk.out"
 
-    if not cdk_out.exists():
-        try:
-            result = subprocess.run(
-                ["cdk", "synth", "--quiet"],
-                capture_output=True,
-                text=True,
-                timeout=synth_timeout,
-                cwd=repo_path,
-                check=False,
-            )
-            if result.returncode != 0:
-                stderr = result.stderr.strip()
-                logger.warning("cdk_nag.synth_failed", returncode=result.returncode, stderr=stderr)
-                return {
-                    "findings": [],
-                    "error": f"cdk synth failed (exit {result.returncode}): {stderr}",
-                }
-        except FileNotFoundError:
-            msg = error_msg(ErrorCode.NOT_INSTALLED, "cdk")
-            logger.warning("cdk_nag.cdk_not_installed", error=msg)
-            return {"findings": [], "error": msg}
-        except subprocess.TimeoutExpired:
-            msg = error_msg(ErrorCode.TIMEOUT, "cdk", timeout=synth_timeout)
-            logger.warning("cdk_nag.synth_timeout", error=msg)
-            return {"findings": [], "error": msg}
+    try:
+        result = subprocess.run(
+            ["cdk", "synth", "--quiet"],
+            capture_output=True,
+            text=True,
+            timeout=synth_timeout,
+            cwd=repo_path,
+            check=False,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            logger.warning("cdk_nag.synth_failed", returncode=result.returncode, stderr=stderr)
+            return {
+                "findings": [],
+                "error": f"cdk synth failed (exit {result.returncode}): {stderr}",
+            }
+    except FileNotFoundError:
+        msg = error_msg(ErrorCode.NOT_INSTALLED, "cdk")
+        logger.warning("cdk_nag.cdk_not_installed", error=msg)
+        return {"findings": [], "error": msg}
+    except subprocess.TimeoutExpired:
+        msg = error_msg(ErrorCode.TIMEOUT, "cdk", timeout=synth_timeout)
+        logger.warning("cdk_nag.synth_timeout", error=msg)
+        return {"findings": [], "error": msg}
 
     templates = list(cdk_out.glob("*.template.json"))
     if not templates:

--- a/src/eedom/plugins/_runners/cdk_nag_runner.py
+++ b/src/eedom/plugins/_runners/cdk_nag_runner.py
@@ -1,0 +1,127 @@
+"""cdk-nag subprocess runner — synths CDK app then scans templates with cfn_nag_scan."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_SEVERITY_MAP = {
+    "FAIL": "critical",
+    "WARN": "warning",
+}
+
+
+def run_cdk_nag(
+    repo_path: str,
+    synth_timeout: int = 120,
+    scan_timeout: int = 60,
+) -> dict:
+    """Run cdk-nag against a CDK project.
+
+    Two-step process:
+    1. If ``cdk.out/`` doesn't exist, run ``cdk synth --quiet`` to generate templates.
+    2. Scan all ``*.template.json`` files in ``cdk.out/`` using ``cfn_nag_scan``.
+    """
+    from eedom.core.errors import ErrorCode, error_msg
+
+    rp = Path(repo_path)
+    cdk_out = rp / "cdk.out"
+
+    if not cdk_out.exists():
+        try:
+            result = subprocess.run(
+                ["cdk", "synth", "--quiet"],
+                capture_output=True,
+                text=True,
+                timeout=synth_timeout,
+                cwd=repo_path,
+                check=False,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                logger.warning("cdk_nag.synth_failed", returncode=result.returncode, stderr=stderr)
+                return {
+                    "findings": [],
+                    "error": f"cdk synth failed (exit {result.returncode}): {stderr}",
+                }
+        except FileNotFoundError:
+            msg = error_msg(ErrorCode.NOT_INSTALLED, "cdk")
+            logger.warning("cdk_nag.cdk_not_installed", error=msg)
+            return {"findings": [], "error": msg}
+        except subprocess.TimeoutExpired:
+            msg = error_msg(ErrorCode.TIMEOUT, "cdk", timeout=synth_timeout)
+            logger.warning("cdk_nag.synth_timeout", error=msg)
+            return {"findings": [], "error": msg}
+
+    templates = list(cdk_out.glob("*.template.json"))
+    if not templates:
+        logger.info("cdk_nag.no_templates", cdk_out=str(cdk_out))
+        return {"findings": [], "files_scanned": 0}
+
+    all_findings: list[dict] = []
+
+    for template in templates:
+        cmd = ["cfn_nag_scan", "--input-path", str(template), "--output-format", "json"]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=scan_timeout,
+                cwd=repo_path,
+                check=False,
+            )
+            if result.stdout:
+                file_findings = _parse_output(result.stdout, str(template))
+                all_findings.extend(file_findings)
+        except FileNotFoundError:
+            msg = error_msg(ErrorCode.NOT_INSTALLED, "cfn_nag_scan")
+            logger.warning("cdk_nag.cfn_nag_not_installed", error=msg)
+            return {"findings": [], "error": msg}
+        except subprocess.TimeoutExpired:
+            msg = error_msg(ErrorCode.TIMEOUT, "cfn_nag_scan", timeout=scan_timeout)
+            logger.warning("cdk_nag.scan_timeout", error=msg)
+            return {"findings": [], "error": msg}
+        except Exception:
+            msg = error_msg(ErrorCode.BINARY_CRASHED, "cfn_nag_scan", exit_code=-1)
+            logger.exception("cdk_nag.scan_failed")
+            return {"findings": [], "error": msg}
+
+    return {
+        "findings": all_findings,
+        "files_scanned": len(templates),
+        "finding_count": len(all_findings),
+    }
+
+
+def _parse_output(stdout: str, default_file: str) -> list[dict]:
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return []
+
+    findings: list[dict] = []
+    for file_result in data:
+        filename = file_result.get("filename", default_file)
+        violations = file_result.get("file_results", {}).get("violations", [])
+        for v in violations:
+            violation_type = v.get("type", "WARN")
+            severity = _SEVERITY_MAP.get(violation_type, "warning")
+            line_numbers = v.get("line_numbers", [])
+            line = line_numbers[0] if line_numbers else 0
+            findings.append(
+                {
+                    "rule_id": v.get("id", ""),
+                    "severity": severity,
+                    "message": v.get("message", ""),
+                    "file": filename,
+                    "line": line,
+                    "logical_resource_ids": v.get("logical_resource_ids", []),
+                }
+            )
+    return findings

--- a/src/eedom/plugins/_runners/cfn_nag_runner.py
+++ b/src/eedom/plugins/_runners/cfn_nag_runner.py
@@ -36,6 +36,31 @@ def run_cfn_nag(
                 cwd=repo_path,
                 check=False,
             )
+            if result.returncode != 0:
+                # cfn-nag exits non-zero both when it finds violations (stdout
+                # contains valid JSON) and when it crashes (empty / garbled
+                # stdout).  Only the crash case is an error.
+                stdout_is_valid_json = False
+                if result.stdout:
+                    try:
+                        json.loads(result.stdout)
+                        stdout_is_valid_json = True
+                    except json.JSONDecodeError:
+                        pass
+                if not stdout_is_valid_json:
+                    from eedom.core.errors import ErrorCode, error_msg
+
+                    msg = error_msg(
+                        ErrorCode.BINARY_CRASHED,
+                        "cfn-nag",
+                        exit_code=result.returncode,
+                    )
+                    logger.warning(
+                        "cfn_nag.crashed",
+                        error=msg,
+                        returncode=result.returncode,
+                    )
+                    return {"error": msg, "findings": []}
             if result.stdout:
                 file_findings = _parse_output(result.stdout, file_path)
                 findings.extend(file_findings)

--- a/src/eedom/plugins/_runners/cfn_nag_runner.py
+++ b/src/eedom/plugins/_runners/cfn_nag_runner.py
@@ -1,0 +1,93 @@
+"""cfn-nag subprocess runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_SEVERITY_MAP = {
+    "FAIL": "critical",
+    "WARN": "warning",
+}
+
+
+def run_cfn_nag(
+    cfn_files: list[str],
+    repo_path: str,
+    timeout: int = 60,
+) -> dict:
+    if not cfn_files:
+        return {"findings": [], "files_scanned": 0}
+
+    findings: list[dict] = []
+
+    for file_path in cfn_files:
+        cmd = ["cfn_nag_scan", "--input-path", file_path, "--output-format", "json"]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=repo_path,
+                check=False,
+            )
+            if result.stdout:
+                file_findings = _parse_output(result.stdout, file_path)
+                findings.extend(file_findings)
+        except FileNotFoundError:
+            from eedom.core.errors import ErrorCode, error_msg
+
+            msg = error_msg(ErrorCode.NOT_INSTALLED, "cfn-nag")
+            logger.warning("cfn_nag.not_installed", error=msg)
+            raise
+        except subprocess.TimeoutExpired:
+            from eedom.core.errors import ErrorCode, error_msg
+
+            msg = error_msg(ErrorCode.TIMEOUT, "cfn-nag", timeout=timeout)
+            logger.warning("cfn_nag.timeout", error=msg)
+            raise
+        except Exception:
+            from eedom.core.errors import ErrorCode, error_msg
+
+            msg = error_msg(ErrorCode.BINARY_CRASHED, "cfn-nag", exit_code=-1)
+            logger.exception("cfn_nag.failed")
+            raise
+
+    return {
+        "findings": findings,
+        "files_scanned": len(cfn_files),
+        "finding_count": len(findings),
+    }
+
+
+def _parse_output(stdout: str, default_file: str) -> list[dict]:
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return []
+
+    findings: list[dict] = []
+    for file_result in data:
+        filename = file_result.get("filename", default_file)
+        violations = file_result.get("file_results", {}).get("violations", [])
+        for v in violations:
+            violation_type = v.get("type", "WARN")
+            severity = _SEVERITY_MAP.get(violation_type, "warning")
+            line_numbers = v.get("line_numbers", [])
+            line = line_numbers[0] if line_numbers else 0
+            findings.append(
+                {
+                    "rule_id": v.get("id", ""),
+                    "severity": severity,
+                    "message": v.get("message", ""),
+                    "file": filename,
+                    "line": line,
+                    "logical_resource_ids": v.get("logical_resource_ids", []),
+                }
+            )
+    return findings

--- a/src/eedom/plugins/cdk_nag.py
+++ b/src/eedom/plugins/cdk_nag.py
@@ -1,0 +1,58 @@
+"""cdk-nag plugin — CDK CloudFormation security scanning.
+# tested-by: tests/unit/test_cdk_nag_plugin.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
+from eedom.plugins._runners.cdk_nag_runner import run_cdk_nag as _run
+
+
+class CdkNagPlugin(ScannerPlugin):
+    @property
+    def name(self) -> str:
+        return "cdk-nag"
+
+    @property
+    def description(self) -> str:
+        return "CDK security — validates synthesized CloudFormation against AWS best practices"
+
+    @property
+    def category(self) -> PluginCategory:
+        return PluginCategory.infra
+
+    def can_run(self, files: list[str], repo_path: Path) -> bool:
+        return (repo_path / "cdk.json").exists() or (repo_path / "cdk.out").is_dir()
+
+    def run(self, files: list[str], repo_path: Path) -> PluginResult:
+        try:
+            data = _run(str(repo_path))
+        except Exception as exc:
+            return PluginResult(plugin_name=self.name, error=str(exc))
+
+        return PluginResult(
+            plugin_name=self.name,
+            findings=data.get("findings", []),
+            summary={"total": data.get("finding_count", 0)},
+            error=data.get("error", ""),
+        )
+
+    def _render_inline(self, result: PluginResult) -> str:
+        if result.error:
+            return f"**cdk-nag**: {result.error}"
+        if not result.findings:
+            return ""
+        lines = ["<details open>"]
+        lines.append(f"<summary>☁️ <b>CDK/CloudFormation ({len(result.findings)})</b></summary>\n")
+        for f in result.findings[:15]:
+            severity_icon = "🔴" if f.get("severity") == "critical" else "🟡"
+            lines.append(f"{severity_icon} **{f.get('rule_id', '?')}** — `{f.get('file', '?')}`")
+            lines.append(f"> {f.get('message', '')[:200]}")
+            resources = f.get("logical_resource_ids", [])
+            if resources:
+                lines.append(f"> Resources: `{'`, `'.join(resources[:5])}`")
+            lines.append("")
+        lines.append("</details>\n")
+        return "\n".join(lines)

--- a/src/eedom/plugins/cfn_nag.py
+++ b/src/eedom/plugins/cfn_nag.py
@@ -1,0 +1,92 @@
+"""cfn-nag plugin — CloudFormation template security scanning.
+# tested-by: tests/unit/test_cfn_nag_plugin.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
+from eedom.plugins._runners.cfn_nag_runner import run_cfn_nag as _run
+
+
+class CfnNagPlugin(ScannerPlugin):
+    @property
+    def name(self) -> str:
+        return "cfn-nag"
+
+    @property
+    def description(self) -> str:
+        return (
+            "CloudFormation security — IAM wildcards, open security groups, unencrypted resources"
+        )
+
+    @property
+    def category(self) -> PluginCategory:
+        return PluginCategory.infra
+
+    @staticmethod
+    def _resolve(f: str, repo_path: Path) -> Path:
+        p = Path(f)
+        return p if p.is_absolute() else repo_path / f
+
+    def _is_cfn(self, f: str, repo_path: Path) -> bool:
+        p = self._resolve(f, repo_path)
+        if p.suffix not in (".json", ".yaml", ".yml") or not p.exists():
+            return False
+        try:
+            content = p.read_text(errors="ignore")[:500]
+            return "AWSTemplateFormatVersion" in content or "Resources" in content
+        except OSError:
+            return False
+
+    def can_run(self, files: list[str], repo_path: Path) -> bool:
+        return any(self._is_cfn(f, repo_path) for f in files)
+
+    def run(self, files: list[str], repo_path: Path) -> PluginResult:
+        cfn_files = [f for f in files if self._is_cfn(f, repo_path)]
+
+        if not cfn_files:
+            return PluginResult(plugin_name=self.name, summary={"status": "skipped"})
+
+        try:
+            data = _run(cfn_files, str(repo_path))
+        except FileNotFoundError:
+            from eedom.core.errors import ErrorCode, error_msg
+
+            return PluginResult(
+                plugin_name=self.name,
+                error=error_msg(ErrorCode.NOT_INSTALLED, "cfn-nag"),
+            )
+        except subprocess.TimeoutExpired:
+            from eedom.core.errors import ErrorCode, error_msg
+
+            return PluginResult(
+                plugin_name=self.name,
+                error=error_msg(ErrorCode.TIMEOUT, "cfn-nag", timeout=60),
+            )
+        except Exception as exc:
+            return PluginResult(plugin_name=self.name, error=str(exc))
+
+        return PluginResult(
+            plugin_name=self.name,
+            findings=data.get("findings", []),
+            summary={"total": data.get("finding_count", 0)},
+            error=data.get("error", ""),
+        )
+
+    def _render_inline(self, result: PluginResult) -> str:
+        if result.error:
+            return f"**cfn-nag**: {result.error}"
+        if not result.findings:
+            return ""
+        lines = ["<details open>"]
+        lines.append(f"<summary>☁️ <b>CloudFormation ({len(result.findings)})</b></summary>\n")
+        for f in result.findings[:15]:
+            severity_icon = "🔴" if f.get("severity") == "critical" else "🟡"
+            lines.append(f"{severity_icon} **{f.get('rule_id', '?')}** — `{f.get('file', '?')}`")
+            lines.append(f"> {f.get('message', '')[:200]}")
+            lines.append("")
+        lines.append("</details>\n")
+        return "\n".join(lines)

--- a/tests/unit/test_cdk_nag_plugin.py
+++ b/tests/unit/test_cdk_nag_plugin.py
@@ -98,10 +98,19 @@ class TestCdkNagPlugin:
         template = cdk_out / "MyStack.template.json"
         template.write_text("{}")
 
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = CFN_NAG_OUTPUT
-        mock_run.return_value = mock_result
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            result = MagicMock()
+            if "synth" in cmd:
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            else:
+                result.returncode = 0
+                result.stdout = CFN_NAG_OUTPUT
+            return result
+
+        mock_run.side_effect = side_effect
 
         p = CdkNagPlugin()
         result = p.run([], tmp_path)
@@ -114,10 +123,13 @@ class TestCdkNagPlugin:
         assert result.findings[1]["rule_id"] == "W35"
         assert result.summary["total"] == 2
 
-        # cfn_nag_scan called, not cdk synth
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
-        assert "cfn_nag_scan" in cmd
+        # synth always called first, then cfn_nag_scan
+        assert mock_run.call_count == 2
+        first_cmd = mock_run.call_args_list[0][0][0]
+        assert "cdk" in first_cmd
+        assert "synth" in first_cmd
+        second_cmd = mock_run.call_args_list[1][0][0]
+        assert "cfn_nag_scan" in second_cmd
 
     @patch(f"{RUNNER_PATH}.subprocess.run")
     def test_run_triggers_cdk_synth_when_no_cdk_out(self, mock_run, tmp_path):
@@ -181,12 +193,22 @@ class TestCdkNagPlugin:
     def test_cfn_nag_not_installed(self, tmp_path):
         from eedom.plugins.cdk_nag import CdkNagPlugin
 
-        # cdk.out exists → skip synth, go straight to cfn_nag_scan → FileNotFoundError
+        # synth succeeds, then cfn_nag_scan raises FileNotFoundError
         cdk_out = tmp_path / "cdk.out"
         cdk_out.mkdir()
         (cdk_out / "MyStack.template.json").write_text("{}")
 
-        with patch(f"{RUNNER_PATH}.subprocess.run", side_effect=FileNotFoundError):
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if "synth" in cmd:
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+                return result
+            raise FileNotFoundError
+
+        with patch(f"{RUNNER_PATH}.subprocess.run", side_effect=side_effect):
             p = CdkNagPlugin()
             result = p.run([], tmp_path)
             assert "NOT_INSTALLED" in result.error
@@ -207,14 +229,22 @@ class TestCdkNagPlugin:
     def test_cfn_nag_scan_timeout(self, tmp_path):
         from eedom.plugins.cdk_nag import CdkNagPlugin
 
+        # synth succeeds, then cfn_nag_scan times out
         cdk_out = tmp_path / "cdk.out"
         cdk_out.mkdir()
         (cdk_out / "MyStack.template.json").write_text("{}")
 
-        with patch(
-            f"{RUNNER_PATH}.subprocess.run",
-            side_effect=subprocess.TimeoutExpired("cfn_nag_scan", 60),
-        ):
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if "synth" in cmd:
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+                return result
+            raise subprocess.TimeoutExpired("cfn_nag_scan", 60)
+
+        with patch(f"{RUNNER_PATH}.subprocess.run", side_effect=side_effect):
             p = CdkNagPlugin()
             result = p.run([], tmp_path)
             assert "TIMEOUT" in result.error
@@ -240,6 +270,57 @@ class TestCdkNagPlugin:
         assert result.summary["total"] == 0
 
     @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_synth_always_called_even_when_cdk_out_exists(self, mock_run, tmp_path):
+        """Synth must run even when cdk.out/ already exists — stale output guard."""
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        (cdk_out / "MyStack.template.json").write_text("{}")
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            result = MagicMock()
+            if "synth" in cmd:
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            else:
+                result.returncode = 0
+                result.stdout = CFN_NAG_OUTPUT
+            return result
+
+        mock_run.side_effect = side_effect
+
+        p = CdkNagPlugin()
+        p.run([], tmp_path)
+
+        assert mock_run.call_count == 2
+        first_cmd = mock_run.call_args_list[0][0][0]
+        assert "cdk" in first_cmd
+        assert "synth" in first_cmd
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_synth_failure_with_existing_cdk_out_returns_error(self, mock_run, tmp_path):
+        """Synth failure must return an error even when stale cdk.out/ exists."""
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        (cdk_out / "MyStack.template.json").write_text("{}")
+
+        synth_result = MagicMock()
+        synth_result.returncode = 1
+        synth_result.stderr = "Synthesis failed — missing context"
+        mock_run.return_value = synth_result
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error != ""
+        assert len(result.findings) == 0
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
     def test_no_templates_in_cdk_out(self, mock_run, tmp_path):
         from eedom.plugins.cdk_nag import CdkNagPlugin
 
@@ -247,9 +328,18 @@ class TestCdkNagPlugin:
         cdk_out.mkdir()
         # No .template.json files
 
+        synth_result = MagicMock()
+        synth_result.returncode = 0
+        synth_result.stdout = ""
+        synth_result.stderr = ""
+        mock_run.return_value = synth_result
+
         p = CdkNagPlugin()
         result = p.run([], tmp_path)
 
         assert result.error == ""
         assert result.findings == []
-        mock_run.assert_not_called()
+        # synth is called, but cfn_nag_scan is never reached (no templates)
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "synth" in cmd

--- a/tests/unit/test_cdk_nag_plugin.py
+++ b/tests/unit/test_cdk_nag_plugin.py
@@ -1,0 +1,255 @@
+"""Tests for cdk-nag plugin.
+# tested-by: tests/unit/test_cdk_nag_plugin.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from eedom.core.plugin import PluginCategory
+
+RUNNER_PATH = "eedom.plugins._runners.cdk_nag_runner"
+
+CFN_NAG_OUTPUT = json.dumps(
+    [
+        {
+            "filename": "cdk.out/MyStack.template.json",
+            "file_results": {
+                "violations": [
+                    {
+                        "type": "FAIL",
+                        "id": "W28",
+                        "message": "Resource found with an explicit name",
+                        "logical_resource_ids": ["MyBucket"],
+                        "line_numbers": [10],
+                    },
+                    {
+                        "type": "WARN",
+                        "id": "W35",
+                        "message": "S3 Bucket should have access logging configured",
+                        "logical_resource_ids": ["MyBucket"],
+                        "line_numbers": [15],
+                    },
+                ],
+                "failure_count": 1,
+            },
+        }
+    ]
+)
+
+CLEAN_OUTPUT = json.dumps(
+    [
+        {
+            "filename": "cdk.out/MyStack.template.json",
+            "file_results": {"violations": [], "failure_count": 0},
+        }
+    ]
+)
+
+
+class TestCdkNagPlugin:
+    def test_name(self):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        p = CdkNagPlugin()
+        assert p.name == "cdk-nag"
+
+    def test_description(self):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        p = CdkNagPlugin()
+        assert "CDK" in p.description
+        assert "CloudFormation" in p.description
+
+    def test_category(self):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        p = CdkNagPlugin()
+        assert p.category == PluginCategory.infra
+
+    def test_can_run_with_cdk_json(self, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        (tmp_path / "cdk.json").write_text("{}")
+        p = CdkNagPlugin()
+        assert p.can_run([], tmp_path) is True
+
+    def test_can_run_with_cdk_out_dir(self, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        (tmp_path / "cdk.out").mkdir()
+        p = CdkNagPlugin()
+        assert p.can_run([], tmp_path) is True
+
+    def test_cannot_run_without_cdk_files(self, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        p = CdkNagPlugin()
+        assert p.can_run([], tmp_path) is False
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_run_with_existing_cdk_out(self, mock_run, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        template = cdk_out / "MyStack.template.json"
+        template.write_text("{}")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = CFN_NAG_OUTPUT
+        mock_run.return_value = mock_result
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error == ""
+        assert len(result.findings) == 2
+        assert result.findings[0]["severity"] == "critical"
+        assert result.findings[0]["rule_id"] == "W28"
+        assert result.findings[1]["severity"] == "warning"
+        assert result.findings[1]["rule_id"] == "W35"
+        assert result.summary["total"] == 2
+
+        # cfn_nag_scan called, not cdk synth
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "cfn_nag_scan" in cmd
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_run_triggers_cdk_synth_when_no_cdk_out(self, mock_run, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        (tmp_path / "cdk.json").write_text("{}")
+
+        def synth_side_effect(*args, **kwargs):
+            cmd = args[0]
+            result = MagicMock()
+            if "synth" in cmd:
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+                cdk_out = tmp_path / "cdk.out"
+                cdk_out.mkdir(exist_ok=True)
+                (cdk_out / "MyStack.template.json").write_text("{}")
+            else:
+                result.returncode = 0
+                result.stdout = CFN_NAG_OUTPUT
+            return result
+
+        mock_run.side_effect = synth_side_effect
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error == ""
+        assert mock_run.call_count == 2
+        first_cmd = mock_run.call_args_list[0][0][0]
+        assert "cdk" in first_cmd
+        assert "synth" in first_cmd
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_cdk_synth_failure_returns_error(self, mock_run, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        (tmp_path / "cdk.json").write_text("{}")
+
+        synth_result = MagicMock()
+        synth_result.returncode = 1
+        synth_result.stderr = "Error: Cannot find module 'aws-cdk-lib'"
+        mock_run.return_value = synth_result
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error != ""
+        assert len(result.findings) == 0
+
+    @patch(f"{RUNNER_PATH}.subprocess.run", side_effect=FileNotFoundError)
+    def test_cdk_not_installed(self, _mock, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        # No cdk.out → will attempt cdk synth → FileNotFoundError
+        (tmp_path / "cdk.json").write_text("{}")
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+        assert "NOT_INSTALLED" in result.error
+
+    def test_cfn_nag_not_installed(self, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        # cdk.out exists → skip synth, go straight to cfn_nag_scan → FileNotFoundError
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        (cdk_out / "MyStack.template.json").write_text("{}")
+
+        with patch(f"{RUNNER_PATH}.subprocess.run", side_effect=FileNotFoundError):
+            p = CdkNagPlugin()
+            result = p.run([], tmp_path)
+            assert "NOT_INSTALLED" in result.error
+
+    def test_cdk_synth_timeout(self, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        (tmp_path / "cdk.json").write_text("{}")
+
+        with patch(
+            f"{RUNNER_PATH}.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("cdk", 120),
+        ):
+            p = CdkNagPlugin()
+            result = p.run([], tmp_path)
+            assert "TIMEOUT" in result.error
+
+    def test_cfn_nag_scan_timeout(self, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        (cdk_out / "MyStack.template.json").write_text("{}")
+
+        with patch(
+            f"{RUNNER_PATH}.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("cfn_nag_scan", 60),
+        ):
+            p = CdkNagPlugin()
+            result = p.run([], tmp_path)
+            assert "TIMEOUT" in result.error
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_clean_scan_no_findings(self, mock_run, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        (cdk_out / "MyStack.template.json").write_text("{}")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = CLEAN_OUTPUT
+        mock_run.return_value = mock_result
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error == ""
+        assert len(result.findings) == 0
+        assert result.summary["total"] == 0
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_no_templates_in_cdk_out(self, mock_run, tmp_path):
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        # No .template.json files
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error == ""
+        assert result.findings == []
+        mock_run.assert_not_called()

--- a/tests/unit/test_cfn_nag_plugin.py
+++ b/tests/unit/test_cfn_nag_plugin.py
@@ -8,9 +8,8 @@ import json
 import subprocess
 from unittest.mock import patch
 
-from eedom.plugins.cfn_nag import CfnNagPlugin
-
 from eedom.core.plugin import PluginCategory
+from eedom.plugins.cfn_nag import CfnNagPlugin
 
 # Realistic cfn-nag JSON output with one FAIL and one WARN
 CFN_NAG_OUTPUT = json.dumps(
@@ -229,3 +228,35 @@ class TestCfnNagPluginRun:
 
         assert "total" in result.summary
         assert result.summary["total"] == 2
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_crashed_with_empty_stdout_returns_error(self, mock_run, tmp_path):
+        """Non-zero exit + empty stdout must report an error, not a clean scan."""
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = "cfn_nag_scan: command failed"
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert "BINARY_CRASHED" in result.error
+        assert result.findings == []
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_crashed_with_invalid_json_returns_error(self, mock_run, tmp_path):
+        """Non-zero exit + non-JSON stdout must report an error, not a clean scan."""
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = "Traceback (most recent call last):\n  RuntimeError: boom"
+        mock_run.return_value.stderr = ""
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert "BINARY_CRASHED" in result.error
+        assert result.findings == []

--- a/tests/unit/test_cfn_nag_plugin.py
+++ b/tests/unit/test_cfn_nag_plugin.py
@@ -1,0 +1,231 @@
+"""Tests for cfn-nag plugin.
+# tested-by: tests/unit/test_cfn_nag_plugin.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+from eedom.plugins.cfn_nag import CfnNagPlugin
+
+from eedom.core.plugin import PluginCategory
+
+# Realistic cfn-nag JSON output with one FAIL and one WARN
+CFN_NAG_OUTPUT = json.dumps(
+    [
+        {
+            "filename": "template.yaml",
+            "file_results": {
+                "security_groups": [],
+                "violations": [
+                    {
+                        "id": "F3",
+                        "type": "FAIL",
+                        "message": "IAM role should not allow * action on its permissions policy",
+                        "logical_resource_ids": ["MyRole"],
+                        "line_numbers": [10],
+                    },
+                    {
+                        "id": "W9",
+                        "type": "WARN",
+                        "message": "Security Groups found with ingress cidr that is not /32 or /128",
+                        "logical_resource_ids": ["MySG"],
+                        "line_numbers": [25],
+                    },
+                ],
+            },
+        }
+    ]
+)
+
+CFN_NAG_CLEAN_OUTPUT = json.dumps(
+    [
+        {
+            "filename": "template.yaml",
+            "file_results": {
+                "security_groups": [],
+                "violations": [],
+            },
+        }
+    ]
+)
+
+
+class TestCfnNagPluginProperties:
+    def test_name(self):
+        p = CfnNagPlugin()
+        assert p.name == "cfn-nag"
+
+    def test_description(self):
+        p = CfnNagPlugin()
+        assert "CloudFormation" in p.description or "cfn" in p.description.lower()
+
+    def test_category_is_infra(self):
+        p = CfnNagPlugin()
+        assert p.category == PluginCategory.infra
+
+
+class TestCfnNagPluginCanRun:
+    def test_can_run_yaml_cfn_template(self, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+        p = CfnNagPlugin()
+        assert p.can_run([str(template)], tmp_path) is True
+
+    def test_can_run_json_cfn_template(self, tmp_path):
+        template = tmp_path / "template.json"
+        template.write_text(json.dumps({"AWSTemplateFormatVersion": "2010-09-09", "Resources": {}}))
+        p = CfnNagPlugin()
+        assert p.can_run([str(template)], tmp_path) is True
+
+    def test_can_run_yml_extension(self, tmp_path):
+        template = tmp_path / "stack.yml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+        p = CfnNagPlugin()
+        assert p.can_run([str(template)], tmp_path) is True
+
+    def test_cannot_run_non_cfn_yaml(self, tmp_path):
+        manifest = tmp_path / "docker-compose.yaml"
+        manifest.write_text("version: '3'\nservices:\n  web:\n    image: nginx\n")
+        p = CfnNagPlugin()
+        assert p.can_run([str(manifest)], tmp_path) is False
+
+    def test_cannot_run_python_file(self, tmp_path):
+        pyfile = tmp_path / "app.py"
+        pyfile.write_text("print('hello')\n")
+        p = CfnNagPlugin()
+        assert p.can_run([str(pyfile)], tmp_path) is False
+
+    def test_can_run_with_resources_marker(self, tmp_path):
+        """File with only 'Resources:' (no AWSTemplateFormatVersion) still qualifies."""
+        template = tmp_path / "partial.yaml"
+        template.write_text("Resources:\n  MyBucket:\n    Type: AWS::S3::Bucket\n")
+        p = CfnNagPlugin()
+        assert p.can_run([str(template)], tmp_path) is True
+
+    def test_cannot_run_empty_file_list(self, tmp_path):
+        p = CfnNagPlugin()
+        assert p.can_run([], tmp_path) is False
+
+    def test_can_run_nonexistent_file(self, tmp_path):
+        """Nonexistent file cannot be verified as CFN — returns False."""
+        p = CfnNagPlugin()
+        assert p.can_run([str(tmp_path / "ghost.yaml")], tmp_path) is False
+
+
+class TestCfnNagPluginRun:
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_findings_parsed_correctly(self, mock_run, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = CFN_NAG_OUTPUT
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert result.error == ""
+        assert len(result.findings) == 2
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_fail_type_maps_to_critical_severity(self, mock_run, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = CFN_NAG_OUTPUT
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        fail_findings = [f for f in result.findings if f.get("rule_id") == "F3"]
+        assert len(fail_findings) == 1
+        assert fail_findings[0]["severity"] == "critical"
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_warn_type_maps_to_warning_severity(self, mock_run, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = CFN_NAG_OUTPUT
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        warn_findings = [f for f in result.findings if f.get("rule_id") == "W9"]
+        assert len(warn_findings) == 1
+        assert warn_findings[0]["severity"] == "warning"
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_finding_has_message_and_file(self, mock_run, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = CFN_NAG_OUTPUT
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        f0 = result.findings[0]
+        assert "message" in f0
+        assert "file" in f0
+        assert f0["message"] != ""
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_clean_scan_no_findings(self, mock_run, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = CFN_NAG_CLEAN_OUTPUT
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert result.error == ""
+        assert len(result.findings) == 0
+
+    @patch(
+        "eedom.plugins._runners.cfn_nag_runner.subprocess.run",
+        side_effect=FileNotFoundError,
+    )
+    def test_not_installed_error(self, _mock, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert "NOT_INSTALLED" in result.error
+
+    @patch(
+        "eedom.plugins._runners.cfn_nag_runner.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="cfn_nag_scan", timeout=60),
+    )
+    def test_timeout_error(self, _mock, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert "TIMEOUT" in result.error
+
+    @patch("eedom.plugins._runners.cfn_nag_runner.subprocess.run")
+    def test_summary_contains_totals(self, mock_run, tmp_path):
+        template = tmp_path / "template.yaml"
+        template.write_text("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n")
+
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = CFN_NAG_OUTPUT
+
+        p = CfnNagPlugin()
+        result = p.run([str(template)], tmp_path)
+
+        assert "total" in result.summary
+        assert result.summary["total"] == 2

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -815,6 +815,39 @@ class TestReviewRepoConfigWiring:
         assert "--package" in result.output
 
 
+class TestBuildFileListJsonDiscovery:
+    """Verify _build_file_list includes .json files in --all mode (issue #55)."""
+
+    _REG_PATCH = "eedom.cli.main.get_default_registry"
+
+    def test_json_cfn_template_appears_in_file_list(self, tmp_path: Path) -> None:
+        """A .json file in the repo is included in the files passed to run_all.
+
+        cfn-nag's can_run() filters non-CFN JSON internally, so the discovery
+        layer must not exclude .json by extension.
+        """
+        (tmp_path / "template.json").write_text(
+            '{"AWSTemplateFormatVersion": "2010-09-09", "Resources": {}}'
+        )
+
+        mock_registry = MagicMock()
+        mock_registry.run_all.return_value = []
+        mock_registry.list.return_value = []
+
+        with patch(self._REG_PATCH, return_value=mock_registry):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["review", "--all", "--repo-path", str(tmp_path)])
+
+        assert result.exit_code == 0
+        call_args = mock_registry.run_all.call_args
+        files: list[str] = (
+            call_args.args[0] if call_args.args else call_args.kwargs.get("files", [])
+        )
+        assert any(
+            "template.json" in f for f in files
+        ), f"Expected template.json in file list but got: {files}"
+
+
 class TestReviewPRMode:
     """Tests for --pr inline review posting mode."""
 


### PR DESCRIPTION
## Summary

Two new infra security plugins for AWS infrastructure-as-code:

### cfn-nag (STORM)
Scans CloudFormation templates for security misconfigurations — IAM wildcards, open security groups, unencrypted resources, public S3 buckets.

### cdk-nag (HAWK)  
Scans CDK synthesized output — runs `cdk synth` then `cfn_nag_scan` on the generated templates. Catches issues before they reach CloudFormation.

### Implementation
- Plugin class + subprocess runner + tests per plugin (same pattern as kube-linter)
- Both category: `infra` (security, gates merges)
- 34 tests, all green
- Handles NOT_INSTALLED, TIMEOUT, parse errors gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)