### PR TITLE
fix: container build — LICENSE + local tag

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -59,6 +59,7 @@ jobs:
           $ENGINE build \
             --tag "$TAG" \
             --tag "$TAG_LATEST" \
+            --tag "eedom:latest" \
             --label "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             .

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --target=/opt/pysite "scancode-toolkit==${SCANCODE_VERSION}"
 
 # eedom itself — invalidated when src/ changes
+COPY LICENSE ./
 COPY src/ src/
 COPY policies/ policies/
 COPY migrations/ migrations/


### PR DESCRIPTION
## Summary
- Add `COPY LICENSE ./` to Dockerfile — hatchling metadata validation requires it (`license = {file = "LICENSE"}` in pyproject.toml). This has been breaking every build-container.yml run.
- Add `--tag "eedom:latest"` to build-container.yml so the gatekeeper workflow can find the image. Previously only tagged with `ghcr.io/` prefix, which didn't match `podman image exists eedom:latest`.

## Test plan
- [ ] build-container.yml workflow succeeds after merge
- [ ] Gatekeeper detects local `eedom:latest` on next PR
- [ ] Plugins run in container without crashing (stale image replaced)