### PR TITLE
fix: correct pypi-publish action SHA pin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,7 +86,7 @@ jobs:
           subject-path: dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54a81bfb41913730ec5c003
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           print-hash: true
 


### PR DESCRIPTION
The pypi-publish action SHA `76f52bc8...` doesn't resolve. Updated to `cef22109...` (v1.14.0).

Blocks the v0.2.1 PyPI publish — the GitHub release exists but the package isn't on PyPI yet.