### PR TITLE
feat: configurable fan-out threshold (closes #95)

### DIFF
--- a/src/eedom/plugins/_runners/checks.yaml
+++ b/src/eedom/plugins/_runners/checks.yaml
@@ -57,7 +57,7 @@ checks:
       JOIN edges e ON e.source_id = s.id AND e.kind = 'calls'
       WHERE s.file IN ({changed_files})
       GROUP BY s.id
-      HAVING calls_out > 8
+      HAVING calls_out > {fan_out_limit}
       ORDER BY calls_out DESC
 
   - name: deep_inheritance

--- a/src/eedom/plugins/_runners/graph_builder.py
+++ b/src/eedom/plugins/_runners/graph_builder.py
@@ -78,10 +78,11 @@ def _load_builtin_checks() -> list[dict]:
 
 
 class CodeGraph:
-    def __init__(self, db_path: str = ":memory:") -> None:
+    def __init__(self, db_path: str = ":memory:", fan_out_limit: int = 8) -> None:
         self.conn = sqlite3.connect(db_path)
         self.conn.row_factory = sqlite3.Row
         self.conn.executescript(_SCHEMA)
+        self._fan_out_limit = fan_out_limit
         self._register_builtin_checks()
 
     def _register_builtin_checks(self) -> None:
@@ -145,6 +146,7 @@ class CodeGraph:
         findings: list[dict] = []
         for check in checks:
             query = check["query"].replace("{changed_files}", placeholders)
+            query = query.replace("{fan_out_limit}", str(self._fan_out_limit))
             try:
                 rows = self.conn.execute(query).fetchall()
                 for row in rows:

--- a/src/eedom/plugins/blast_radius.py
+++ b/src/eedom/plugins/blast_radius.py
@@ -51,7 +51,13 @@ class BlastRadiusPlugin(ScannerPlugin):
             db_dir = Path(tempfile.mkdtemp(prefix="eedom-blast-radius-"))
         db_path = str(db_dir / "code_graph.sqlite")
 
-        graph = CodeGraph(db_path=db_path)
+        from eedom.core.repo_config import load_repo_config
+
+        config = load_repo_config(repo_path)
+        br_thresholds = config.thresholds.get("blast-radius", {})
+        fan_out_limit = br_thresholds.get("fan_out_limit", 8)
+
+        graph = CodeGraph(db_path=db_path, fan_out_limit=fan_out_limit)
 
         if graph.stats()["symbols"] == 0:
             graph.index_directory(repo_path)

--- a/tests/unit/test_fan_out_threshold.py
+++ b/tests/unit/test_fan_out_threshold.py
@@ -1,0 +1,34 @@
+"""Tests for configurable fan-out threshold.
+# tested-by: tests/unit/test_fan_out_threshold.py
+"""
+
+from __future__ import annotations
+
+from eedom.core.repo_config import RepoConfig
+
+
+class TestFanOutThresholdConfig:
+    def test_default_thresholds_empty(self) -> None:
+        config = RepoConfig()
+        assert config.thresholds == {}
+
+    def test_blast_radius_fan_out_limit_from_yaml(self) -> None:
+        config = RepoConfig(thresholds={"blast-radius": {"fan_out_limit": 15}})
+        limit = config.thresholds["blast-radius"]["fan_out_limit"]
+        assert limit == 15
+
+
+class TestFanOutQueryParameterization:
+    def test_checks_yaml_uses_fan_out_limit_placeholder(self) -> None:
+        from pathlib import Path
+
+        checks_path = (
+            Path(__file__).parent.parent.parent
+            / "src"
+            / "eedom"
+            / "plugins"
+            / "_runners"
+            / "checks.yaml"
+        )
+        content = checks_path.read_text()
+        assert "{fan_out_limit}" in content


### PR DESCRIPTION
## Summary
- `high_fan_out` check threshold is now configurable via `.eagle-eyed-dom.yaml`
- Default remains 8 (no behavior change for existing users)
- Config path: `thresholds.blast-radius.fan_out_limit`
- Parameterized in checks.yaml as `{fan_out_limit}`, injected by graph_builder

Closes #95

## Test plan
- [x] 3 tests: default config, custom config, YAML placeholder presence
- [x] Red-green verified