### PR TITLE
fix: expand default ignore patterns — build artifacts, IDE, agent state

### DIFF
--- a/src/eedom/core/ignore.py
+++ b/src/eedom/core/ignore.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import fnmatch
 from pathlib import Path
 
+_GLOB_CHARS = frozenset("*?[")
+
 # ---------------------------------------------------------------------------
 # Built-in defaults — always applied even without a .eedomignore file.
 # These mirror the hard-coded exclusion sets already present in cli/main.py.
@@ -23,9 +25,19 @@ DEFAULT_PATTERNS: list[str] = [
     "__pycache__/",
     "node_modules/",
     ".venv/",
+    "venv/",
     ".claude/",
     ".eedom/",
+    ".dogfood/",
     "cdk.out/",
+    "build/",
+    "dist/",
+    "*.egg-info/",
+    ".temp/",
+    ".tox/",
+    ".idea/",
+    ".vscode/",
+    "htmlcov/",
 ]
 
 
@@ -89,10 +101,13 @@ def should_ignore(file_path: str, patterns: list[str]) -> bool:
 
     for pattern in patterns:
         if pattern.endswith("/"):
-            # Multi- or single-component directory pattern.  The trailing "/"
-            # is preserved so the match always ends at a directory boundary.
-            if ("/" + pattern) in anchored:
-                return True
+            dir_pat = pattern[:-1]
+            if _GLOB_CHARS & set(dir_pat):
+                if any(fnmatch.fnmatch(part, dir_pat) for part in anchored.split("/")):
+                    return True
+            else:
+                if ("/" + pattern) in anchored:
+                    return True
         else:
             if fnmatch.fnmatch(file_path, pattern):
                 return True

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -209,3 +209,48 @@ class TestCdkOutExclusion:
 
     def test_cdk_out_manifest_excluded(self) -> None:
         assert should_ignore("cdk.out/manifest.json", DEFAULT_PATTERNS) is True
+
+
+# ---------------------------------------------------------------------------
+# Expanded default ignore patterns — issue #85
+# ---------------------------------------------------------------------------
+
+
+class TestExpandedDefaultPatterns:
+    """DEFAULT_PATTERNS must exclude build artifacts, agent state, and IDE dirs."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "build/lib/module.py",
+            "dist/package.tar.gz",
+            "my_pkg.egg-info/PKG-INFO",
+            ".dogfood/fleet-state.json",
+            ".temp/scratch.txt",
+            ".idea/workspace.xml",
+            ".vscode/settings.json",
+            "htmlcov/index.html",
+            "venv/lib/python3.12/site.py",
+            ".tox/py312/lib/x.py",
+        ],
+    )
+    def test_generated_paths_excluded(self, path: str) -> None:
+        assert should_ignore(path, DEFAULT_PATTERNS) is True
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "build/",
+            "dist/",
+            "*.egg-info/",
+            ".dogfood/",
+            ".temp/",
+            ".idea/",
+            ".vscode/",
+            "htmlcov/",
+            "venv/",
+            ".tox/",
+        ],
+    )
+    def test_pattern_in_defaults(self, pattern: str) -> None:
+        assert pattern in DEFAULT_PATTERNS


### PR DESCRIPTION
## Summary

Closes #85 (W2-A), closes #57.

- Added 10 new patterns to `DEFAULT_PATTERNS`: `build/`, `dist/`, `*.egg-info/`, `.dogfood/`, `.temp/`, `venv/`, `.tox/`, `.idea/`, `.vscode/`, `htmlcov/`
- Extended `should_ignore()` to support glob characters in directory patterns (e.g. `*.egg-info/`) — previously only literal substring matching was used for trailing-`/` patterns
- Reduces false positives from scanning build artifacts, IDE config, and agent state directories

## Test plan

- [x] 20 new parametrized tests (TDD red-green confirmed)
- [x] Full unit suite: 1031 passed, 0 failures
- [ ] Gatekeeper CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)