### PR TITLE
fix: exclude cdk.out/ from discovery + add .json to watch mode

### DIFF
--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -20,7 +20,9 @@ logger = structlog.get_logger()
 # ---------------------------------------------------------------------------
 # Watch-mode constants
 # ---------------------------------------------------------------------------
-_WATCH_EXTENSIONS: frozenset[str] = frozenset({".py", ".ts", ".js", ".tf", ".yaml", ".yml"})
+_WATCH_EXTENSIONS: frozenset[str] = frozenset(
+    {".py", ".ts", ".js", ".tf", ".yaml", ".yml", ".json"}
+)
 _IGNORE_DIRS: frozenset[str] = frozenset({"__pycache__", ".git", ".eedom", ".dogfood"})
 
 

--- a/src/eedom/core/ignore.py
+++ b/src/eedom/core/ignore.py
@@ -25,7 +25,7 @@ DEFAULT_PATTERNS: list[str] = [
     ".venv/",
     ".claude/",
     ".eedom/",
-
+    "cdk.out/",
 ]
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -815,6 +815,15 @@ class TestReviewRepoConfigWiring:
         assert "--package" in result.output
 
 
+class TestWatchExtensionsIncludesJson:
+    """Watch mode must detect .json file changes (issue #81)."""
+
+    def test_json_in_watch_extensions(self) -> None:
+        from eedom.cli.main import _WATCH_EXTENSIONS
+
+        assert ".json" in _WATCH_EXTENSIONS
+
+
 class TestBuildFileListJsonDiscovery:
     """Verify _build_file_list includes .json files in --all mode (issue #55)."""
 

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from eedom.core.ignore import DEFAULT_PATTERNS, load_ignore_patterns, should_ignore
 
 # ---------------------------------------------------------------------------
@@ -185,3 +186,26 @@ class TestShouldIgnoreEdgeCases:
     def test_default_patterns_do_not_exclude_source_files(self, path: str) -> None:
         """Default patterns must not exclude ordinary source files."""
         assert should_ignore(path, DEFAULT_PATTERNS) is False
+
+
+# ---------------------------------------------------------------------------
+# cdk.out exclusion — issue #81
+# ---------------------------------------------------------------------------
+
+
+class TestCdkOutExclusion:
+    """cdk.out/ must be excluded by DEFAULT_PATTERNS to prevent double-scanning."""
+
+    def test_cdk_out_in_default_patterns(self) -> None:
+        assert "cdk.out/" in DEFAULT_PATTERNS
+
+    def test_cdk_out_template_excluded(self) -> None:
+        assert should_ignore("cdk.out/MyStack.template.json", DEFAULT_PATTERNS) is True
+
+    def test_cdk_out_nested_excluded(self) -> None:
+        assert (
+            should_ignore("cdk.out/assembly-Prod/MyStack.template.json", DEFAULT_PATTERNS) is True
+        )
+
+    def test_cdk_out_manifest_excluded(self) -> None:
+        assert should_ignore("cdk.out/manifest.json", DEFAULT_PATTERNS) is True


### PR DESCRIPTION
## Summary

Closes #81 (W1-C), closes #71.

- **cdk.out/ double-scan**: `_build_file_list()` collected synthesized CloudFormation templates from `cdk.out/`, which cfn-nag then scanned redundantly alongside cdk-nag's internal handling. Added `cdk.out/` to `DEFAULT_PATTERNS` in `ignore.py`.
- **Watch mode blind to .json**: `_WATCH_EXTENSIONS` was missing `.json`, so editing a JSON CloudFormation template didn't trigger a re-scan. Added `.json` to the frozenset.

## Test plan

- [x] 5 new tests (TDD red-green confirmed)
- [x] Full unit suite: 1011 passed, 0 failures
- [ ] Gatekeeper CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)