### PR TITLE
fix: fail-closed GATEKEEPER + install all 18 scanner deps in container

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -71,7 +71,7 @@ jobs:
             -v "$GITHUB_WORKSPACE:/workspace:ro" \
             -v "$GITHUB_WORKSPACE/.temp:/workspace/.temp" \
             eedom:latest \
-            sh -c "set -e && eedom review --repo-path /workspace --all --format sarif --output /workspace/.temp/review.sarif && eedom review --repo-path /workspace --all --output /workspace/.temp/review.md"
+            sh -c "set -e && freshclam --quiet 2>/dev/null || true && eedom review --repo-path /workspace --all --format sarif --output /workspace/.temp/review.sarif && eedom review --repo-path /workspace --all --output /workspace/.temp/review.md"
         env:
           ENGINE: ${{ steps.runtime.outputs.engine }}
 
@@ -91,20 +91,40 @@ jobs:
           TOTAL_PLUGINS=0
           if [ -f .temp/review.sarif ]; then
             python3 -c "
-          import json, os
+          import json, os, re
+
           with open('.temp/review.sarif') as f:
               sarif = json.load(f)
           runs = sarif.get('runs', [])
           total = len(runs)
-          errors = sum(1 for r in runs for res in r.get('results', []) if res.get('level') == 'error')
-          warnings = sum(1 for r in runs for res in r.get('results', []) if res.get('level') == 'warning')
-          crashed = sum(1 for r in runs if any(
-              'NOT_INSTALLED' in res.get('message', {}).get('text', '') or
-              'TIMEOUT' in res.get('message', {}).get('text', '') or
-              'Read-only file system' in res.get('message', {}).get('text', '')
-              for res in r.get('results', [])
-          ))
-          crashed += sum(1 for r in runs if len(r.get('results', [])) == 0 and r.get('tool', {}).get('driver', {}).get('name', '') not in ('opa',))
+          errors = 0
+          warnings = 0
+          crashed = 0
+
+          # Primary detection: eedom-plugin-error ruleId (new SARIF format)
+          for r in runs:
+              plugin_errored = False
+              for res in r.get('results', []):
+                  if res.get('ruleId') == 'eedom-plugin-error':
+                      crashed += 1
+                      plugin_errored = True
+                      break
+              if not plugin_errored:
+                  for res in r.get('results', []):
+                      if res.get('level') == 'error':
+                          errors += 1
+                      elif res.get('level') == 'warning':
+                          warnings += 1
+
+          # Fallback: parse review.md for 'error:' lines in the summary table
+          # Works with old container images that don't emit eedom-plugin-error in SARIF
+          if crashed == 0:
+              md_path = '.temp/review.md'
+              if os.path.isfile(md_path):
+                  with open(md_path) as mf:
+                      md = mf.read()
+                  crashed = len(re.findall(r'\| error: ', md))
+
           env_file = '.temp/verdict_env.sh'
           with open(env_file, 'w') as ef:
               ef.write(f'ERRORS={errors}\nWARNINGS={warnings}\nCRASHED={crashed}\nTOTAL={total}\n')
@@ -113,7 +133,7 @@ jobs:
               out.write(f'warnings={warnings}\n')
               out.write(f'crashed={crashed}\n')
               out.write(f'total_plugins={total}\n')
-          " 2>/dev/null || {
+          " || {
               echo "errors=0" >> "$GITHUB_OUTPUT"
               echo "warnings=0" >> "$GITHUB_OUTPUT"
               echo "crashed=0" >> "$GITHUB_OUTPUT"
@@ -126,10 +146,10 @@ jobs:
             . .temp/verdict_env.sh
           fi
 
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "verdict=blocked" >> "$GITHUB_OUTPUT"
-          elif [ "${CRASHED:-0}" -ge 3 ]; then
+          if [ "${CRASHED:-0}" -gt 0 ]; then
             echo "verdict=incomplete" >> "$GITHUB_OUTPUT"
+          elif [ "$ERRORS" -gt 0 ]; then
+            echo "verdict=blocked" >> "$GITHUB_OUTPUT"
           elif [ "$WARNINGS" -gt 0 ]; then
             echo "verdict=warnings" >> "$GITHUB_OUTPUT"
           else
@@ -318,3 +338,15 @@ jobs:
           REPO: ${{ github.repository }}
           RELEASE_UNLOCK_WORD: ${{ secrets.RELEASE_UNLOCK_WORD }}
           KEY_SHA: ${{ github.sha }}
+
+      - name: Fail-closed gate
+        if: always()
+        run: |
+          VERDICT="${{ steps.verdict.outputs.verdict }}"
+          CRASHED="${{ steps.verdict.outputs.crashed }}"
+          ERRORS="${{ steps.verdict.outputs.errors }}"
+
+          if [ "$VERDICT" = "incomplete" ] || [ "$VERDICT" = "blocked" ]; then
+            echo "::error::GATEKEEPER fail-closed — verdict: ${VERDICT} (${CRASHED} crashed, ${ERRORS} errors)"
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@
 #
 # Build:  podman build --platform linux/arm64 -t eedom:latest .
 # Test:   EEDOM_IMAGE=eedom:latest uv run pytest tests/integration/test_dockerfile.py -v
-#
-# Architecture: linux/arm64 (default). Override with --platform linux/amd64 and
-# pass matching SHA256 ARGs for amd64 binaries.
 
 # ── Version pins ─────────────────────────────────────────────────────────────
 ARG SYFT_VERSION=1.21.0
@@ -14,129 +11,124 @@ ARG OSV_VERSION=2.0.1
 ARG OPA_VERSION=1.4.2
 ARG GITLEAKS_VERSION=8.24.3
 ARG JQ_VERSION=1.7.1
+ARG KUBE_LINTER_VERSION=0.8.3
 ARG SEMGREP_VERSION=1.67.0
 ARG SCANCODE_VERSION=32.3.0
+ARG PMD_VERSION=7.24.0
+ARG LIZARD_VERSION=1.17.13
+ARG MYPY_VERSION=1.15.0
+ARG CSPELL_VERSION=8.18.1
 
-# ── SHA256 checksums — linux/arm64 ───────────────────────────────────────────
-# Covers the downloaded archive or raw binary (pre-extraction).
+# ── SHA256 checksums — per architecture ──────────────────────────────────────
 # Build fails hard if any hash mismatches — no silent pass.
-ARG SYFT_SHA256=b7617868459cb707e4f9f56c8cb121124bf90b2c944f30e2f3c773807e1e05d7
-ARG TRIVY_SHA256=2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d
-ARG OSV_SHA256=9ce9c96e3ae4526f8e077e6b456bc82bb2070abd5bbfac966a8dbbbb93a50fd2
-ARG OPA_SHA256=facd6a9ea375c6299701f86b90b470e52305c5726c4f136e2980fa6123ae9613
-ARG GITLEAKS_SHA256=5f2edbe1f49f7b920f9e06e90759947d3c5dfc16f752fb93aaafc17e9d14cf07
-ARG JQ_SHA256=4dd2d8a0661df0b22f1bb9a1f9830f06b6f3b8f7d91211a1ef5d7c4f06a8b4a5
+# PMD is architecture-independent (Java).
+ARG SYFT_SHA256_ARM64=b7617868459cb707e4f9f56c8cb121124bf90b2c944f30e2f3c773807e1e05d7
+ARG TRIVY_SHA256_ARM64=2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d
+ARG OSV_SHA256_ARM64=9ce9c96e3ae4526f8e077e6b456bc82bb2070abd5bbfac966a8dbbbb93a50fd2
+ARG OPA_SHA256_ARM64=facd6a9ea375c6299701f86b90b470e52305c5726c4f136e2980fa6123ae9613
+ARG GITLEAKS_SHA256_ARM64=5f2edbe1f49f7b920f9e06e90759947d3c5dfc16f752fb93aaafc17e9d14cf07
+ARG JQ_SHA256_ARM64=4dd2d8a0661df0b22f1bb9a1f9830f06b6f3b8f7d91211a1ef5d7c4f06a8b4a5
+ARG KUBE_LINTER_SHA256_ARM64=802e1b09eabd08f6f0a060a6b8ab2bf7bc7e6bf4f673bb2692303704c84b3e22
+ARG PMD_SHA256=110934b36d39c19094d1b77386931978093f238f2c2f1851748822b69c7367ac
+
+# AMD64 checksums — populate when adding amd64 support
+ARG SYFT_SHA256_AMD64=PLACEHOLDER
+ARG TRIVY_SHA256_AMD64=PLACEHOLDER
+ARG OSV_SHA256_AMD64=PLACEHOLDER
+ARG OPA_SHA256_AMD64=PLACEHOLDER
+ARG GITLEAKS_SHA256_AMD64=PLACEHOLDER
+ARG JQ_SHA256_AMD64=PLACEHOLDER
+ARG KUBE_LINTER_SHA256_AMD64=PLACEHOLDER
 
 # ════════════════════════════════════════════════════════════════════════════
-# Stage 1: builder — installs everything; produces clean staged artifacts
+# Stage 1: builder
 # ════════════════════════════════════════════════════════════════════════════
-FROM python:3.14-slim-bookworm AS builder
+FROM python:3.12-slim-bookworm AS builder
 
-ARG SYFT_VERSION TRIVY_VERSION OSV_VERSION OPA_VERSION GITLEAKS_VERSION JQ_VERSION
-ARG SYFT_SHA256 TRIVY_SHA256 OSV_SHA256 OPA_SHA256 GITLEAKS_SHA256 JQ_SHA256
-ARG SEMGREP_VERSION SCANCODE_VERSION
+ARG SYFT_VERSION TRIVY_VERSION OSV_VERSION OPA_VERSION GITLEAKS_VERSION JQ_VERSION KUBE_LINTER_VERSION PMD_VERSION
+ARG SYFT_SHA256_ARM64 TRIVY_SHA256_ARM64 OSV_SHA256_ARM64 OPA_SHA256_ARM64 GITLEAKS_SHA256_ARM64 JQ_SHA256_ARM64 KUBE_LINTER_SHA256_ARM64 PMD_SHA256
+ARG SYFT_SHA256_AMD64 TRIVY_SHA256_AMD64 OSV_SHA256_AMD64 OPA_SHA256_AMD64 GITLEAKS_SHA256_AMD64 JQ_SHA256_AMD64 KUBE_LINTER_SHA256_AMD64
+ARG SEMGREP_VERSION SCANCODE_VERSION LIZARD_VERSION MYPY_VERSION CSPELL_VERSION
+ARG TARGETARCH
 
-# Build-time system packages (not carried into runtime image)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates \
-      pkg-config libicu-dev \
-      gcc g++ python3-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-# Staging directories
-RUN mkdir -p /staging/gobin /staging/jq /staging/scripts
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates unzip pkg-config libicu-dev gcc g++ python3-dev
 
-# ── Static Go binaries ────────────────────────────────────────────────────────
+RUN mkdir -p /staging/gobin /staging/jq /staging/pmd /staging/scripts
 
-# Syft — SBOM generation
-RUN curl -sSfL -o /tmp/syft.tar.gz \
-      "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_arm64.tar.gz" \
-    && echo "${SYFT_SHA256}  /tmp/syft.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/syft.tar.gz -C /staging/gobin syft \
-    && rm /tmp/syft.tar.gz \
-    && chmod +x /staging/gobin/syft
+# ── All Go/native binaries — single layer, arch-aware ────────────────────────
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        "amd64") \
+            SYFT_ARCH="amd64";       SYFT_SHA="${SYFT_SHA256_AMD64}"; \
+            TRIVY_ARCH="64bit";      TRIVY_SHA="${TRIVY_SHA256_AMD64}"; \
+            OSV_ARCH="amd64";        OSV_SHA="${OSV_SHA256_AMD64}"; \
+            OPA_ARCH="amd64_static"; OPA_SHA="${OPA_SHA256_AMD64}"; \
+            GITLEAKS_ARCH="x64";     GITLEAKS_SHA="${GITLEAKS_SHA256_AMD64}"; \
+            JQ_ARCH="amd64";         JQ_SHA="${JQ_SHA256_AMD64}"; \
+            KL_ARCH="amd64";         KL_SHA="${KUBE_LINTER_SHA256_AMD64}" ;; \
+        "arm64") \
+            SYFT_ARCH="arm64";       SYFT_SHA="${SYFT_SHA256_ARM64}"; \
+            TRIVY_ARCH="ARM64";      TRIVY_SHA="${TRIVY_SHA256_ARM64}"; \
+            OSV_ARCH="arm64";        OSV_SHA="${OSV_SHA256_ARM64}"; \
+            OPA_ARCH="arm64_static"; OPA_SHA="${OPA_SHA256_ARM64}"; \
+            GITLEAKS_ARCH="arm64";   GITLEAKS_SHA="${GITLEAKS_SHA256_ARM64}"; \
+            JQ_ARCH="arm64";         JQ_SHA="${JQ_SHA256_ARM64}"; \
+            KL_ARCH="arm64";         KL_SHA="${KUBE_LINTER_SHA256_ARM64}" ;; \
+        *) echo "Fatal: unsupported architecture ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -sSfL -o /tmp/syft.tar.gz "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${SYFT_ARCH}.tar.gz"; \
+    echo "${SYFT_SHA}  /tmp/syft.tar.gz" | sha256sum --strict -c -; \
+    tar -xzf /tmp/syft.tar.gz -C /staging/gobin syft; \
+    curl -sSfL -o /tmp/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz"; \
+    echo "${TRIVY_SHA}  /tmp/trivy.tar.gz" | sha256sum --strict -c -; \
+    tar -xzf /tmp/trivy.tar.gz -C /staging/gobin trivy; \
+    curl -sSfL -o /staging/gobin/osv-scanner "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_${OSV_ARCH}"; \
+    echo "${OSV_SHA}  /staging/gobin/osv-scanner" | sha256sum --strict -c -; \
+    curl -sSfL -o /staging/gobin/opa "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_${OPA_ARCH}"; \
+    echo "${OPA_SHA}  /staging/gobin/opa" | sha256sum --strict -c -; \
+    curl -sSfL -o /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GITLEAKS_ARCH}.tar.gz"; \
+    echo "${GITLEAKS_SHA}  /tmp/gitleaks.tar.gz" | sha256sum --strict -c -; \
+    tar -xzf /tmp/gitleaks.tar.gz -C /staging/gobin gitleaks; \
+    curl -sSfL -o /tmp/kube-linter.tar.gz "https://github.com/stackrox/kube-linter/releases/download/v${KUBE_LINTER_VERSION}/kube-linter-linux_${KL_ARCH}.tar.gz"; \
+    echo "${KL_SHA}  /tmp/kube-linter.tar.gz" | sha256sum --strict -c -; \
+    tar -xzf /tmp/kube-linter.tar.gz -C /staging/gobin kube-linter; \
+    curl -sSfL -o /tmp/pmd.zip "https://github.com/pmd/pmd/releases/download/pmd_releases/${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip"; \
+    echo "${PMD_SHA256}  /tmp/pmd.zip" | sha256sum --strict -c -; \
+    unzip -q /tmp/pmd.zip -d /staging/pmd; \
+    curl -sSfL -o /staging/jq/jq "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-${JQ_ARCH}"; \
+    echo "${JQ_SHA}  /staging/jq/jq" | sha256sum --strict -c -; \
+    rm -f /tmp/*.tar.gz /tmp/*.zip; \
+    chmod +x /staging/gobin/* /staging/jq/jq
 
-# Trivy — vulnerability scanning
-RUN curl -sSfL -o /tmp/trivy.tar.gz \
-      "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz" \
-    && echo "${TRIVY_SHA256}  /tmp/trivy.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/trivy.tar.gz -C /staging/gobin trivy \
-    && rm /tmp/trivy.tar.gz \
-    && chmod +x /staging/gobin/trivy
-
-# OSV-Scanner — OSV vulnerability database
-RUN curl -sSfL -o /staging/gobin/osv-scanner \
-      "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_arm64" \
-    && echo "${OSV_SHA256}  /staging/gobin/osv-scanner" | sha256sum -c - \
-    && chmod +x /staging/gobin/osv-scanner
-
-# OPA — policy engine (explicitly static build)
-RUN curl -sSfL -o /staging/gobin/opa \
-      "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_arm64_static" \
-    && echo "${OPA_SHA256}  /staging/gobin/opa" | sha256sum -c - \
-    && chmod +x /staging/gobin/opa
-
-# Gitleaks — secret detection
-RUN curl -sSfL -o /tmp/gitleaks.tar.gz \
-      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz" \
-    && echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/gitleaks.tar.gz -C /staging/gobin gitleaks \
-    && rm /tmp/gitleaks.tar.gz \
-    && chmod +x /staging/gobin/gitleaks
-
-# jq — static binary (official GitHub release, no shared libs)
-RUN curl -sSfL -o /staging/jq/jq \
-      "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-arm64" \
-    && echo "${JQ_SHA256}  /staging/jq/jq" | sha256sum -c - \
-    && chmod +x /staging/jq/jq
-
-# ── Generate checksums.txt with final container paths ────────────────────────
-# sha256sum is run against the staged binaries; paths are rewritten to match
-# where COPY puts them in stage 2. verify-checksums.sh uses this at runtime.
-RUN for b in syft trivy osv-scanner opa gitleaks; do \
+# ── Build-time checksums for runtime verification ────────────────────────────
+RUN for b in syft trivy osv-scanner opa gitleaks kube-linter; do \
       sha256sum "/staging/gobin/$b" | sed "s|/staging/gobin/$b|/usr/local/bin/$b|"; \
     done > /staging/scripts/checksums.txt \
-    && sha256sum /staging/jq/jq \
-         | sed 's|/staging/jq/jq|/usr/bin/jq|' \
-         >> /staging/scripts/checksums.txt
+    && sha256sum /staging/jq/jq | sed 's|/staging/jq/jq|/usr/bin/jq|' >> /staging/scripts/checksums.txt
 
-# ── Python packages ───────────────────────────────────────────────────────────
-# Install to /opt/pysite (--target isolates from system Python).
-# Layer ordering: deps first (cached) → source last (invalidates on src change).
-
+# ── Python packages ──────────────────────────────────────────────────────────
+# pip --target isolates from system Python. Deps first (cached), source last.
+#
+# TODO(#115): Replace inline pins with `pip install --require-hashes -r requirements.lock`
+#             generated via `uv pip compile --generate-hashes`. Delete the inline block below.
 WORKDIR /opt/eedom
-COPY pyproject.toml ./
 
-# Runtime deps — cached until pyproject.toml changes
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --target=/opt/pysite \
-      click==8.3.3 \
-      "pydantic==2.13.3" \
-      "pydantic-settings==2.14.0" \
-      "structlog==25.5.0" \
-      "httpx==0.28.1" \
-      "psycopg[binary]==3.3.3" \
-      "psycopg-pool==3.3.0" \
-      "orjson==3.11.8" \
-      "packaging==26.1" \
-      "pyarrow==24.0.0" \
-      "agent-framework-github-copilot==1.0.0b260423" \
-      "jinja2==3.1.6" \
-      "pyyaml==6.0.3" \
-      "watchdog==6.0.0" \
-      "rich>=13.7.0"
+      click==8.3.3 "pydantic==2.13.3" "pydantic-settings==2.14.0" "structlog==25.5.0" \
+      "httpx==0.28.1" "psycopg[binary]==3.3.3" "psycopg-pool==3.3.0" "orjson==3.11.8" \
+      "packaging==26.1" "pyarrow==24.0.0" "agent-framework-github-copilot==1.0.0b260423" \
+      "jinja2==3.1.6" "pyyaml==6.0.3" "watchdog==6.0.0" "rich>=13.7.0" \
+      "semgrep==${SEMGREP_VERSION}" "scancode-toolkit==${SCANCODE_VERSION}" \
+      "lizard==${LIZARD_VERSION}" "mypy==${MYPY_VERSION}"
 
-# Semgrep — invoked via python -m semgrep (not a console_script)
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --target=/opt/pysite "semgrep==${SEMGREP_VERSION}"
-
-# ScanCode — invoked via python -m scancode (not a console_script)
-# Requires libicu-dev at build time for pyicu compilation.
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --target=/opt/pysite "scancode-toolkit==${SCANCODE_VERSION}"
-
-# eedom itself — invalidated when src/ changes
-COPY LICENSE README.md ./
+COPY pyproject.toml LICENSE README.md ./
 COPY src/ src/
 COPY policies/ policies/
 COPY migrations/ migrations/
@@ -144,18 +136,20 @@ COPY migrations/ migrations/
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --target=/opt/pysite .
 
-# Semgrep ≥1.38 intentionally exits 2 from its __main__.py with a deprecation
-# notice. Override it so `python3 -m semgrep` routes to the real CLI entry point.
+# ── Module entry point fixes ────────────────────────────────────────���────────
+# pip --target does not create console_scripts. Plugin runners call bare tool
+# names, so we need `python3 -m <module>` to work. These overrides are needed
+# until we switch to a real venv (#117) which creates proper entry points.
+
+# Semgrep ≥1.38 __main__.py deliberately exits 2 with a deprecation notice.
 RUN printf '%s\n' \
       'from semgrep.cli import cli' \
       'if __name__ == "__main__":' \
       '    cli()' \
     > /opt/pysite/semgrep/__main__.py
 
-# scancode-toolkit has no __main__.py — create one so `python3 -m scancode` works.
-# The full CLI import triggers extractcode/libarchive2.py which loads libarchive
-# via ctypes; that import fails for the --version flag before any real scanning.
-# Short-circuit --version using importlib.metadata to avoid the full plugin load.
+# scancode-toolkit ships no __main__.py. Short-circuit --version to avoid
+# the full plugin load which triggers ctypes/libarchive imports.
 RUN printf '%s\n' \
       'import sys' \
       'if len(sys.argv) >= 2 and sys.argv[1] == "--version":' \
@@ -171,85 +165,89 @@ RUN printf '%s\n' \
     > /opt/pysite/scancode/__main__.py
 
 # ════════════════════════════════════════════════════════════════════════════
-# Stage 2: runtime — receives only staged artifacts; no build tools
+# Stage 2: runtime
 # ════════════════════════════════════════════════════════════════════════════
-FROM python:3.14-slim-bookworm
+FROM python:3.12-slim-bookworm
 
-# Runtime system packages:
-#   git       — /usr/bin/git with all shared libs (satisfies ldd test)
-#   clamav    — /usr/bin/clamscan with all shared libs (no freshclam)
-#   libicu72  — required by scancode-toolkit's pyicu C extension
-#   ca-certs  — HTTPS for any runtime outbound calls
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      git clamav libicu72 libarchive13 ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+ARG CSPELL_VERSION
+ARG PMD_VERSION
 
-# Static Go scanner binaries → /usr/local/bin/ (in PATH)
+LABEL org.opencontainers.image.title="Eagle Eyed Dom" \
+      org.opencontainers.image.description="DHI hardened multi-stage production scanner" \
+      org.opencontainers.image.source="https://github.com/gitrdunhq/eedom"
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      git clamav clamav-freshclam libicu72 libarchive13 ca-certificates \
+      default-jre-headless nodejs npm \
+    && npm install -g "cspell@${CSPELL_VERSION}" --no-fund --no-audit \
+    && npm cache clean --force \
+    && apt-get purge -y npm \
+    && apt-get autoremove -y
+
+# Non-root user — scanners must not run as root.
+RUN groupadd -r eedom && useradd -r -g eedom -m -d /home/eedom -s /bin/false eedom
+
+# ClamAV directories — present but empty. Signatures are fetched at scan time
+# via `freshclam --quiet` in the CI workflow, never baked into the image.
+RUN mkdir -p /var/lib/clamav /var/log/clamav \
+    && chown -R eedom:eedom /var/lib/clamav /var/log/clamav \
+    && chmod 0750 /var/lib/clamav /var/log/clamav
+
+# ── Staged artifacts from builder ────────────────────────────────────────────
 COPY --from=builder /staging/gobin/syft        /usr/local/bin/syft
 COPY --from=builder /staging/gobin/trivy       /usr/local/bin/trivy
 COPY --from=builder /staging/gobin/osv-scanner /usr/local/bin/osv-scanner
 COPY --from=builder /staging/gobin/opa         /usr/local/bin/opa
 COPY --from=builder /staging/gobin/gitleaks    /usr/local/bin/gitleaks
+COPY --from=builder /staging/gobin/kube-linter /usr/local/bin/kube-linter
+COPY --from=builder /staging/pmd/              /opt/pmd/
+COPY --from=builder /staging/jq/jq             /usr/bin/jq
+COPY --from=builder /opt/pysite/               /opt/pysite/
 
-# Static jq binary → /usr/bin/jq (test expects this exact path)
-COPY --from=builder /staging/jq/jq /usr/bin/jq
-
-# Python packages from builder
-COPY --from=builder /opt/pysite/ /opt/pysite/
-
-# Jinja2 templates — .j2 files are not picked up by pip --target (no package_data
-# entry in pyproject.toml). Copy directly from build context into site-packages.
+# Jinja2 templates — not picked up by pip --target (see #118)
 COPY src/eedom/templates/ /opt/pysite/eedom/templates/
 
-# eedom policies (OPA + plugin rules)
 COPY --from=builder /opt/eedom/policies/ /opt/eedom/policies/
 
-# Checksum verification infrastructure
 RUN mkdir -p /opt/eedom/scripts
 COPY --from=builder /staging/scripts/checksums.txt /opt/eedom/scripts/checksums.txt
 COPY scripts/verify-checksums.sh /opt/eedom/scripts/verify-checksums.sh
 RUN chmod +x /opt/eedom/scripts/verify-checksums.sh
 
-# ClamAV signature directory — present but empty.
-# Signatures are fetched at container startup via an entrypoint wrapper or
-# init-container. Never baked into the image (they go stale within days).
-RUN mkdir -p /var/lib/clamav
-
-# python3 wrapper — the test_no_clamav_db_in_image test passes a -c string
-# containing `; if condition:` which is a SyntaxError in standard Python
-# (compound_stmt cannot follow a simple_stmt in the same line after ;).
-# This wrapper rewrites "; if " → "\nif " in -c arguments before delegating
-# to the real interpreter. All other invocations pass through unchanged.
-RUN mv /usr/local/bin/python3 /usr/local/bin/python3.13-real \
-    && printf '%s\n' \
-         '#!/bin/sh' \
-         'if [ "$1" = "-c" ] && [ $# -ge 2 ]; then' \
-         '  code=$(printf "%s" "$2" | sed "s/; if /\nif /g")' \
-         '  shift 2' \
-         '  exec /usr/local/bin/python3.13-real -c "$code" "$@"' \
-         'fi' \
-         'exec /usr/local/bin/python3.13-real "$@"' \
-    > /usr/local/bin/python3 \
-    && chmod 0755 /usr/local/bin/python3
-
-# /bin/sh wrapper — handles the test harness double-invocation pattern:
-#   podman run --entrypoint /bin/sh IMAGE /bin/sh /opt/eedom/scripts/verify-checksums.sh
-# The kernel resolves our shebang (#!/usr/bin/dash), which runs the wrapper;
-# the wrapper detects the redundant /bin/sh first-arg and strips it before
-# exec'ing the actual script. All other /bin/sh usage (RUN, shell -c) works
-# normally because -c is not /bin/sh.
-RUN rm -f /bin/sh \
-    && echo '#!/usr/bin/dash'                                   > /bin/sh \
-    && echo 'if [ "$1" = "/bin/sh" ]; then shift; fi'          >> /bin/sh \
-    && echo 'exec /usr/bin/dash "$@"'                          >> /bin/sh \
-    && chmod 0755 /bin/sh
-
+# ── CLI wrappers ─────────────────────────────────────────────────────────────
+# pip --target does not generate console_scripts. Shell wrappers bridge the gap.
+# TODO(#117): Replace with venv approach that creates proper entry points.
 RUN printf '#!/bin/sh\nexec python3 -m eedom.cli.main "$@"\n' > /usr/local/bin/eedom \
-    && chmod +x /usr/local/bin/eedom
+    && chmod +x /usr/local/bin/eedom \
+    && for tool in semgrep scancode lizard mypy; do \
+         printf '#!/bin/sh\nexec python3 -m %s "$@"\n' "$tool" > "/usr/local/bin/$tool" \
+         && chmod +x "/usr/local/bin/$tool"; \
+       done \
+    && printf '#!/bin/sh\nexec /opt/pmd/pmd-bin-%s/bin/pmd "$@"\n' "${PMD_VERSION}" > /usr/local/bin/pmd \
+    && chmod +x /usr/local/bin/pmd
+
+# Entrypoint verifies binary integrity before running eedom
+RUN printf '#!/bin/sh\n/opt/eedom/scripts/verify-checksums.sh || exit 1\nexec eedom "$@"\n' > /usr/local/bin/entrypoint.sh \
+    && chmod +x /usr/local/bin/entrypoint.sh
 
 ENV PYTHONPATH=/opt/pysite \
+    TRIVY_CACHE_DIR=/home/eedom/.cache/trivy \
+    MYPY_CACHE_DIR=/home/eedom/.cache/mypy \
+    SEMGREP_USER_DATA_FOLDER=/home/eedom/.cache/semgrep \
+    XDG_CACHE_HOME=/home/eedom/.cache \
     EEDOM_OPERATING_MODE=monitor \
     EEDOM_OPA_POLICY_PATH=/opt/eedom/policies \
-    EEDOM_ENABLED_SCANNERS=syft,osv-scanner,trivy,scancode,semgrep,gitleaks,clamav
+    EEDOM_ENABLED_SCANNERS=syft,osv-scanner,trivy,scancode,semgrep,gitleaks,clamav,kube-linter,pmd,lizard,mypy,cspell
 
-ENTRYPOINT ["eedom"]
+USER eedom
+WORKDIR /home/eedom
+
+HEALTHCHECK --interval=5m --timeout=30s --retries=3 \
+  CMD eedom healthcheck || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/eedom/cli/inspect_cmds.py
+++ b/src/eedom/cli/inspect_cmds.py
@@ -1,0 +1,114 @@
+"""Scanner inspection CLI commands — healthcheck, check-health, plugins."""
+
+from __future__ import annotations
+
+import shutil
+
+import click
+
+from eedom.plugins import get_default_registry
+
+_BINARY_MAP: dict[str, list[str] | None] = {
+    "blast-radius": None,
+    "cdk-nag": ["cdk"],
+    "cfn-nag": ["cfn_nag_scan"],
+    "clamav": ["clamscan"],
+    "complexity": ["lizard"],
+    "cpd": ["pmd"],
+    "cspell": ["cspell"],
+    "gitleaks": ["gitleaks"],
+    "kube-linter": ["kube-linter"],
+    "ls-lint": ["ls-lint"],
+    "mypy": ["mypy", "pyright"],
+    "opa": ["opa"],
+    "osv-scanner": ["osv-scanner"],
+    "scancode": ["scancode"],
+    "semgrep": ["semgrep"],
+    "supply-chain": None,
+    "syft": ["syft"],
+    "trivy": ["trivy"],
+}
+
+
+@click.command()
+def healthcheck() -> None:
+    """Check all registered scanners are available. Exits 1 if any are missing."""
+    registry = get_default_registry()
+    all_plugins = registry.list()
+    ok = 0
+    fail = 0
+    for p in sorted(all_plugins, key=lambda x: x.name):
+        binaries = _BINARY_MAP.get(p.name)
+        if binaries is None:
+            ok += 1
+            click.echo(f"  ok       {p.name} (pure python)")
+            continue
+        found = any(shutil.which(b) for b in binaries)
+        if found:
+            ok += 1
+            click.echo(f"  ok       {p.name}")
+        else:
+            fail += 1
+            click.echo(f"  MISSING  {p.name} (needs: {', '.join(binaries)})")
+    click.echo(f"\n{ok}/{ok + fail} scanners available")
+    raise SystemExit(1 if fail else 0)
+
+
+@click.command("check-health")
+def check_health() -> None:
+    """Verify scanner binaries and database connectivity."""
+    tools = ["syft", "osv-scanner", "trivy", "scancode", "opa"]
+    all_ok = True
+
+    click.echo("Scanner Health Check")
+    click.echo("=" * 40)
+    for tool in tools:
+        path = shutil.which(tool)
+        if path:
+            click.echo(f"  {tool:<15} OK  ({path})")
+        else:
+            click.echo(f"  {tool:<15} MISSING")
+            all_ok = False
+
+    click.echo()
+
+    try:
+        from eedom.core.config import EedomSettings
+
+        config = EedomSettings()  # type: ignore[call-arg]
+        from eedom.data.db import DecisionRepository
+
+        db = DecisionRepository(dsn=config.db_dsn)
+        if db.connect():
+            click.echo("  Database        OK")
+            db.close()
+        else:
+            click.echo("  Database        UNAVAILABLE")
+            all_ok = False
+    except Exception:
+        click.echo("  Database        UNAVAILABLE (config error)")
+        all_ok = False
+
+    click.echo()
+    if all_ok:
+        click.echo("All checks passed.")
+    else:
+        click.echo("Some checks failed. See above.")
+
+
+@click.command()
+def plugins() -> None:
+    """List all registered Eagle Eyed Dom plugins."""
+    registry = get_default_registry()
+    all_plugins = registry.list()
+
+    click.echo(f"{'Name':<20} {'Category':<15} {'Binary':<12} {'Depends On':<18} Description")
+    click.echo("-" * 95)
+    for p in sorted(all_plugins, key=lambda x: (x.category, x.name)):
+        binary = p.name.replace("-", "")
+        installed = "ok" if shutil.which(p.name) or shutil.which(binary) else "—"
+        deps = ", ".join(p.depends_on) if p.depends_on else "—"
+        click.echo(
+            f"{p.name:<20} {p.category.value:<15} {installed:<12} {deps:<18} {p.description}"
+        )
+    click.echo(f"\n{len(all_plugins)} plugins registered")

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -77,9 +77,23 @@ def _check_isolated_environment() -> None:
 
 
 @click.group()
+@click.version_option(package_name="eedom")
 def cli() -> None:
     """Eagle Eyed Dom — fully deterministic dependency and code review for CI."""
     _check_isolated_environment()
+
+
+def _register_subcommands() -> None:
+    from eedom.cli.inspect_cmds import check_health, healthcheck, plugins
+    from eedom.cli.query_cmd import query
+
+    cli.add_command(healthcheck)
+    cli.add_command(check_health)
+    cli.add_command(plugins)
+    cli.add_command(query)
+
+
+_register_subcommands()
 
 
 @cli.command()
@@ -156,50 +170,6 @@ def evaluate(
     except Exception:
         logger.exception("pipeline_failed_unexpectedly")
         sys.exit(1)
-
-
-@cli.command("check-health")
-def check_health() -> None:
-    """Verify scanner binaries and database connectivity."""
-    import shutil
-
-    tools = ["syft", "osv-scanner", "trivy", "scancode", "opa"]
-    all_ok = True
-
-    click.echo("Scanner Health Check")
-    click.echo("=" * 40)
-    for tool in tools:
-        path = shutil.which(tool)
-        if path:
-            click.echo(f"  {tool:<15} OK  ({path})")
-        else:
-            click.echo(f"  {tool:<15} MISSING")
-            all_ok = False
-
-    click.echo()
-
-    try:
-        from eedom.core.config import EedomSettings
-
-        config = EedomSettings()  # type: ignore[call-arg]
-        from eedom.data.db import DecisionRepository
-
-        db = DecisionRepository(dsn=config.db_dsn)
-        if db.connect():
-            click.echo("  Database        OK")
-            db.close()
-        else:
-            click.echo("  Database        UNAVAILABLE")
-            all_ok = False
-    except Exception:
-        click.echo("  Database        UNAVAILABLE (config error)")
-        all_ok = False
-
-    click.echo()
-    if all_ok:
-        click.echo("All checks passed.")
-    else:
-        click.echo("Some checks failed. See above.")
 
 
 @cli.command()
@@ -424,107 +394,6 @@ def review(
 
     if watch:
         _watch_and_rerun(repo_path=repo, run_review=run_review)
-
-
-@cli.command()
-def plugins() -> None:
-    """List all registered Eagle Eyed Dom plugins."""
-    import shutil
-
-    registry = get_default_registry()
-    all_plugins = registry.list()
-
-    click.echo(f"{'Name':<20} {'Category':<15} {'Binary':<12} {'Depends On':<18} Description")
-    click.echo("-" * 95)
-    for p in sorted(all_plugins, key=lambda x: (x.category, x.name)):
-        binary = p.name.replace("-", "")
-        installed = "ok" if shutil.which(p.name) or shutil.which(binary) else "—"
-        deps = ", ".join(p.depends_on) if p.depends_on else "—"
-        click.echo(
-            f"{p.name:<20} {p.category.value:<15} {installed:<12} {deps:<18} {p.description}"
-        )
-    click.echo(f"\n{len(all_plugins)} plugins registered")
-
-
-@cli.command()
-@click.argument("question")
-@click.option(
-    "--db",
-    "db_path",
-    type=click.Path(),
-    default=".eedom/graph.db",
-    show_default=True,
-    help="Path to the CodeGraph SQLite database.",
-)
-def query(question: str, db_path: str) -> None:
-    """Query the code graph using natural language.
-
-    Examples:
-
-    \b
-      eedom query "which functions have the highest fan-out?"
-      eedom query "show me dead code"
-      eedom query "what depends on ReviewPipeline"
-      eedom query "are there circular imports?"
-    """
-    from eedom.core.nl_query import TEMPLATES, query_code
-
-    db = Path(db_path)
-    if not db.exists():
-        click.echo(f"Database not found: {db}", err=True)
-        click.echo(
-            "Run 'eedom review --repo-path .' first to build the code graph.",
-            err=True,
-        )
-        sys.exit(1)
-
-    result = query_code(question, db)
-
-    if not result.query:
-        click.echo("No matching query found.\n")
-        click.echo(f"Available queries ({len(TEMPLATES)} templates):")
-        click.echo()
-        for row in result.rows:
-            desc = row.get("template", "")
-            kws = row.get("keywords", "")
-            click.echo(f"  {desc}")
-            if kws:
-                click.echo(f"    Keywords: {kws}")
-        sys.exit(0)
-
-    click.echo(f"Query: {result.description}\n")
-
-    if not result.rows:
-        click.echo("No results found.")
-        sys.exit(0)
-
-    _print_table(result.columns, result.rows)
-
-
-def _print_table(columns: list[str], rows: list[dict]) -> None:
-    """Print rows as an aligned table, using rich when available."""
-    try:
-        from rich.console import Console
-        from rich.table import Table
-
-        table = Table(show_header=True, header_style="bold")
-        for col in columns:
-            table.add_column(col)
-        for row in rows:
-            table.add_row(*[str(row.get(col, "")) for col in columns])
-        Console().print(table)
-    except ImportError:
-        col_widths = {col: len(col) for col in columns}
-        for row in rows:
-            for col in columns:
-                col_widths[col] = max(col_widths[col], len(str(row.get(col, ""))))
-        header = "  ".join(col.ljust(col_widths[col]) for col in columns)
-        separator = "  ".join("-" * col_widths[col] for col in columns)
-        click.echo(header)
-        click.echo(separator)
-        for row in rows:
-            line = "  ".join(str(row.get(col, "")).ljust(col_widths[col]) for col in columns)
-            click.echo(line)
 
 
 def _read_diff(diff_path: str) -> str:

--- a/src/eedom/cli/query_cmd.py
+++ b/src/eedom/cli/query_cmd.py
@@ -1,0 +1,89 @@
+"""Code graph query CLI command."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+
+@click.command()
+@click.argument("question")
+@click.option(
+    "--db",
+    "db_path",
+    type=click.Path(),
+    default=".eedom/graph.db",
+    show_default=True,
+    help="Path to the CodeGraph SQLite database.",
+)
+def query(question: str, db_path: str) -> None:
+    """Query the code graph using natural language.
+
+    Examples:
+
+    \b
+      eedom query "which functions have the highest fan-out?"
+      eedom query "show me dead code"
+      eedom query "what depends on ReviewPipeline"
+      eedom query "are there circular imports?"
+    """
+    from eedom.core.nl_query import TEMPLATES, query_code
+
+    db = Path(db_path)
+    if not db.exists():
+        click.echo(f"Database not found: {db}", err=True)
+        click.echo(
+            "Run 'eedom review --repo-path .' first to build the code graph.",
+            err=True,
+        )
+        sys.exit(1)
+
+    result = query_code(question, db)
+
+    if not result.query:
+        click.echo("No matching query found.\n")
+        click.echo(f"Available queries ({len(TEMPLATES)} templates):")
+        click.echo()
+        for row in result.rows:
+            desc = row.get("template", "")
+            kws = row.get("keywords", "")
+            click.echo(f"  {desc}")
+            if kws:
+                click.echo(f"    Keywords: {kws}")
+        sys.exit(0)
+
+    click.echo(f"Query: {result.description}\n")
+
+    if not result.rows:
+        click.echo("No results found.")
+        sys.exit(0)
+
+    _print_table(result.columns, result.rows)
+
+
+def _print_table(columns: list[str], rows: list[dict]) -> None:
+    """Print rows as an aligned table, using rich when available."""
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold")
+        for col in columns:
+            table.add_column(col)
+        for row in rows:
+            table.add_row(*[str(row.get(col, "")) for col in columns])
+        Console().print(table)
+    except ImportError:
+        col_widths = {col: len(col) for col in columns}
+        for row in rows:
+            for col in columns:
+                col_widths[col] = max(col_widths[col], len(str(row.get(col, ""))))
+        header = "  ".join(col.ljust(col_widths[col]) for col in columns)
+        separator = "  ".join("-" * col_widths[col] for col in columns)
+        click.echo(header)
+        click.echo(separator)
+        for row in rows:
+            line = "  ".join(str(row.get(col, "")).ljust(col_widths[col]) for col in columns)
+            click.echo(line)

--- a/src/eedom/core/sarif.py
+++ b/src/eedom/core/sarif.py
@@ -101,6 +101,15 @@ def _plugin_to_run(
             sarif_result["locations"] = locations
         sarif_results.append(sarif_result)
 
+    if result.error:
+        sarif_results.append(
+            {
+                "ruleId": "eedom-plugin-error",
+                "level": "error",
+                "message": {"text": result.error},
+            }
+        )
+
     if truncated > 0:
         sarif_results.append(
             {

--- a/src/eedom/plugins/blast_radius.py
+++ b/src/eedom/plugins/blast_radius.py
@@ -40,9 +40,12 @@ class BlastRadiusPlugin(ScannerPlugin):
         db_dir = repo_path / ".eedom"
         try:
             db_dir.mkdir(exist_ok=True)
+            test_file = db_dir / ".write_test"
+            test_file.touch()
+            test_file.unlink()
         except OSError:
             logger.warning(
-                "blast-radius: cannot create .eedom in repo_path (read-only?), using temp dir",
+                "blast-radius: repo_path not writable, using temp dir",
                 repo_path=str(repo_path),
             )
             db_dir = Path(tempfile.mkdtemp(prefix="eedom-blast-radius-"))

--- a/tests/integration/test_dockerfile.py
+++ b/tests/integration/test_dockerfile.py
@@ -479,7 +479,7 @@ class TestChecksumVerification:
         A tampered binary causes the script (and therefore this test) to fail.
         """
         result = container_run(
-            ["/bin/sh", "/opt/eedom/scripts/verify-checksums.sh"],
+            ["/opt/eedom/scripts/verify-checksums.sh"],
             entrypoint="/bin/sh",
             extra_flags=[],
         )
@@ -524,11 +524,11 @@ class TestNoStaleSignatures:
             [
                 "-c",
                 (
-                    "import os, sys; "
-                    "db_dir = '/var/lib/clamav'; "
-                    "if not os.path.exists(db_dir): sys.exit(0); "
-                    "db_files = [f for f in os.listdir(db_dir) if f.endswith(('.cvd', '.cld'))]; "
-                    "print(f'Found DB files: {db_files}'); "
+                    "import os, sys\n"
+                    "db_dir = '/var/lib/clamav'\n"
+                    "if not os.path.exists(db_dir): sys.exit(0)\n"
+                    "db_files = [f for f in os.listdir(db_dir) if f.endswith(('.cvd', '.cld'))]\n"
+                    "print(f'Found DB files: {db_files}')\n"
                     "sys.exit(1 if db_files else 0)"
                 ),
             ],

--- a/tests/unit/test_sarif.py
+++ b/tests/unit/test_sarif.py
@@ -176,13 +176,17 @@ class TestMultiplePlugins:
         assert names == ["semgrep", "gitleaks"]
 
     def test_error_plugins_still_produce_runs(self) -> None:
-        """Errored plugins still appear as runs with zero results."""
+        """Errored plugins appear as runs with an error-level result."""
         results = [
             PluginResult(plugin_name="semgrep", findings=[], summary={}, error="timeout"),
         ]
         out = to_sarif(results)
         assert len(out["runs"]) == 1
-        assert out["runs"][0]["results"] == []
+        assert len(out["runs"][0]["results"]) == 1
+        err_result = out["runs"][0]["results"][0]
+        assert err_result["level"] == "error"
+        assert "timeout" in err_result["message"]["text"]
+        assert err_result["ruleId"] == "eedom-plugin-error"
 
 
 class TestRuleIdFallbacks:
@@ -423,3 +427,66 @@ class TestFindingCap:
         )
         out = to_sarif([result], max_findings_per_run=0)
         assert len(out["runs"][0]["results"]) == 5000
+
+
+class TestPluginErrorsInSarif:
+    """Plugin errors must be visible in SARIF so downstream consumers can detect failures."""
+
+    def test_not_installed_error_emits_error_result(self) -> None:
+        result = PluginResult(
+            plugin_name="semgrep",
+            findings=[],
+            summary={},
+            error="[NOT_INSTALLED] semgrep not installed",
+        )
+        out = to_sarif([result])
+        run = out["runs"][0]
+        assert len(run["results"]) == 1
+        assert run["results"][0]["level"] == "error"
+        assert "NOT_INSTALLED" in run["results"][0]["message"]["text"]
+
+    def test_timeout_error_emits_error_result(self) -> None:
+        result = PluginResult(
+            plugin_name="scancode",
+            findings=[],
+            summary={},
+            error="[TIMEOUT] scancode timed out after 60s",
+        )
+        out = to_sarif([result])
+        assert out["runs"][0]["results"][0]["level"] == "error"
+        assert "TIMEOUT" in out["runs"][0]["results"][0]["message"]["text"]
+
+    def test_error_result_has_eedom_plugin_error_rule_id(self) -> None:
+        result = PluginResult(
+            plugin_name="blast-radius",
+            findings=[],
+            summary={},
+            error="unable to open database file",
+        )
+        out = to_sarif([result])
+        assert out["runs"][0]["results"][0]["ruleId"] == "eedom-plugin-error"
+
+    def test_error_plus_findings_emits_both(self) -> None:
+        """A plugin that partially ran before erroring keeps its findings + error."""
+        result = PluginResult(
+            plugin_name="trivy",
+            findings=[{"id": "CVE-1", "severity": "high", "summary": "vuln"}],
+            summary={},
+            error="scan interrupted",
+        )
+        out = to_sarif([result])
+        results = out["runs"][0]["results"]
+        assert len(results) == 2
+        levels = {r["level"] for r in results}
+        assert "error" in levels
+
+    def test_clean_plugin_zero_findings_no_error_result(self) -> None:
+        """A plugin that ran cleanly with 0 findings must NOT emit an error result."""
+        result = PluginResult(
+            plugin_name="gitleaks",
+            findings=[],
+            summary={},
+            error="",
+        )
+        out = to_sarif([result])
+        assert out["runs"][0]["results"] == []


### PR DESCRIPTION
## Summary

- **Fail-closed GATEKEEPER**: SARIF now emits `eedom-plugin-error` results when scanners crash. The gate step exits 1 on `incomplete` or `blocked` verdicts. Hybrid detection: checks SARIF first, falls back to parsing review.md for `| error: ` lines (handles old container images).
- **Container image**: All 18 scanner plugins now have their dependencies installed. Added kube-linter (Go binary), PMD/CPD (Java + JRE), cspell (Node.js + npm), lizard, mypy, and PATH wrappers for Python tools installed via `pip --target`.
- **blast-radius**: Fixed read-only mount crash by verifying write permission before using repo_path, falling back to tempdir.
- **clamav**: Added `clamav-freshclam` package and signature fetch at scan time in CI workflow.

Supersedes #110.

## What changed

| File | Change |
|------|--------|
| `src/eedom/core/sarif.py` | Emit `eedom-plugin-error` error-level result when `PluginResult.error` is set |
| `tests/unit/test_sarif.py` | 5 new tests for plugin error SARIF encoding |
| `.github/workflows/gatekeeper.yml` | Hybrid crash detection, fail-closed gate step, freshclam at scan time |
| `Dockerfile` | Add kube-linter, PMD, cspell, lizard, mypy; PATH wrappers; clamav-freshclam |
| `src/eedom/plugins/blast_radius.py` | Write-permission check before using repo_path for SQLite |

## Test plan

- [x] Unit tests: 1040 passed, 4 skipped
- [ ] Container build completes successfully
- [ ] CI GATEKEEPER runs 18/18 plugins with 0 crashes
- [ ] `dom: approved` label applied to this PR