### PR TITLE
feat: add --scope flag for diff-scoped and folder-scoped scanning

### DIFF
--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -202,6 +202,12 @@ def evaluate(
 
 
 @cli.command()
+@click.option(
+    "--scope",
+    type=click.Choice(["repo", "diff", "folder"]),
+    default=None,
+    help="Scan scope: repo (full), diff (changed files only), folder (single directory).",
+)
 @click.option("--diff", type=str, default=None, help="Path to diff file.")
 @click.option("--repo-path", type=click.Path(exists=True), default=".", help="Repository root.")
 @click.option("--scanners", type=str, default=None, help="Comma-separated plugin names.")
@@ -263,6 +269,7 @@ def evaluate(
     help="GitHub repo (owner/name) for --pr mode. Auto-detected if omitted.",
 )
 def review(
+    scope: str | None,
     diff: str | None,
     repo_path: str,
     scanners: str | None,
@@ -286,6 +293,13 @@ def review(
     from eedom.core.plugin import PluginCategory
     from eedom.core.renderer import render_comment
     from eedom.core.repo_config import RepoConfig, load_repo_config
+    from eedom.core.use_cases import ScanScope
+
+    resolved_scope = ScanScope(scope) if scope else None
+    if resolved_scope == ScanScope.DIFF and not diff:
+        raise click.UsageError("--scope diff requires --diff <path>")
+    if resolved_scope == ScanScope.FOLDER and not package:
+        raise click.UsageError("--scope folder requires --package <path>")
 
     _ctx = bootstrap_review(registry_factory=get_default_registry)
     registry = _ctx.analyzer_registry
@@ -309,28 +323,11 @@ def review(
             enabled_names.add(_e.strip())
     enabled_names.discard("")
 
-    def _build_file_list() -> list[str]:
+    def _all_repo_files() -> list[str]:
         from eedom.core.ignore import load_ignore_patterns, should_ignore
 
         ignore_patterns = load_ignore_patterns(repo)
-
-        if diff:
-            diff_text = _read_diff(diff)
-            files: list[str] = []
-            for line in diff_text.split("\n"):
-                if line.startswith("diff --git"):
-                    parts = line.split(" b/")
-                    if len(parts) == 2:
-                        fpath = parts[1].strip()
-                        full = (repo / fpath).resolve()
-                        if not full.is_relative_to(repo.resolve()):
-                            continue
-                        if (full.exists() or not fpath.startswith(".git")) and not should_ignore(
-                            fpath, ignore_patterns
-                        ):
-                            files.append(str(full))
-            return files
-        files = []
+        files: list[str] = []
         for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json"):
             files.extend(
                 str(p)
@@ -339,18 +336,60 @@ def review(
             )
         return files
 
+    def _diff_files() -> list[str]:
+        from eedom.core.ignore import load_ignore_patterns, should_ignore
+
+        ignore_patterns = load_ignore_patterns(repo)
+        diff_text = _read_diff(diff)  # type: ignore[arg-type]
+        files: list[str] = []
+        for line in diff_text.split("\n"):
+            if line.startswith("diff --git"):
+                parts = line.split(" b/")
+                if len(parts) == 2:
+                    fpath = parts[1].strip()
+                    full = (repo / fpath).resolve()
+                    if not full.is_relative_to(repo.resolve()):
+                        continue
+                    if (full.exists() or not fpath.startswith(".git")) and not should_ignore(
+                        fpath, ignore_patterns
+                    ):
+                        files.append(str(full))
+        return files
+
+    def _build_file_lists() -> tuple[list[str], list[str] | None]:
+        """Return (files, repo_files). repo_files is non-None only in diff scope."""
+        if resolved_scope == ScanScope.DIFF:
+            return _diff_files(), _all_repo_files()
+        if resolved_scope == ScanScope.FOLDER:
+            from eedom.core.ignore import load_ignore_patterns, should_ignore
+
+            ignore_patterns = load_ignore_patterns(repo)
+            folder = Path(package).resolve()  # type: ignore[arg-type]
+            files: list[str] = []
+            for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json"):
+                files.extend(
+                    str(p)
+                    for p in folder.rglob(ext)
+                    if not should_ignore(str(p.relative_to(repo)), ignore_patterns)
+                )
+            return files, None
+        if diff:
+            return _diff_files(), None
+        return _all_repo_files(), None
+
     def run_review() -> None:
         from eedom.core.use_cases import ReviewOptions, review_repository
 
-        files = _build_file_list()
+        files, repo_file_list = _build_file_lists()
 
         options = ReviewOptions(
             scanners=names,
             categories=cats,
             disabled=disabled_names,
             enabled=enabled_names,
+            scope=resolved_scope or ScanScope.REPO,
         )
-        review_result = review_repository(_ctx, files, repo, options)
+        review_result = review_repository(_ctx, files, repo, options, repo_files=repo_file_list)
         results = review_result.results
 
         if output_format == "sarif" or pr is not None:

--- a/src/eedom/core/registry.py
+++ b/src/eedom/core/registry.py
@@ -94,6 +94,11 @@ class PluginRegistry:
             plugins = [p for p in plugins if p.name in name_set]
         return plugins
 
+    # Categories that always scan the full repo even in diff mode.
+    _REPO_WIDE_CATEGORIES: frozenset[PluginCategory] = frozenset(
+        {PluginCategory.dependency, PluginCategory.infra, PluginCategory.supply_chain}
+    )
+
     def run_all(
         self,
         files: list[str],
@@ -103,6 +108,7 @@ class PluginRegistry:
         disabled_names: set[str] | list[str] | None = None,
         enabled_names: set[str] | list[str] | None = None,
         package_units: list | None = None,
+        repo_files: list[str] | None = None,
     ) -> list[PluginResult]:
         """Run all matching plugins.
 
@@ -112,6 +118,9 @@ class PluginRegistry:
         3. *enabled_names* — plugins in this set override disabled_names.
            A plugin that is both disabled and enabled will run.
            enabled_names alone (without any disabled_names) has no filtering effect.
+
+        When *repo_files* is provided (diff mode), dependency/infra/supply_chain
+        plugins receive *repo_files* while code/quality plugins receive *files*.
 
         When *package_units* is provided (a list of
         ``eedom.core.manifest_discovery.PackageUnit``), each plugin is executed
@@ -145,7 +154,12 @@ class PluginRegistry:
 
         results: list[PluginResult] = []
         for plugin in plugins:
-            results.append(self._run_one(plugin, files, repo_path))
+            plugin_files = (
+                repo_files
+                if repo_files is not None and plugin.category in self._REPO_WIDE_CATEGORIES
+                else files
+            )
+            results.append(self._run_one(plugin, plugin_files, repo_path))
 
         return results
 

--- a/src/eedom/core/use_cases.py
+++ b/src/eedom/core/use_cases.py
@@ -10,11 +10,18 @@ Three public symbols:
 from __future__ import annotations
 
 import dataclasses
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from eedom.core.bootstrap import ApplicationContext
+
+
+class ScanScope(StrEnum):
+    REPO = "repo"
+    DIFF = "diff"
+    FOLDER = "folder"
 
 
 @dataclasses.dataclass
@@ -25,6 +32,7 @@ class ReviewOptions:
     categories: list | None = None
     disabled: set[str] = dataclasses.field(default_factory=set)
     enabled: set[str] = dataclasses.field(default_factory=set)
+    scope: ScanScope = ScanScope.REPO
 
 
 @dataclasses.dataclass
@@ -67,11 +75,16 @@ def review_repository(
     files: list,
     repo_path: Path,
     options: ReviewOptions,
+    repo_files: list | None = None,
 ) -> ReviewResult:
     """Run all matching plugins and return a structured ReviewResult.
 
     Delegates execution to ``context.analyzer_registry.run_all()``.
     Scores and verdict are derived from the aggregated plugin results.
+
+    When *repo_files* is provided (diff mode), code/quality plugins receive
+    *files* (diff-scoped) while dependency/infra/supply_chain plugins receive
+    *repo_files* (full repo).
     """
     from eedom.core.renderer import calculate_quality_score, calculate_severity_score
 
@@ -82,6 +95,7 @@ def review_repository(
         categories=options.categories,
         disabled_names=options.disabled,
         enabled_names=options.enabled,
+        repo_files=repo_files,
     )
 
     verdict = _derive_verdict(plugin_results)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1189,3 +1189,40 @@ class TestReviewPRMode:
 
         assert result.exit_code == 1
         assert "API error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --scope CLI flag
+# ---------------------------------------------------------------------------
+
+
+class TestScopeFlag:
+    def test_scope_option_in_review_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--help"])
+        assert "--scope" in result.output
+
+    def test_scope_accepts_repo_value(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--help"])
+        assert "repo" in result.output
+
+    def test_scope_accepts_diff_value(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--help"])
+        assert "diff" in result.output
+
+    def test_scope_accepts_folder_value(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--help"])
+        assert "folder" in result.output
+
+    def test_scope_diff_without_diff_file_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--scope", "diff", "--repo-path", "."])
+        assert result.exit_code != 0
+
+    def test_scope_folder_without_path_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["review", "--scope", "folder", "--repo-path", "."])
+        assert result.exit_code != 0

--- a/tests/unit/test_plugin_registry.py
+++ b/tests/unit/test_plugin_registry.py
@@ -768,3 +768,120 @@ class TestPluginDependencyGraph:
         from eedom.plugins._opa import OpaPlugin
 
         assert OpaPlugin().depends_on == ["*"]
+
+
+# ── run_all() with repo_files (diff-scoped routing) ──
+
+
+class _TrackingPlugin(ScannerPlugin):
+    """Records which files it received on each run() call."""
+
+    def __init__(self, plugin_name: str, plugin_category: PluginCategory) -> None:
+        self._name = plugin_name
+        self._category = plugin_category
+        self.received_files: list[list[str]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Tracking plugin {self._name}"
+
+    @property
+    def category(self) -> PluginCategory:
+        return self._category
+
+    def can_run(self, files: list[str], repo_path: Path) -> bool:
+        return True
+
+    def run(self, files: list[str], repo_path: Path) -> PluginResult:
+        self.received_files.append(list(files))
+        return PluginResult(plugin_name=self._name)
+
+
+class TestRepoFilesRouting:
+    """run_all(repo_files=...) routes files by plugin category."""
+
+    def test_repo_files_none_all_plugins_get_same_files(self):
+        reg = PluginRegistry()
+        code_p = _TrackingPlugin("code-scanner", PluginCategory.code)
+        dep_p = _TrackingPlugin("dep-scanner", PluginCategory.dependency)
+        reg.register(code_p)
+        reg.register(dep_p)
+
+        reg.run_all(["a.py", "b.py"], Path("."), repo_files=None)
+
+        assert code_p.received_files[0] == ["a.py", "b.py"]
+        assert dep_p.received_files[0] == ["a.py", "b.py"]
+
+    def test_repo_files_code_plugin_gets_diff_files(self):
+        reg = PluginRegistry()
+        code_p = _TrackingPlugin("code-scanner", PluginCategory.code)
+        reg.register(code_p)
+
+        diff_files = ["changed.py"]
+        repo_files = ["changed.py", "untouched.py", "other.py"]
+        reg.run_all(diff_files, Path("."), repo_files=repo_files)
+
+        assert code_p.received_files[0] == ["changed.py"]
+
+    def test_repo_files_quality_plugin_gets_diff_files(self):
+        reg = PluginRegistry()
+        qual_p = _TrackingPlugin("quality-scanner", PluginCategory.quality)
+        reg.register(qual_p)
+
+        diff_files = ["changed.py"]
+        repo_files = ["changed.py", "untouched.py"]
+        reg.run_all(diff_files, Path("."), repo_files=repo_files)
+
+        assert qual_p.received_files[0] == ["changed.py"]
+
+    def test_repo_files_dependency_plugin_gets_repo_files(self):
+        reg = PluginRegistry()
+        dep_p = _TrackingPlugin("dep-scanner", PluginCategory.dependency)
+        reg.register(dep_p)
+
+        diff_files = ["changed.py"]
+        repo_files = ["changed.py", "untouched.py", "other.py"]
+        reg.run_all(diff_files, Path("."), repo_files=repo_files)
+
+        assert dep_p.received_files[0] == ["changed.py", "untouched.py", "other.py"]
+
+    def test_repo_files_infra_plugin_gets_repo_files(self):
+        reg = PluginRegistry()
+        infra_p = _TrackingPlugin("infra-scanner", PluginCategory.infra)
+        reg.register(infra_p)
+
+        diff_files = ["changed.tf"]
+        repo_files = ["changed.tf", "main.tf", "vars.tf"]
+        reg.run_all(diff_files, Path("."), repo_files=repo_files)
+
+        assert infra_p.received_files[0] == ["changed.tf", "main.tf", "vars.tf"]
+
+    def test_repo_files_supply_chain_plugin_gets_repo_files(self):
+        reg = PluginRegistry()
+        sc_p = _TrackingPlugin("sc-scanner", PluginCategory.supply_chain)
+        reg.register(sc_p)
+
+        diff_files = ["changed.py"]
+        repo_files = ["changed.py", "requirements.txt"]
+        reg.run_all(diff_files, Path("."), repo_files=repo_files)
+
+        assert sc_p.received_files[0] == ["changed.py", "requirements.txt"]
+
+    def test_repo_files_mixed_plugins_route_correctly(self):
+        """Code gets diff files, dependency gets repo files, in same run."""
+        reg = PluginRegistry()
+        code_p = _TrackingPlugin("code-scanner", PluginCategory.code)
+        dep_p = _TrackingPlugin("dep-scanner", PluginCategory.dependency)
+        reg.register(code_p)
+        reg.register(dep_p)
+
+        diff_files = ["changed.py"]
+        repo_files = ["changed.py", "untouched.py", "other.py"]
+        reg.run_all(diff_files, Path("."), repo_files=repo_files)
+
+        assert code_p.received_files[0] == ["changed.py"]
+        assert dep_p.received_files[0] == ["changed.py", "untouched.py", "other.py"]

--- a/tests/unit/test_use_cases.py
+++ b/tests/unit/test_use_cases.py
@@ -202,3 +202,69 @@ class TestReviewRepository:
         # Must accept a real pathlib.Path, not just a string.
         result = review_repository(ctx, files=[], repo_path=Path("/tmp/fake-repo"), options=opts)
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# ScanScope enum
+# ---------------------------------------------------------------------------
+
+
+class TestScanScope:
+    def test_scan_scope_is_importable(self) -> None:
+        from eedom.core.use_cases import ScanScope  # noqa: F401
+
+    def test_scan_scope_has_repo_value(self) -> None:
+        from eedom.core.use_cases import ScanScope
+
+        assert ScanScope.REPO == "repo"
+
+    def test_scan_scope_has_diff_value(self) -> None:
+        from eedom.core.use_cases import ScanScope
+
+        assert ScanScope.DIFF == "diff"
+
+    def test_scan_scope_has_folder_value(self) -> None:
+        from eedom.core.use_cases import ScanScope
+
+        assert ScanScope.FOLDER == "folder"
+
+    def test_review_options_has_scope_field(self) -> None:
+        from eedom.core.use_cases import ReviewOptions
+
+        fields = {f.name for f in dataclasses.fields(ReviewOptions)}
+        assert "scope" in fields
+
+    def test_review_options_scope_defaults_to_repo(self) -> None:
+        from eedom.core.use_cases import ReviewOptions, ScanScope
+
+        opts = ReviewOptions()
+        assert opts.scope == ScanScope.REPO
+
+
+# ---------------------------------------------------------------------------
+# review_repository() with repo_files (diff-scoped routing)
+# ---------------------------------------------------------------------------
+
+
+class TestReviewRepositoryRepoFiles:
+    def test_review_repository_accepts_repo_files_kwarg(self) -> None:
+        from eedom.core.bootstrap import bootstrap_test
+        from eedom.core.use_cases import ReviewOptions, review_repository
+
+        ctx = bootstrap_test()
+        opts = ReviewOptions()
+        result = review_repository(
+            ctx, files=[], repo_path=Path("."), options=opts, repo_files=["a.py"]
+        )
+        assert result is not None
+
+    def test_review_repository_repo_files_none_is_backward_compat(self) -> None:
+        from eedom.core.bootstrap import bootstrap_test
+        from eedom.core.use_cases import ReviewOptions, review_repository
+
+        ctx = bootstrap_test()
+        opts = ReviewOptions()
+        result = review_repository(
+            ctx, files=[], repo_path=Path("."), options=opts, repo_files=None
+        )
+        assert result.verdict == "clear"


### PR DESCRIPTION
## Summary

- Adds `--scope repo|diff|folder` CLI flag to `eedom review`
- In **diff** mode: code/quality plugins (semgrep, cpd, mypy, complexity, cspell, blast_radius, ls_lint) receive only changed files; dependency/infra/supply_chain plugins (trivy, osv, scancode, syft, opa, cdk_nag, cfn_nag, kube_linter, clamav, gitleaks, supply_chain) receive the full repo file list
- In **folder** mode: all plugins scoped to a single directory tree
- Backward compatible — existing `--diff` and `--all` flags work unchanged without `--scope`

### Changes

- `src/eedom/core/use_cases.py`: Added `ScanScope` enum (`repo`/`diff`/`folder`) and `scope` field on `ReviewOptions`. Added `repo_files` parameter to `review_repository()`
- `src/eedom/core/registry.py`: Added `repo_files` parameter to `run_all()`. When provided, `_REPO_WIDE_CATEGORIES` (dependency, infra, supply_chain) receive `repo_files` while code/quality receive `files`
- `src/eedom/cli/main.py`: Added `--scope` Click option with validation. Refactored file list building into `_all_repo_files()`, `_diff_files()`, and `_build_file_lists()` which returns the appropriate tuple based on scope

## Test plan

- [x] RED: 21 new tests written first, confirmed failing for the right reasons
- [x] GREEN: All 21 tests pass after implementation
- [x] 157 tests in changed files pass with 0 regressions
- [x] Lint clean (ruff check)
- [ ] Container test run (`make test`)