### PR TITLE
fix: fail-closed GATEKEEPER — block PRs when scanners crash

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -91,20 +91,40 @@ jobs:
           TOTAL_PLUGINS=0
           if [ -f .temp/review.sarif ]; then
             python3 -c "
-          import json, os
+          import json, os, re
+
           with open('.temp/review.sarif') as f:
               sarif = json.load(f)
           runs = sarif.get('runs', [])
           total = len(runs)
-          errors = sum(1 for r in runs for res in r.get('results', []) if res.get('level') == 'error')
-          warnings = sum(1 for r in runs for res in r.get('results', []) if res.get('level') == 'warning')
-          crashed = sum(1 for r in runs if any(
-              'NOT_INSTALLED' in res.get('message', {}).get('text', '') or
-              'TIMEOUT' in res.get('message', {}).get('text', '') or
-              'Read-only file system' in res.get('message', {}).get('text', '')
-              for res in r.get('results', [])
-          ))
-          crashed += sum(1 for r in runs if len(r.get('results', [])) == 0 and r.get('tool', {}).get('driver', {}).get('name', '') not in ('opa',))
+          errors = 0
+          warnings = 0
+          crashed = 0
+
+          # Primary detection: eedom-plugin-error ruleId (new SARIF format)
+          for r in runs:
+              plugin_errored = False
+              for res in r.get('results', []):
+                  if res.get('ruleId') == 'eedom-plugin-error':
+                      crashed += 1
+                      plugin_errored = True
+                      break
+              if not plugin_errored:
+                  for res in r.get('results', []):
+                      if res.get('level') == 'error':
+                          errors += 1
+                      elif res.get('level') == 'warning':
+                          warnings += 1
+
+          # Fallback: parse review.md for 'error:' lines in the summary table
+          # Works with old container images that don't emit eedom-plugin-error in SARIF
+          if crashed == 0:
+              md_path = '.temp/review.md'
+              if os.path.isfile(md_path):
+                  with open(md_path) as mf:
+                      md = mf.read()
+                  crashed = len(re.findall(r'\| error: ', md))
+
           env_file = '.temp/verdict_env.sh'
           with open(env_file, 'w') as ef:
               ef.write(f'ERRORS={errors}\nWARNINGS={warnings}\nCRASHED={crashed}\nTOTAL={total}\n')
@@ -113,7 +133,7 @@ jobs:
               out.write(f'warnings={warnings}\n')
               out.write(f'crashed={crashed}\n')
               out.write(f'total_plugins={total}\n')
-          " 2>/dev/null || {
+          " || {
               echo "errors=0" >> "$GITHUB_OUTPUT"
               echo "warnings=0" >> "$GITHUB_OUTPUT"
               echo "crashed=0" >> "$GITHUB_OUTPUT"
@@ -126,10 +146,10 @@ jobs:
             . .temp/verdict_env.sh
           fi
 
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "verdict=blocked" >> "$GITHUB_OUTPUT"
-          elif [ "${CRASHED:-0}" -ge 3 ]; then
+          if [ "${CRASHED:-0}" -gt 0 ]; then
             echo "verdict=incomplete" >> "$GITHUB_OUTPUT"
+          elif [ "$ERRORS" -gt 0 ]; then
+            echo "verdict=blocked" >> "$GITHUB_OUTPUT"
           elif [ "$WARNINGS" -gt 0 ]; then
             echo "verdict=warnings" >> "$GITHUB_OUTPUT"
           else
@@ -318,3 +338,15 @@ jobs:
           REPO: ${{ github.repository }}
           RELEASE_UNLOCK_WORD: ${{ secrets.RELEASE_UNLOCK_WORD }}
           KEY_SHA: ${{ github.sha }}
+
+      - name: Fail-closed gate
+        if: always()
+        run: |
+          VERDICT="${{ steps.verdict.outputs.verdict }}"
+          CRASHED="${{ steps.verdict.outputs.crashed }}"
+          ERRORS="${{ steps.verdict.outputs.errors }}"
+
+          if [ "$VERDICT" = "incomplete" ] || [ "$VERDICT" = "blocked" ]; then
+            echo "::error::GATEKEEPER fail-closed — verdict: ${VERDICT} (${CRASHED} crashed, ${ERRORS} errors)"
+            exit 1
+          fi

--- a/src/eedom/core/sarif.py
+++ b/src/eedom/core/sarif.py
@@ -101,6 +101,15 @@ def _plugin_to_run(
             sarif_result["locations"] = locations
         sarif_results.append(sarif_result)
 
+    if result.error:
+        sarif_results.append(
+            {
+                "ruleId": "eedom-plugin-error",
+                "level": "error",
+                "message": {"text": result.error},
+            }
+        )
+
     if truncated > 0:
         sarif_results.append(
             {

--- a/tests/unit/test_sarif.py
+++ b/tests/unit/test_sarif.py
@@ -176,13 +176,17 @@ class TestMultiplePlugins:
         assert names == ["semgrep", "gitleaks"]
 
     def test_error_plugins_still_produce_runs(self) -> None:
-        """Errored plugins still appear as runs with zero results."""
+        """Errored plugins appear as runs with an error-level result."""
         results = [
             PluginResult(plugin_name="semgrep", findings=[], summary={}, error="timeout"),
         ]
         out = to_sarif(results)
         assert len(out["runs"]) == 1
-        assert out["runs"][0]["results"] == []
+        assert len(out["runs"][0]["results"]) == 1
+        err_result = out["runs"][0]["results"][0]
+        assert err_result["level"] == "error"
+        assert "timeout" in err_result["message"]["text"]
+        assert err_result["ruleId"] == "eedom-plugin-error"
 
 
 class TestRuleIdFallbacks:
@@ -423,3 +427,66 @@ class TestFindingCap:
         )
         out = to_sarif([result], max_findings_per_run=0)
         assert len(out["runs"][0]["results"]) == 5000
+
+
+class TestPluginErrorsInSarif:
+    """Plugin errors must be visible in SARIF so downstream consumers can detect failures."""
+
+    def test_not_installed_error_emits_error_result(self) -> None:
+        result = PluginResult(
+            plugin_name="semgrep",
+            findings=[],
+            summary={},
+            error="[NOT_INSTALLED] semgrep not installed",
+        )
+        out = to_sarif([result])
+        run = out["runs"][0]
+        assert len(run["results"]) == 1
+        assert run["results"][0]["level"] == "error"
+        assert "NOT_INSTALLED" in run["results"][0]["message"]["text"]
+
+    def test_timeout_error_emits_error_result(self) -> None:
+        result = PluginResult(
+            plugin_name="scancode",
+            findings=[],
+            summary={},
+            error="[TIMEOUT] scancode timed out after 60s",
+        )
+        out = to_sarif([result])
+        assert out["runs"][0]["results"][0]["level"] == "error"
+        assert "TIMEOUT" in out["runs"][0]["results"][0]["message"]["text"]
+
+    def test_error_result_has_eedom_plugin_error_rule_id(self) -> None:
+        result = PluginResult(
+            plugin_name="blast-radius",
+            findings=[],
+            summary={},
+            error="unable to open database file",
+        )
+        out = to_sarif([result])
+        assert out["runs"][0]["results"][0]["ruleId"] == "eedom-plugin-error"
+
+    def test_error_plus_findings_emits_both(self) -> None:
+        """A plugin that partially ran before erroring keeps its findings + error."""
+        result = PluginResult(
+            plugin_name="trivy",
+            findings=[{"id": "CVE-1", "severity": "high", "summary": "vuln"}],
+            summary={},
+            error="scan interrupted",
+        )
+        out = to_sarif([result])
+        results = out["runs"][0]["results"]
+        assert len(results) == 2
+        levels = {r["level"] for r in results}
+        assert "error" in levels
+
+    def test_clean_plugin_zero_findings_no_error_result(self) -> None:
+        """A plugin that ran cleanly with 0 findings must NOT emit an error result."""
+        result = PluginResult(
+            plugin_name="gitleaks",
+            findings=[],
+            summary={},
+            error="",
+        )
+        out = to_sarif([result])
+        assert out["runs"][0]["results"] == []


### PR DESCRIPTION
## Summary

- **SARIF now emits plugin errors**: when a scanner fails (NOT_INSTALLED, TIMEOUT, crash), `sarif.py` emits an `eedom-plugin-error` result at `error` level — previously errored plugins produced empty `results: []`, identical to clean scans
- **Fixed crash detection**: GATEKEEPER now detects crashed plugins via `eedom-plugin-error` ruleId instead of broken NOT_INSTALLED text search on empty arrays + false-positive 0-results count
- **Fail-closed gate**: any crashed or blocked verdict exits non-zero, failing the required GitHub status check — PRs cannot merge with broken scanners
- **Removed crash threshold**: previously needed 3+ crashed plugins for `incomplete`; now any single crashed plugin blocks
- **Removed `2>/dev/null`**: crash detection errors were silently swallowed

### What was broken

Every PR we merged was scanned by a container with **17/18 plugins crashed**. The GATEKEEPER still reported `success` because:
1. SARIF encoded errored plugins identically to clean plugins (`results: []`)
2. Crash detection searched for `NOT_INSTALLED` text inside empty arrays (never matches)
3. Fallback counted ANY 0-result plugin as crashed — including clean scans like gitleaks, trivy
4. Even with 17 crashes detected, threshold was `>= 3` for `incomplete` which didn't fail the check

## Test plan

- [x] `TestPluginErrorsInSarif` — 5 new tests (NOT_INSTALLED, TIMEOUT, error+findings, clean scan)
- [x] Updated `test_error_plugins_still_produce_runs` — asserts error result instead of empty
- [x] Full unit suite: 1040 passed, 0 failures
- [ ] CI on this PR should report `incomplete` verdict and **FAIL** (proving fail-closed works)