### PR TITLE
fix(docker): copy README.md into build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --target=/opt/pysite "scancode-toolkit==${SCANCODE_VERSION}"
 
 # eedom itself — invalidated when src/ changes
-COPY LICENSE ./
+COPY LICENSE README.md ./
 COPY src/ src/
 COPY policies/ policies/
 COPY migrations/ migrations/


### PR DESCRIPTION
## Summary

- hatchling validates `pyproject.toml` `readme` field during `pip install --target=/opt/pysite .`
- `README.md` was not copied into the build stage, causing: `OSError: Readme file does not exist: README.md`
- Same class of bug as the LICENSE fix in PR #99 — merged both into a single `COPY LICENSE README.md ./` line

## Context

Build run [24975426844](https://github.com/gitrdunhq/eedom/actions/runs/24975426844) failed at step 23 (`pip install --target=/opt/pysite .`) with this error. Demo is 2026-04-28 — need a working container image.

## Test plan

- [ ] Build-container workflow passes after merge
- [ ] `eedom:latest` image created with local tag on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)