### PR TITLE
feat: --format json + two-axis scoring (closes #92, #93)

### DIFF
--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -182,7 +182,7 @@ def evaluate(
 @click.option(
     "--format",
     "output_format",
-    type=click.Choice(["markdown", "sarif"]),
+    type=click.Choice(["markdown", "sarif", "json"]),
     default="markdown",
     help="Output format.",
 )
@@ -374,6 +374,17 @@ def review(
                 click.echo(f"SARIF written to {output}")
             else:
                 click.echo(sarif_text)
+            return
+
+        if output_format == "json":
+            from eedom.core.json_report import render_json
+
+            json_text = render_json(results, repo=repo_name or str(repo))
+            if output:
+                Path(output).write_text(json_text)
+                click.echo(f"JSON written to {output}")
+            else:
+                click.echo(json_text)
             return
 
         md = render_comment(

--- a/src/eedom/core/json_report.py
+++ b/src/eedom/core/json_report.py
@@ -1,0 +1,65 @@
+# tested-by: tests/unit/test_json_report.py
+"""Structured JSON output for machine consumption."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import orjson
+
+from eedom.core.plugin import PluginResult
+from eedom.core.renderer import calculate_quality_score, calculate_severity_score
+
+
+def _plugin_status(result: PluginResult) -> str:
+    if result.error:
+        return "error"
+    if result.summary.get("status") == "skipped":
+        return "skipped"
+    return "ran"
+
+
+def render_json(
+    results: list[PluginResult],
+    repo: str = "",
+    commit: str = "",
+) -> str:
+    from eedom.core.renderer import _build_sections
+
+    verdict, _, _ = _build_sections(results, None)
+    security_score = calculate_severity_score(results)
+    quality_score = calculate_quality_score(results)
+
+    total_findings = sum(len(r.findings) for r in results)
+
+    plugins = []
+    for r in results:
+        status = _plugin_status(r)
+        plugins.append(
+            {
+                "name": r.plugin_name,
+                "category": r.category,
+                "status": status,
+                "skip_reason": r.skip_reason or None,
+                "skip_remediation": r.skip_remediation or None,
+                "findings_count": len(r.findings),
+                "findings": r.findings,
+                "summary": r.summary,
+                "error": r.error or None,
+            }
+        )
+
+    doc = {
+        "schema_version": "1.0",
+        "timestamp": datetime.now(UTC).isoformat(),
+        "repo": repo,
+        "commit": commit,
+        "verdict": verdict,
+        "security_score": security_score,
+        "quality_score": quality_score,
+        "total_findings": total_findings,
+        "total_plugins": len(results),
+        "plugins": plugins,
+    }
+
+    return orjson.dumps(doc, option=orjson.OPT_INDENT_2).decode()

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -260,7 +260,8 @@ def _build_sections(
         summary_rows.append((label, str(count)))
 
         has_crit = any(f.get("severity") in ("critical", "high") for f in r.findings)
-        if has_crit:
+        is_security = r.category in {"dependency", "supply_chain", "infra"}
+        if has_crit and is_security:
             verdict = "blocked"
         elif count and verdict != "blocked":
             verdict = "warnings"

--- a/tests/unit/test_json_report.py
+++ b/tests/unit/test_json_report.py
@@ -1,0 +1,120 @@
+"""Tests for JSON structured output.
+# tested-by: tests/unit/test_json_report.py
+"""
+
+from __future__ import annotations
+
+import json
+
+from eedom.core.plugin import PluginResult
+
+
+def _make_result(
+    name: str = "trivy",
+    findings: list[dict] | None = None,
+    error: str = "",
+    skip_reason: str = "",
+    skip_remediation: str = "",
+    category: str = "dependency",
+) -> PluginResult:
+    return PluginResult(
+        plugin_name=name,
+        findings=findings or [],
+        summary={"status": "skipped"} if skip_reason else {},
+        error=error,
+        category=category,
+        skip_reason=skip_reason,
+        skip_remediation=skip_remediation,
+    )
+
+
+class TestJsonReport:
+    def test_output_is_valid_json(self) -> None:
+        from eedom.core.json_report import render_json
+
+        results = [_make_result()]
+        output = render_json(results)
+        parsed = json.loads(output)
+        assert isinstance(parsed, dict)
+
+    def test_has_schema_version(self) -> None:
+        from eedom.core.json_report import render_json
+
+        output = json.loads(render_json([_make_result()]))
+        assert "schema_version" in output
+        assert output["schema_version"] == "1.0"
+
+    def test_has_verdict(self) -> None:
+        from eedom.core.json_report import render_json
+
+        output = json.loads(render_json([_make_result()]))
+        assert "verdict" in output
+
+    def test_includes_all_plugins(self) -> None:
+        from eedom.core.json_report import render_json
+
+        results = [
+            _make_result("trivy"),
+            _make_result("gitleaks", category="supply_chain"),
+            _make_result("semgrep", category="code"),
+        ]
+        output = json.loads(render_json(results))
+        names = [p["name"] for p in output["plugins"]]
+        assert "trivy" in names
+        assert "gitleaks" in names
+        assert "semgrep" in names
+
+    def test_includes_skip_reasons(self) -> None:
+        from eedom.core.json_report import render_json
+
+        results = [
+            _make_result(
+                "osv-scanner",
+                skip_reason="Binary not installed",
+                skip_remediation="brew install osv-scanner",
+            ),
+        ]
+        output = json.loads(render_json(results))
+        plugin = output["plugins"][0]
+        assert plugin["skip_reason"] == "Binary not installed"
+        assert plugin["skip_remediation"] == "brew install osv-scanner"
+        assert plugin["status"] == "skipped"
+
+    def test_includes_error(self) -> None:
+        from eedom.core.json_report import render_json
+
+        results = [_make_result("clamav", error="TIMEOUT after 60s")]
+        output = json.loads(render_json(results))
+        plugin = output["plugins"][0]
+        assert plugin["status"] == "error"
+        assert plugin["error"] == "TIMEOUT after 60s"
+
+    def test_includes_findings(self) -> None:
+        from eedom.core.json_report import render_json
+
+        findings = [{"id": "CVE-2025-1234", "severity": "critical"}]
+        results = [_make_result("trivy", findings=findings)]
+        output = json.loads(render_json(results))
+        plugin = output["plugins"][0]
+        assert plugin["status"] == "ran"
+        assert plugin["findings_count"] == 1
+        assert plugin["findings"][0]["id"] == "CVE-2025-1234"
+
+    def test_has_totals(self) -> None:
+        from eedom.core.json_report import render_json
+
+        findings = [{"id": "CVE-1"}, {"id": "CVE-2"}]
+        results = [
+            _make_result("trivy", findings=findings),
+            _make_result("gitleaks", category="supply_chain"),
+        ]
+        output = json.loads(render_json(results))
+        assert output["total_findings"] == 2
+        assert output["total_plugins"] == 2
+
+    def test_has_scores(self) -> None:
+        from eedom.core.json_report import render_json
+
+        output = json.loads(render_json([_make_result()]))
+        assert "security_score" in output
+        assert "quality_score" in output

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -17,6 +17,7 @@ from eedom.core.renderer import (  # noqa: PLC2701
 def _vuln_result() -> PluginResult:
     return PluginResult(
         plugin_name="osv-scanner",
+        category="dependency",
         findings=[
             {
                 "id": "CVE-2023-0286",
@@ -209,6 +210,7 @@ class TestPerPackageRendering:
         return PluginResult(
             plugin_name=plugin_name,
             package_root=package_root,
+            category="dependency",
             findings=[{"severity": severity, "id": "CVE-T3-1", "message": "test finding"}],
             summary={},
         )
@@ -225,15 +227,14 @@ class TestPerPackageRendering:
         """Results with package_root=None render identically to current behavior."""
         result = PluginResult(
             plugin_name="semgrep",
+            category="code",
             findings=[{"severity": "high", "id": "CVE-1", "message": "x"}],
             summary={},
         )
         md = render_comment([result], repo="org/repo", pr_num=1, title="test")
-        # No per-package section headers
         assert "## apps/" not in md
         assert "## libs/" not in md
-        # Standard verdict still applies
-        assert "BLOCKED" in md
+        assert "PASS WITH WARNINGS" in md
 
     def test_multi_package_section_headers(self):
         """Two packages get separate section headers."""

--- a/tests/unit/test_two_axis_scoring.py
+++ b/tests/unit/test_two_axis_scoring.py
@@ -1,0 +1,82 @@
+"""Tests for two-axis scoring — security blocks, quality advises.
+# tested-by: tests/unit/test_two_axis_scoring.py
+"""
+
+from __future__ import annotations
+
+from eedom.core.plugin import PluginResult
+from eedom.core.renderer import _build_sections
+
+_SECURITY_CATEGORIES = {"dependency", "supply_chain", "infra"}
+_QUALITY_CATEGORIES = {"quality", "code"}
+
+
+def _result(
+    name: str,
+    category: str,
+    findings: list[dict] | None = None,
+) -> PluginResult:
+    return PluginResult(
+        plugin_name=name,
+        findings=findings or [],
+        category=category,
+    )
+
+
+class TestTwoAxisVerdict:
+    def test_security_critical_blocks(self) -> None:
+        results = [
+            _result(
+                "trivy",
+                "dependency",
+                [{"id": "CVE-1", "severity": "critical"}],
+            ),
+        ]
+        verdict, _, _ = _build_sections(results, None)
+        assert verdict == "blocked"
+
+    def test_quality_critical_does_not_block(self) -> None:
+        results = [
+            _result(
+                "complexity",
+                "quality",
+                [{"severity": "critical", "check": "high_fan_out"}],
+            ),
+        ]
+        verdict, _, _ = _build_sections(results, None)
+        assert verdict != "blocked"
+
+    def test_quality_findings_produce_warnings(self) -> None:
+        results = [
+            _result(
+                "blast-radius",
+                "quality",
+                [{"severity": "high", "check": "layer_violation"}],
+            ),
+        ]
+        verdict, _, _ = _build_sections(results, None)
+        assert verdict == "warnings"
+
+    def test_mixed_security_and_quality(self) -> None:
+        results = [
+            _result(
+                "trivy",
+                "dependency",
+                [{"id": "CVE-1", "severity": "critical"}],
+            ),
+            _result(
+                "complexity",
+                "quality",
+                [{"severity": "critical", "check": "god_function"}],
+            ),
+        ]
+        verdict, _, _ = _build_sections(results, None)
+        assert verdict == "blocked"
+
+    def test_no_findings_is_clear(self) -> None:
+        results = [
+            _result("trivy", "dependency"),
+            _result("complexity", "quality"),
+        ]
+        verdict, _, _ = _build_sections(results, None)
+        assert verdict == "clear"


### PR DESCRIPTION
## Summary
- **#92** `--format json` structured output — full plugin results, skip reasons, scores, verdict as parseable JSON
- **#93** Two-axis scoring — only security-category findings (dependency, supply_chain, infra) can trigger BLOCKED; quality/code findings are advisory warnings
- Closes Wave 3 epic (#76)

Closes #92, #93

## Test plan
- [x] 9 JSON report tests: schema version, verdict, plugins, skip reasons, errors, findings, totals, scores
- [x] 5 two-axis scoring tests: security blocks, quality doesn't block, quality warns, mixed, clear
- [x] 36 existing renderer tests pass (updated category on test fixtures)
- [x] Red-green verified on both features