### PR TITLE
fix: cdk-nag assembly-only mode + TDD enforcer semgrep exclusion

### DIFF
--- a/src/eedom/plugins/_runners/cdk_nag_runner.py
+++ b/src/eedom/plugins/_runners/cdk_nag_runner.py
@@ -20,43 +20,48 @@ def run_cdk_nag(
     repo_path: str,
     synth_timeout: int = 120,
     scan_timeout: int = 60,
+    skip_synth: bool = False,
 ) -> dict:
     """Run cdk-nag against a CDK project.
 
-    Two-step process:
-    1. Always run ``cdk synth --quiet`` to generate fresh templates. Stale
-       ``cdk.out/`` is never used — new code changes would be silently missed.
-    2. Scan all ``*.template.json`` files in ``cdk.out/`` using ``cfn_nag_scan``.
+    When ``skip_synth`` is False (default), runs ``cdk synth`` first to
+    generate fresh templates. When True, scans existing ``cdk.out/``
+    templates directly — used for assembly-only repos without ``cdk.json``.
     """
     from eedom.core.errors import ErrorCode, error_msg
 
     rp = Path(repo_path)
     cdk_out = rp / "cdk.out"
 
-    try:
-        result = subprocess.run(
-            ["cdk", "synth", "--quiet"],
-            capture_output=True,
-            text=True,
-            timeout=synth_timeout,
-            cwd=repo_path,
-            check=False,
-        )
-        if result.returncode != 0:
-            stderr = result.stderr.strip()
-            logger.warning("cdk_nag.synth_failed", returncode=result.returncode, stderr=stderr)
-            return {
-                "findings": [],
-                "error": f"cdk synth failed (exit {result.returncode}): {stderr}",
-            }
-    except FileNotFoundError:
-        msg = error_msg(ErrorCode.NOT_INSTALLED, "cdk")
-        logger.warning("cdk_nag.cdk_not_installed", error=msg)
-        return {"findings": [], "error": msg}
-    except subprocess.TimeoutExpired:
-        msg = error_msg(ErrorCode.TIMEOUT, "cdk", timeout=synth_timeout)
-        logger.warning("cdk_nag.synth_timeout", error=msg)
-        return {"findings": [], "error": msg}
+    if not skip_synth:
+        try:
+            result = subprocess.run(
+                ["cdk", "synth", "--quiet"],
+                capture_output=True,
+                text=True,
+                timeout=synth_timeout,
+                cwd=repo_path,
+                check=False,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                logger.warning(
+                    "cdk_nag.synth_failed",
+                    returncode=result.returncode,
+                    stderr=stderr,
+                )
+                return {
+                    "findings": [],
+                    "error": f"cdk synth failed (exit {result.returncode}): {stderr}",
+                }
+        except FileNotFoundError:
+            msg = error_msg(ErrorCode.NOT_INSTALLED, "cdk")
+            logger.warning("cdk_nag.cdk_not_installed", error=msg)
+            return {"findings": [], "error": msg}
+        except subprocess.TimeoutExpired:
+            msg = error_msg(ErrorCode.TIMEOUT, "cdk", timeout=synth_timeout)
+            logger.warning("cdk_nag.synth_timeout", error=msg)
+            return {"findings": [], "error": msg}
 
     templates = list(cdk_out.glob("*.template.json"))
     if not templates:

--- a/src/eedom/plugins/cdk_nag.py
+++ b/src/eedom/plugins/cdk_nag.py
@@ -27,8 +27,9 @@ class CdkNagPlugin(ScannerPlugin):
         return (repo_path / "cdk.json").exists() or (repo_path / "cdk.out").is_dir()
 
     def run(self, files: list[str], repo_path: Path) -> PluginResult:
+        skip_synth = not (repo_path / "cdk.json").exists()
         try:
-            data = _run(str(repo_path))
+            data = _run(str(repo_path), skip_synth=skip_synth)
         except Exception as exc:
             return PluginResult(plugin_name=self.name, error=str(exc))
 

--- a/tests/unit/test_cdk_nag_plugin.py
+++ b/tests/unit/test_cdk_nag_plugin.py
@@ -93,6 +93,7 @@ class TestCdkNagPlugin:
     def test_run_with_existing_cdk_out(self, mock_run, tmp_path):
         from eedom.plugins.cdk_nag import CdkNagPlugin
 
+        (tmp_path / "cdk.json").write_text("{}")
         cdk_out = tmp_path / "cdk.out"
         cdk_out.mkdir()
         template = cdk_out / "MyStack.template.json"
@@ -270,10 +271,11 @@ class TestCdkNagPlugin:
         assert result.summary["total"] == 0
 
     @patch(f"{RUNNER_PATH}.subprocess.run")
-    def test_synth_always_called_even_when_cdk_out_exists(self, mock_run, tmp_path):
-        """Synth must run even when cdk.out/ already exists — stale output guard."""
+    def test_synth_called_when_cdk_json_exists(self, mock_run, tmp_path):
+        """Synth must run when cdk.json exists — stale output guard."""
         from eedom.plugins.cdk_nag import CdkNagPlugin
 
+        (tmp_path / "cdk.json").write_text("{}")
         cdk_out = tmp_path / "cdk.out"
         cdk_out.mkdir()
         (cdk_out / "MyStack.template.json").write_text("{}")
@@ -324,6 +326,7 @@ class TestCdkNagPlugin:
     def test_no_templates_in_cdk_out(self, mock_run, tmp_path):
         from eedom.plugins.cdk_nag import CdkNagPlugin
 
+        (tmp_path / "cdk.json").write_text("{}")
         cdk_out = tmp_path / "cdk.out"
         cdk_out.mkdir()
         # No .template.json files
@@ -371,6 +374,42 @@ class TestCdkNagPlugin:
         assert (
             result.error is not None and result.error != ""
         ), "Non-zero exit from cfn_nag_scan must be an error, not a clean pass"
+
+    @patch(f"{RUNNER_PATH}.subprocess.run")
+    def test_assembly_only_skips_synth(self, mock_run, tmp_path):
+        """cdk.out/ exists but no cdk.json → scan templates without running cdk synth."""
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        cdk_out = tmp_path / "cdk.out"
+        cdk_out.mkdir()
+        (cdk_out / "MyStack.template.json").write_text("{}")
+
+        scan_result = MagicMock()
+        scan_result.returncode = 0
+        scan_result.stdout = CFN_NAG_OUTPUT
+        mock_run.return_value = scan_result
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.error == ""
+        assert len(result.findings) == 2
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args[0][0]
+        assert "cfn_nag_scan" in cmd
+        assert "cdk" not in cmd or "synth" not in cmd
+
+    def test_assembly_only_no_templates_returns_empty(self, tmp_path):
+        """cdk.out/ exists with no templates and no cdk.json → no findings, no error."""
+        from eedom.plugins.cdk_nag import CdkNagPlugin
+
+        (tmp_path / "cdk.out").mkdir()
+
+        p = CdkNagPlugin()
+        result = p.run([], tmp_path)
+
+        assert result.findings == []
+        assert result.error == ""
 
     @patch(f"{RUNNER_PATH}.subprocess.run")
     def test_scanner_malformed_json_returns_error(self, mock_run, tmp_path):


### PR DESCRIPTION
## Summary
- **#80** cdk-nag now supports assembly-only repos — skips `cdk synth` when `cdk.json` is absent but `cdk.out/` exists
- **#91** TDD enforcer hook excludes `/semgrep/` and `/policies/` dirs from test-sibling warnings

Closes #80, #91

## Test plan
- [x] 21 cdk-nag tests passing (2 new: assembly-only skip synth, assembly-only no templates)
- [x] Red-green verified — new tests failed before fix, pass after
- [x] Existing tests updated to reflect new behavior (synth only runs when cdk.json present)