### PR TITLE
fix: SLSA attestation non-blocking + Dockerfile tech debt triage

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -79,6 +79,7 @@ jobs:
           $ENGINE push "${{ steps.build.outputs.tag_latest }}"
 
       - name: Generate SLSA provenance attestation
+        continue-on-error: true
         uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # v4
         with:
           subject-name: ghcr.io/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary
- **#105** SLSA attestation step now `continue-on-error: true` — build succeeds even when attestation fails on self-hosted runners
- **#115, #116, #117** Dockerfile tech debt consolidated into a single future task (pip --target → venv, layer consolidation, lockfile-based installs)

Closes #105

## Test plan
- [x] Workflow YAML is valid (no syntax changes beyond adding continue-on-error)
- [x] Build+push still succeeds; attestation failure no longer shows red