### PR TITLE
ci: auto-merge release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,16 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Auto-merge release PR
+        if: steps.release.outputs.pr
+        run: |
+          PR_NUM=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
+          if [ "$PR_NUM" != "null" ] && [ -n "$PR_NUM" ]; then
+            gh pr merge "$PR_NUM" --auto --rebase || true
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   verify-key:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
Release-please PRs now auto-merge after GATEKEEPER passes (which skips on release-please branches). No more manual merge for version bumps.

Flow: push to main → release-please opens PR → GATEKEEPER skips → auto-merge → release cut → PyPI publish

Never touch a release PR again.