### PR TITLE
fix: publish job needs ubuntu-latest for PyPI action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,7 +57,7 @@ jobs:
   publish:
     needs: [release-please, verify-key]
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/project/eedom/


### PR DESCRIPTION
pypa/gh-action-pypi-publish requires Linux. Self-hosted runner is macOS. Switch publish to ubuntu-latest.