### PR TITLE
fix: cyclonedx-py CLI flags + non-blocking SBOM

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,9 +73,10 @@ jobs:
         run: uv build
 
       - name: Generate SBOM
+        continue-on-error: true
         run: |
           uv tool install cyclonedx-bom --force
-          cyclonedx-py environment --output sbom.cdx.json --output-format json
+          cyclonedx-py environment -o sbom.cdx.json --of json
           gh release upload ${{ needs.release-please.outputs.tag_name }} sbom.cdx.json
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
cyclonedx-py changed --output to -o. Also make SBOM generation continue-on-error so it doesn't block PyPI publish.