### PR TITLE
fix: render report sections security-first by category priority

### DIFF
--- a/src/eedom/core/plugin.py
+++ b/src/eedom/core/plugin.py
@@ -29,6 +29,7 @@ class PluginResult:
     summary: dict = field(default_factory=dict)
     error: str = ""
     package_root: str | None = None
+    category: str = ""
 
 
 class ScannerPlugin(abc.ABC):

--- a/src/eedom/core/registry.py
+++ b/src/eedom/core/registry.py
@@ -193,20 +193,24 @@ class PluginRegistry:
         repo_path: Path,
         findings: list[dict],
     ) -> PluginResult:
+        cat = plugin.category.value
         if not plugin.can_run(files, repo_path):
             return PluginResult(
                 plugin_name=plugin.name,
                 summary={"status": "skipped"},
+                category=cat,
             )
         try:
-            return plugin.run(files, repo_path, findings=findings)
+            result = plugin.run(files, repo_path, findings=findings)
+            result.category = cat
+            return result
         except Exception as exc:
             logger.warning(
                 "plugin.policy_failed",
                 plugin=plugin.name,
                 error=str(exc),
             )
-            return PluginResult(plugin_name=plugin.name, error=str(exc))
+            return PluginResult(plugin_name=plugin.name, error=str(exc), category=cat)
 
     def _run_one(
         self,
@@ -214,20 +218,24 @@ class PluginRegistry:
         files: list[str],
         repo_path: Path,
     ) -> PluginResult:
+        cat = plugin.category.value
         if not plugin.can_run(files, repo_path):
             return PluginResult(
                 plugin_name=plugin.name,
                 summary={"status": "skipped"},
+                category=cat,
             )
         try:
-            return plugin.run(files, repo_path)
+            result = plugin.run(files, repo_path)
+            result.category = cat
+            return result
         except Exception as exc:
             logger.warning(
                 "plugin.run_failed",
                 plugin=plugin.name,
                 error=str(exc),
             )
-            return PluginResult(plugin_name=plugin.name, error=str(exc))
+            return PluginResult(plugin_name=plugin.name, error=str(exc), category=cat)
 
 
 def discover_plugins(plugin_dir: Path) -> list[ScannerPlugin]:

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -13,6 +13,14 @@ import jinja2
 from eedom.core.plugin import PluginResult
 
 _MAX_COMMENT_LENGTH = 65536
+
+CATEGORY_PRIORITY: dict[str, int] = {
+    "supply_chain": 0,
+    "dependency": 1,
+    "infra": 2,
+    "code": 3,
+    "quality": 4,
+}
 _DEFAULT_TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
 _VERSION = "1.2.0"
 
@@ -223,7 +231,13 @@ def _build_sections(
     summary_rows: list[tuple[str, str]] = []
     sections: list[str] = []
 
-    for r in results:
+    _max_priority = max(CATEGORY_PRIORITY.values()) + 1
+    sorted_results = sorted(
+        results,
+        key=lambda r: CATEGORY_PRIORITY.get(r.category, _max_priority),
+    )
+
+    for r in sorted_results:
         count = len(r.findings)
         label = r.plugin_name
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -5,7 +5,13 @@
 from __future__ import annotations
 
 from eedom.core.plugin import PluginResult
-from eedom.core.renderer import _VERSION, calculate_severity_score, render_comment  # noqa: PLC2701
+from eedom.core.renderer import (  # noqa: PLC2701
+    _VERSION,
+    CATEGORY_PRIORITY,
+    _build_sections,
+    calculate_severity_score,
+    render_comment,
+)
 
 
 def _vuln_result() -> PluginResult:
@@ -360,3 +366,65 @@ class TestCalculateSeverityScore:
         results = [PluginResult(plugin_name="osv-scanner", findings=[])]
         md = render_comment(results, repo="org/repo", pr_num=1, title="test")
         assert "Security: 100/100" in md
+
+
+class TestSectionOrdering:
+    """Sections must render security-first regardless of input order (#89)."""
+
+    def test_security_sections_before_quality(self):
+        results = [
+            PluginResult(
+                plugin_name="complexity",
+                findings=[{"severity": "medium", "message": "high complexity"}],
+                category="quality",
+            ),
+            PluginResult(
+                plugin_name="gitleaks",
+                findings=[{"severity": "critical", "message": "leaked secret"}],
+                category="supply_chain",
+            ),
+        ]
+        _, _, sections = _build_sections(results, None)
+        assert len(sections) == 2
+        assert "gitleaks" in sections[0]
+        assert "complexity" in sections[1]
+
+    def test_dependency_before_code(self):
+        results = [
+            PluginResult(
+                plugin_name="semgrep",
+                findings=[{"severity": "medium", "message": "code issue"}],
+                category="code",
+            ),
+            PluginResult(
+                plugin_name="osv-scanner",
+                findings=[{"severity": "high", "message": "CVE found"}],
+                category="dependency",
+            ),
+        ]
+        _, _, sections = _build_sections(results, None)
+        assert len(sections) == 2
+        assert "osv-scanner" in sections[0]
+        assert "semgrep" in sections[1]
+
+    def test_category_priority_map_exists(self):
+        assert "supply_chain" in CATEGORY_PRIORITY
+        assert "dependency" in CATEGORY_PRIORITY
+        assert "quality" in CATEGORY_PRIORITY
+        assert CATEGORY_PRIORITY["supply_chain"] < CATEGORY_PRIORITY["quality"]
+
+    def test_results_without_category_sort_last(self):
+        results = [
+            PluginResult(
+                plugin_name="unknown",
+                findings=[{"severity": "low", "message": "something"}],
+            ),
+            PluginResult(
+                plugin_name="gitleaks",
+                findings=[{"severity": "critical", "message": "secret"}],
+                category="supply_chain",
+            ),
+        ]
+        _, _, sections = _build_sections(results, None)
+        assert len(sections) == 2
+        assert "gitleaks" in sections[0]


### PR DESCRIPTION
## Summary

- Add `category` field to `PluginResult` dataclass, populated by the registry from each plugin's `PluginCategory`
- Sort results in `_build_sections()` by `CATEGORY_PRIORITY` map: supply_chain → dependency → infra → code → quality
- Security-critical findings (gitleaks, osv-scanner, trivy) now always render before advisory quality findings (complexity, cspell)
- Uncategorized results sort last

Closes #89

## Test plan

- [x] `TestSectionOrdering::test_security_sections_before_quality` — supply_chain renders before quality
- [x] `TestSectionOrdering::test_dependency_before_code` — dependency renders before code
- [x] `TestSectionOrdering::test_category_priority_map_exists` — priority map covers all categories
- [x] `TestSectionOrdering::test_results_without_category_sort_last` — uncategorized results sort after all categorized
- [x] Full renderer + registry regression suite (68 tests pass)