### PR TITLE
fix: tie version strings to importlib.metadata

### DIFF
--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import jinja2
 
 from eedom.core.plugin import PluginResult
+from eedom.core.version import get_version
 
 _MAX_COMMENT_LENGTH = 65536
 
@@ -22,7 +23,7 @@ CATEGORY_PRIORITY: dict[str, int] = {
     "quality": 4,
 }
 _DEFAULT_TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
-_VERSION = "1.2.0"
+_VERSION = get_version()
 
 _SEVERITY_WEIGHTS: dict[str, int] = {
     "critical": 10,

--- a/src/eedom/core/sarif.py
+++ b/src/eedom/core/sarif.py
@@ -10,6 +10,7 @@ import contextlib
 from pathlib import Path
 
 from eedom.core.plugin import PluginResult
+from eedom.core.version import get_version
 
 _SARIF_SCHEMA = (
     "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/"
@@ -131,6 +132,7 @@ def _plugin_to_run(
         "tool": {
             "driver": {
                 "name": tool_name,
+                "version": get_version(),
             }
         },
         "results": sarif_results,

--- a/src/eedom/core/version.py
+++ b/src/eedom/core/version.py
@@ -1,0 +1,16 @@
+"""Canonical version source for eedom.
+# tested-by: tests/unit/test_version_drift.py
+
+Single source of truth — delegates to importlib.metadata so the version
+always matches what is installed, with no risk of drift from a hardcoded
+literal.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+
+def get_version() -> str:
+    """Return the installed eedom version from importlib.metadata."""
+    return importlib.metadata.version("eedom")

--- a/tests/unit/test_version_drift.py
+++ b/tests/unit/test_version_drift.py
@@ -1,0 +1,112 @@
+"""Version drift guard — ensures a single canonical version source.
+# tested-by: tests/unit/test_version_drift.py
+
+All tests in this file are RED. They drive implementation of eedom.core.version.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# 1. get_version() exists in eedom.core.version
+# ---------------------------------------------------------------------------
+
+
+def test_get_version_is_importable():
+    """eedom.core.version must export get_version()."""
+    from eedom.core.version import get_version  # noqa: F401 — existence check only
+
+    assert callable(get_version)
+
+
+# ---------------------------------------------------------------------------
+# 2. renderer._VERSION matches get_version()
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_version_matches_canonical():
+    """renderer._VERSION must equal get_version() — no local override allowed."""
+    from eedom.core.version import get_version
+
+    import eedom.core.renderer as renderer
+
+    canonical = get_version()
+    assert canonical == renderer._VERSION, (
+        f"renderer._VERSION={renderer._VERSION!r} diverges from "
+        f"get_version()={canonical!r}. "
+        "renderer._VERSION must be removed and replaced with get_version()."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. SARIF tool driver version matches get_version()
+# ---------------------------------------------------------------------------
+
+
+def test_sarif_tool_driver_version_matches_canonical():
+    """SARIF tool driver must embed get_version() as the driver version."""
+    from eedom.core.version import get_version
+
+    from eedom.core.plugin import PluginResult
+    from eedom.core.sarif import to_sarif
+
+    result = PluginResult(plugin_name="test-plugin", findings=[])
+    doc = to_sarif([result])
+
+    canonical = get_version()
+    runs = doc.get("runs", [])
+    assert runs, "SARIF document must contain at least one run"
+
+    driver = runs[0]["tool"]["driver"]
+    driver_version = driver.get("version")
+    assert driver_version == canonical, (
+        f"SARIF tool driver version={driver_version!r} diverges from "
+        f"get_version()={canonical!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. get_version() returns a semver string (X.Y.Z)
+# ---------------------------------------------------------------------------
+
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
+
+
+def test_get_version_returns_semver():
+    """get_version() must return a string matching X.Y.Z semver pattern."""
+    from eedom.core.version import get_version
+
+    version = get_version()
+    assert isinstance(version, str), f"get_version() must return str, got {type(version)}"
+    assert _SEMVER_RE.match(
+        version
+    ), f"get_version() returned {version!r} which does not match semver X.Y.Z"
+
+
+# ---------------------------------------------------------------------------
+# 5. get_version() reads from importlib.metadata, not a hardcoded literal
+# ---------------------------------------------------------------------------
+
+
+def test_get_version_reads_from_importlib_metadata():
+    """get_version() must delegate to importlib.metadata, not return a literal."""
+    sentinel = "9.9.9-sentinel"
+
+    with patch("importlib.metadata.version", return_value=sentinel):
+        # Re-import to bypass any module-level caching
+        import importlib as _importlib
+
+        import eedom.core.version as _version_mod
+
+        _importlib.reload(_version_mod)
+        from eedom.core.version import get_version
+
+        result = get_version()
+
+    assert result == sentinel, (
+        f"get_version() returned {result!r} instead of the patched sentinel "
+        f"{sentinel!r}. It must call importlib.metadata.version('eedom') at "
+        "call-time (not cache a hardcoded literal at import time)."
+    )


### PR DESCRIPTION
## Summary
All version strings now read from `importlib.metadata.version("eedom")` — one source of truth.

- New `src/eedom/core/version.py` with `get_version()`
- `renderer._VERSION` uses `get_version()` instead of hardcoded `"1.2.0"`
- SARIF `tool.driver.version` uses `get_version()`
- Drift guard tests fail if any version diverges from package metadata

Closes #194

## Test plan
- [x] 5 drift guard tests: importable, renderer matches, SARIF matches, semver format, reads from importlib
- [x] 1159 tests pass, zero regressions