### PR TITLE
Improve Dom review prose and prescriptive comments

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -223,7 +223,19 @@ jobs:
         if: steps.docs.outputs.docs_only != 'true' && github.event_name == 'pull_request' && steps.verdict.outputs.verdict == 'incomplete'
         continue-on-error: true
         run: |
-          TITLE="[eedom-crash] ${CRASHED} plugin(s) crashed reviewing PR #${PR_NUM}"
+          format_count() {
+            local count="$1"
+            local singular="$2"
+            local plural="$3"
+            if [ "$count" = "1" ]; then
+              printf "%s %s" "$count" "$singular"
+            else
+              printf "%s %s" "$count" "$plural"
+            fi
+          }
+
+          CRASHED_TEXT="$(format_count "${CRASHED:-0}" "plugin crashed" "plugins crashed")"
+          TITLE="[eedom-crash] ${CRASHED_TEXT} reviewing PR #${PR_NUM}"
           EXISTING=$(gh issue list --search "\"$TITLE\" in:title" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [ -n "$EXISTING" ]; then
             echo "Issue #$EXISTING already open — skipping"
@@ -270,13 +282,28 @@ jobs:
           if [ "$VERDICT" = "warnings" ]; then ICON="⚠️"; fi
           if [ "$VERDICT" = "incomplete" ]; then ICON="🟣"; fi
 
+          format_count() {
+            local count="$1"
+            local singular="$2"
+            local plural="$3"
+            if [ "$count" = "1" ]; then
+              printf "%s %s" "$count" "$singular"
+            else
+              printf "%s %s" "$count" "$plural"
+            fi
+          }
+
+          ERROR_TEXT="$(format_count "${ERRORS:-0}" "error" "errors")"
+          WARNING_TEXT="$(format_count "${WARNINGS:-0}" "warning" "warnings")"
+
           MARKER="<!-- eedom-review -->"
           CRASHED_NOTE=""
           if [ "${CRASHED:-0}" -ge 1 ]; then
-            CRASHED_NOTE=" | ${CRASHED} plugin(s) crashed"
+            CRASHED_TEXT="$(format_count "${CRASHED:-0}" "plugin crashed" "plugins crashed")"
+            CRASHED_NOTE=" | ${CRASHED_TEXT}"
           fi
           BODY="${MARKER}
-          ${ICON} **dom: ${VERDICT}** — ${ERRORS} error(s), ${WARNINGS} warning(s)${CRASHED_NOTE}
+          ${ICON} **dom: ${VERDICT}** - ${ERROR_TEXT}, ${WARNING_TEXT}${CRASHED_NOTE}
 
           <details>
           <summary>Full review</summary>

--- a/src/eedom/agent/prompt.py
+++ b/src/eedom/agent/prompt.py
@@ -9,53 +9,66 @@ Semgrep findings, and formats PR comments.
 from __future__ import annotations
 
 _RUBRIC = """\
-Evaluate each changed package against these 8 dimensions. Score each PASS, CONCERN, or FAIL.
+Evaluate each changed package against these 8 dimensions. Score each PASS, CONCERN,
+or FAIL.
 
-1. NECESSITY — Is a third-party dependency required at all? Could the stated use case \
-be satisfied by the language's standard library, an existing approved internal package, \
-or fewer than 50 lines of purpose-built code? If yes, the dependency is unnecessary \
-regardless of quality.
+1. NECESSITY
+   Is a third-party dependency required at all? Could the use case be satisfied by
+   the standard library, an approved internal package, or fewer than 50 lines of
+   purpose-built code?
 
-2. MINIMALITY — Is this the narrowest reasonable dependency for the task? A package \
-that provides 200 features when the team needs 1 is an overpowered choice. Flag \
-disproportionate scope.
+2. MINIMALITY
+   Is this the narrowest reasonable dependency for the task? Flag packages whose
+   scope is much larger than the stated need.
 
-3. MAINTENANCE — Is the project actively maintained? When was the last release? \
-Is the repo archived or deprecated? How many maintainers? A single-maintainer \
-package with no release in 2 years is a future supply chain risk.
+3. MAINTENANCE
+   Is the project actively maintained? Check release recency, archive/deprecation
+   status, maintainer depth, and unresolved maintenance signals.
 
-4. SECURITY — Does the package show healthy supply-chain signals? Signed releases, \
-provenance attestation, security policy, responsible disclosure, timely CVE response. \
-Multiple absences compound.
+4. SECURITY
+   Does the package show healthy supply-chain signals: signed releases, provenance,
+   a security policy, responsible disclosure, and timely CVE response?
 
-5. EXPOSURE — Will this package process untrusted input, handle secrets, manage auth \
-tokens, parse external serialized data, or run internet-facing? Higher exposure demands \
-higher scrutiny.
+5. EXPOSURE
+   Will this package process untrusted input, secrets, auth tokens, serialized data,
+   or internet-facing requests? Higher exposure demands higher scrutiny.
 
-6. BLAST_RADIUS — How much transitive complexity does this package add? A package \
-that pulls 300 transitive deps for a logging utility is a blast radius problem. \
-Native extensions and platform-specific binaries increase operational risk.
+6. BLAST_RADIUS
+   How much transitive complexity does this package add? Native extensions,
+   platform-specific binaries, and large dependency trees increase operational risk.
 
-7. ALTERNATIVES — Are there safer, already-approved alternatives that serve the same \
-purpose? If the organization has approved package X for this category, recommending Y \
-requires justification. Always surface approved alternatives when they exist.
+7. ALTERNATIVES
+   Are there safer, already-approved alternatives that serve the same purpose?
+   If yes, explain why the proposed package is still justified.
 
-8. BEHAVIORAL — Does the package execute code at install time? Make network requests \
-during import? Spawn child processes or access the filesystem outside its scope? \
-Any of these is a flag."""
+8. BEHAVIORAL
+   Does the package execute code at install time, make network requests during import,
+   spawn child processes, or access the filesystem outside its scope?"""
 
 _COMMENT_FORMAT = """\
 Format each package comment as:
 
 ## {verdict_badge} `{package}@{version}` ({ecosystem})
 
-**Decision**: {verdict} | **Policy**: v{policy_version}
+**Decision:** {verdict} | **Policy:** v{policy_version}
 
-{key findings — 2-3 bullet points for approve, more detail for reject/review}
+**Required:** Use only when the PR must change before merge.
+What failed:
+  Name the exact dependency, policy, scanner result, or code pattern.
+Why it matters:
+  Explain the concrete risk to the code, build, runtime, or reviewability.
+Fix:
+  Give the smallest acceptable remediation when the policy or scanner is clear.
+Done when:
+  State the observable condition that makes the comment resolved.
+Verify:
+  Name the scanner, command, or evidence that should be clean after the fix.
 
-{task-fit assessment: list only dimensions that scored CONCERN or FAIL, skip if all PASS}
+**Consider:** Use for non-blocking improvements where author judgment is appropriate.
+Why it matters:
+  Explain the tradeoff, then let the author choose the implementation.
 
-{what to do — only for reject or needs_review verdicts}
+**FYI:** Use only for durable context that does not need action in this PR.
 
 Verdict badges:
 - 🟢 APPROVED
@@ -84,7 +97,7 @@ Semgrep catches:
 - Docker issues: running as root, missing health checks, insecure base images
 - CI/CD issues: secret exposure in workflows, unsafe script injection
 - Shell script issues: unquoted variables, injection risks, unsafe eval
-- Org custom rules: bare except:pass, print() in prod, hardcoded localhost, pickle.load
+- Org custom rules: bare except:pass, print calls in prod, hardcoded localhost, pickle.load
 - Repeated mistakes: patterns the team keeps introducing
 
 Semgrep does NOT catch:
@@ -96,7 +109,7 @@ Semgrep does NOT catch:
 When presenting Semgrep findings:
 - Group by severity: ERROR first, then WARNING, then INFO
 - For each finding: rule name, what it caught, why it matters, file:line
-- Keep it actionable — the developer should know what to fix
+- Keep it prescriptive enough that the developer knows what to fix
 - Clearly separate code findings from dependency findings
 - Label the section: "### Code Patterns (Semgrep)"
 - If no findings: do NOT post a "no findings" section — silence means clean
@@ -113,8 +126,13 @@ Rules:
 - If you lack information for a dimension, score it CONCERN with "insufficient data."
 - Never score PASS on trust alone — "it's popular" is not evidence of safety.
 - If approved alternatives exist, ALTERNATIVES must be CONCERN or FAIL.
-- Keep comments concise. A developer should read your comment and immediately understand: \
-what changed, what the risk is, and what to do about it.
+- Always comment about the code, not the developer.
+- Explain why the finding matters; do not just restate scanner output.
+- Be prescriptive when a deterministic gate blocks the PR.
+- Point out the problem and let the author choose when multiple fixes are acceptable.
+- Encourage simpler code or code comments instead of accepting complex explanations in chat.
+- Keep comments concise enough that the author immediately understands the change, risk,
+  and next action.
 - Each package gets its own separate comment block.
 - Do not repeat scanner output verbatim — synthesize and explain."""
 
@@ -130,20 +148,20 @@ def build_system_prompt(
         alt_section = f"\n\nApproved alternative packages in this organization: {alt_list}"
 
     return f"""\
-You are GATEKEEPER, a dependency review and code review agent for a \
-software engineering organization.
+You are GATEKEEPER, a dependency review and code review agent for a software
+engineering organization.
 
-Your job: when a pull request changes dependency manifests or source code, you \
-evaluate the changes and post clear, concise review comments. You have three tools:
+Your job: when a pull request changes dependency manifests or source code, evaluate
+the changes and post clear, concise review comments. You have three tools:
 
-1. **evaluate_change** — runs the full review pipeline (5 scanners + OPA policy) \
-on a PR diff. Call this for every PR with dependency changes.
-2. **check_package** — evaluates a single package via scanners + OPA. Use for \
-targeted lookups.
-3. **scan_code** — runs Semgrep on changed files. Call this for every PR to surface \
-code pattern issues.
+1. **evaluate_change** — runs the full review pipeline on a PR diff.
+   Call this for every PR with dependency changes.
+2. **check_package** — evaluates a single package via scanners and OPA.
+   Use this for targeted lookups.
+3. **scan_code** — runs Semgrep on changed files.
+   Call this for every PR to surface code pattern issues.
 
-Always call evaluate_change first for dependency changes, then scan_code for code \
+Always call evaluate_change first for dependency changes, then scan_code for code
 patterns. Use check_package only if the developer asks about a specific package.
 
 ## Dependency Review — 8-Dimension Task-Fit Rubric
@@ -160,10 +178,11 @@ patterns. Use check_package only if the developer asks about a specific package.
 
 Current policy bundle: v{policy_version}{alt_section}
 
-## {_RULES}
+## Review Rules
+
+{_RULES}
 
 ## Tone
 
-Professional but not robotic. Concise. A developer should read your comment and \
-immediately understand what changed, what the risk is, and what to do about it. \
-No filler, no generic advice. Specifics only."""
+Professional but not robotic. Be direct about the patch, courteous to the author,
+and precise about what would resolve the review. No filler and no generic advice."""

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -300,6 +300,7 @@ def review(
         raise click.UsageError("--scope diff requires --diff <path>")
     if resolved_scope == ScanScope.FOLDER and not package:
         raise click.UsageError("--scope folder requires --package <path>")
+    effective_scope = resolved_scope or (ScanScope.DIFF if diff else ScanScope.REPO)
 
     _ctx = bootstrap_review(registry_factory=get_default_registry)
     registry = _ctx.analyzer_registry
@@ -387,7 +388,7 @@ def review(
             categories=cats,
             disabled=disabled_names,
             enabled=enabled_names,
-            scope=resolved_scope or ScanScope.REPO,
+            scope=effective_scope,
         )
         review_result = review_repository(_ctx, files, repo, options, repo_files=repo_file_list)
         results = review_result.results
@@ -455,6 +456,8 @@ def review(
             pr_num=pr_num,
             title=title,
             file_count=len(files),
+            scan_scope=effective_scope.value,
+            repo_file_count=len(repo_file_list) if repo_file_list is not None else None,
             plugin_renderers=plugin_map,
         )
         if output:

--- a/src/eedom/core/actionability.py
+++ b/src/eedom/core/actionability.py
@@ -15,9 +15,12 @@ _CRITICAL_HIGH = {"critical", "high"}
 class ActionabilitySummary:
     actionable: list[dict] = field(default_factory=list)
     blocked: list[dict] = field(default_factory=list)
+    owner_action: list[dict] = field(default_factory=list)
     actionable_count: int = 0
     blocked_count: int = 0
+    owner_action_count: int = 0
     blocked_by_source: dict[str, list[dict]] = field(default_factory=dict)
+    owner_action_by_source: dict[str, list[dict]] = field(default_factory=dict)
     summary_text: str = ""
 
 
@@ -26,41 +29,86 @@ def _is_actionable(finding: dict) -> bool:
     return bool(fv and fv.strip())
 
 
+_DEPENDENCY_SOURCES = {"trivy", "osv", "osv-scanner"}
+_OWNER_ACTION_SOURCES = {"opa"}
+
+
+def _is_dependency_source(result: PluginResult) -> bool:
+    if result.plugin_name in _OWNER_ACTION_SOURCES:
+        return False
+    return result.category == "dependency" or result.plugin_name in _DEPENDENCY_SOURCES
+
+
+def _severity_counts(findings: list[dict]) -> str:
+    crit = sum(1 for f in findings if f.get("severity", "") == "critical")
+    high = sum(1 for f in findings if f.get("severity", "") == "high")
+    parts = []
+    if crit:
+        parts.append(f"{crit} CRITICAL")
+    if high:
+        parts.append(f"{high} HIGH")
+    return " + ".join(parts)
+
+
+def _finding_noun(count: int) -> str:
+    return "finding" if count == 1 else "findings"
+
+
+def _finding_verb(count: int) -> str:
+    return "requires" if count == 1 else "require"
+
+
 def _build_summary_text(
     actionable: list[dict],
     blocked: list[dict],
+    owner_action: list[dict],
 ) -> str:
-    total = len(actionable) + len(blocked)
+    total = len(actionable) + len(blocked) + len(owner_action)
     if total == 0:
         return "No findings."
 
     crit_high_blocked = sum(1 for f in blocked if f.get("severity", "") in _CRITICAL_HIGH)
-    crit_blocked = sum(1 for f in blocked if f.get("severity", "") == "critical")
-    high_blocked = sum(1 for f in blocked if f.get("severity", "") == "high")
+    blocked_severity = _severity_counts(blocked)
+    owner_severity = _severity_counts(owner_action)
 
-    if not actionable:
+    if owner_action and not actionable and not blocked:
+        count = len(owner_action)
+        prefix = (
+            f"{owner_severity} {_finding_noun(count)}"
+            if owner_severity
+            else f"{count} {_finding_noun(count)}"
+        )
+        return f"{prefix} {_finding_verb(count)} code/config changes in this PR."
+
+    if blocked and not actionable and not owner_action:
         # All blocked
         if crit_high_blocked > 0:
-            parts = []
-            if crit_blocked:
-                parts.append(f"{crit_blocked} CRITICAL")
-            if high_blocked:
-                parts.append(f"{high_blocked} HIGH")
-            severity_str = " + ".join(parts) if parts else f"{crit_high_blocked} CRITICAL/HIGH"
+            severity_str = (
+                blocked_severity if blocked_severity else f"{crit_high_blocked} CRITICAL/HIGH"
+            )
             return (
                 f"{severity_str} findings — none actionable by you. "
                 "All in upstream dependencies at latest release."
             )
         return f"{len(blocked)} findings — none actionable by you."
 
-    if not blocked:
+    if actionable and not blocked and not owner_action:
         # All actionable
         return f"All {len(actionable)} findings have available fixes."
 
-    # Mixed
-    return (
-        f"{len(actionable)} findings have available fixes. {len(blocked)} are blocked on upstream."
-    )
+    parts = []
+    if actionable:
+        verb = "has" if len(actionable) == 1 else "have"
+        parts.append(f"{len(actionable)} {_finding_noun(len(actionable))} {verb} available fixes")
+    if owner_action:
+        parts.append(
+            f"{len(owner_action)} {_finding_noun(len(owner_action))} "
+            f"{_finding_verb(len(owner_action))} code/config changes"
+        )
+    if blocked:
+        verb = "is" if len(blocked) == 1 else "are"
+        parts.append(f"{len(blocked)} {_finding_noun(len(blocked))} {verb} blocked on upstream")
+    return ". ".join(parts) + "."
 
 
 def classify_findings(results: list[PluginResult]) -> ActionabilitySummary:
@@ -75,21 +123,29 @@ def classify_findings(results: list[PluginResult]) -> ActionabilitySummary:
     """
     actionable: list[dict] = []
     blocked: list[dict] = []
+    owner_action: list[dict] = []
     blocked_by_source: dict[str, list[dict]] = {}
+    owner_action_by_source: dict[str, list[dict]] = {}
 
     for result in results:
         for finding in result.findings:
             if _is_actionable(finding):
                 actionable.append(finding)
-            else:
+            elif _is_dependency_source(result):
                 blocked.append(finding)
                 blocked_by_source.setdefault(result.plugin_name, []).append(finding)
+            else:
+                owner_action.append(finding)
+                owner_action_by_source.setdefault(result.plugin_name, []).append(finding)
 
     return ActionabilitySummary(
         actionable=actionable,
         blocked=blocked,
+        owner_action=owner_action,
         actionable_count=len(actionable),
         blocked_count=len(blocked),
+        owner_action_count=len(owner_action),
         blocked_by_source=blocked_by_source,
-        summary_text=_build_summary_text(actionable, blocked),
+        owner_action_by_source=owner_action_by_source,
+        summary_text=_build_summary_text(actionable, blocked, owner_action),
     )

--- a/src/eedom/core/pr_review.py
+++ b/src/eedom/core/pr_review.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import textwrap
 from dataclasses import dataclass, field
 
 import structlog
@@ -52,21 +53,158 @@ class PRReview:
     outside_diff: list[dict] = field(default_factory=list)
 
 
-def _build_smart_comment(rule_id: str, level: str, msg: str, result: dict) -> str:
-    """Build a SMART inline comment: Specific, Measurable, Actionable, Relevant, Targeted."""
-    icon = {"error": "🔴", "warning": "🟡", "note": "🔵"}.get(level, "⚪")
-    parts = [f"{icon} **{rule_id}** (`{level}`)"]
-    parts.append("")
-    parts.append(msg)
+def _location_from_result(result: dict) -> tuple[str, int]:
+    locations = result.get("locations", [])
+    if not locations:
+        return "", 1
+    phys = locations[0].get("physicalLocation", {})
+    file_path = phys.get("artifactLocation", {}).get("uri", "")
+    line_num = phys.get("region", {}).get("startLine", 1)
+    return file_path, line_num
 
+
+def _target_text(file_path: str, line_num: int) -> str:
+    return f"`{file_path}:{line_num}`" if file_path else "`repository`"
+
+
+def _wrap_lines(text: str, width: int = 96) -> list[str]:
+    return textwrap.wrap(
+        str(text),
+        width=width,
+        break_long_words=True,
+        break_on_hyphens=False,
+    ) or [""]
+
+
+def _labeled_lines(label: str, text: str) -> list[str]:
+    return [f"{label}:"] + [f"  {line}" for line in _wrap_lines(text)]
+
+
+def _bullet_lines(label: str, text: str) -> list[str]:
+    return [f"- {label}:"] + [f"  {line}" for line in _wrap_lines(text)]
+
+
+def _finding_noun(count: int) -> str:
+    return "finding" if count == 1 else "findings"
+
+
+def _count_phrase(count: int, noun: str) -> str:
+    suffix = "" if count == 1 else "s"
+    return f"{count} {noun}{suffix}"
+
+
+def _review_label(level: str) -> str:
+    if level == "error":
+        return "Required"
+    if level == "warning":
+        return "Consider"
+    return "FYI"
+
+
+def _why_text(rule_id: str, level: str, msg: str) -> str:
+    rule_lower = rule_id.lower()
+    msg_lower = msg.lower()
+    if "secret" in rule_lower or "secret" in msg_lower or "key" in rule_lower:
+        return "Exposed credentials can be reused outside this PR until removed and rotated."
+    if "sql" in rule_lower or "sql" in msg_lower:
+        return "Concatenated input can let request data change the SQL query structure."
+    if "dependency" in rule_lower or "cve" in rule_lower:
+        return "A vulnerable dependency can ship exploitable code with the application."
+    if level == "error":
+        return "Dom marks this required because eedom reported an error-level finding in this PR."
+    if level == "warning":
+        return "This is non-blocking guidance; addressing it now can reduce follow-up review churn."
+    return "This is informational context for future cleanup."
+
+
+def _fix_text(rule_id: str, msg: str, result: dict) -> str:
     fixes = result.get("fixes", [])
     if fixes:
         fix_text = fixes[0].get("description", {}).get("text", "")
         if fix_text:
-            parts.append("")
-            parts.append(f"**Fix:** {fix_text}")
+            return fix_text
+
+    rule_lower = rule_id.lower()
+    msg_lower = msg.lower()
+    if "secret" in rule_lower or "secret" in msg_lower or "key" in rule_lower:
+        return (
+            "Remove the secret from the diff, rotate the exposed credential, "
+            "and load it from secrets management."
+        )
+    if "sql" in rule_lower or "sql" in msg_lower:
+        return "Parameterize the query or use a safe query builder; do not concatenate input."
+    if "dependency" in rule_lower or "cve" in rule_lower:
+        return "Upgrade, replace, or pin the affected dependency to a safe release."
+    return (
+        "Simplify the flagged code/config where possible, or make the intent explicit, "
+        "then change it so the rule no longer matches."
+    )
+
+
+def _build_smart_comment(rule_id: str, level: str, msg: str, result: dict) -> str:
+    """Build an inline comment with concrete fix, pass condition, and verification."""
+    icon = {"error": "🔴", "warning": "🟡", "note": "🔵"}.get(level, "⚪")
+    file_path, line_num = _location_from_result(result)
+    target = _target_text(file_path, line_num)
+    fix_text = _fix_text(rule_id, msg, result)
+    label = _review_label(level)
+    parts = [f"{icon} **{label}:** `{rule_id}` (`{level}`)"]
+    parts.append("")
+    parts.extend(_labeled_lines("What failed", msg))
+    why_label = "Why it blocks" if label == "Required" else "Why it matters"
+    parts.extend(_labeled_lines(why_label, _why_text(rule_id, level, msg)))
+    parts.extend(_labeled_lines("Fix", fix_text))
+    parts.extend(_labeled_lines("Done when", f"`{rule_id}` is absent on the next eedom run."))
+    parts.extend(_labeled_lines("Where", target))
+    parts.extend(_labeled_lines("Verify", "`uv run eedom review --repo-path . --all`"))
 
     return "\n".join(parts)
+
+
+def _build_body_smart_plan(blockers: list[dict]) -> list[str]:
+    if not blockers:
+        return []
+
+    lines = [
+        "",
+        "### Blocking Fix Plan",
+        "",
+        f"> Why blocked: {len(blockers)} error-level {_finding_noun(len(blockers))} "
+        "must be fixed before merge.",
+        "",
+    ]
+    for blocker in blockers[:5]:
+        target = _target_text(blocker["file"], blocker["line"])
+        lines.append(f"**Required:** `{blocker['rule']}` — {target}")
+        lines.extend(_bullet_lines("What failed", blocker["message"]))
+        lines.extend(
+            _bullet_lines(
+                "Why it blocks",
+                _why_text(blocker["rule"], blocker["level"], blocker["message"]),
+            )
+        )
+        lines.extend(
+            _bullet_lines(
+                "Fix",
+                _fix_text(blocker["rule"], blocker["message"], blocker["raw"]),
+            )
+        )
+        lines.extend(
+            _bullet_lines(
+                "Done when",
+                f"This `{blocker['level']}` finding is absent from the next run.",
+            )
+        )
+        lines.extend(
+            _bullet_lines(
+                "Verify",
+                "Fix this location and verify with `uv run eedom review --repo-path . --all`.",
+            )
+        )
+        lines.append("")
+    if len(blockers) > 5:
+        lines.append(f"*...{len(blockers) - 5} more blocker(s) omitted from this summary.*")
+    return lines
 
 
 def sarif_to_review(
@@ -82,6 +220,7 @@ def sarif_to_review(
     """
     comments: list[ReviewComment] = []
     outside: list[dict] = []
+    blockers: list[dict] = []
     error_count = 0
     warning_count = 0
     total = 0
@@ -98,16 +237,21 @@ def sarif_to_review(
 
             msg = result.get("message", {}).get("text", "")
             rule_id = result.get("ruleId", tool_name)
-            locations = result.get("locations", [])
-
-            file_path = ""
-            line_num = 1
-            if locations:
-                phys = locations[0].get("physicalLocation", {})
-                file_path = phys.get("artifactLocation", {}).get("uri", "")
-                line_num = phys.get("region", {}).get("startLine", 1)
+            file_path, line_num = _location_from_result(result)
 
             comment_body = _build_smart_comment(rule_id, level, msg, result)
+
+            if level == "error":
+                blockers.append(
+                    {
+                        "file": file_path,
+                        "line": line_num,
+                        "rule": rule_id,
+                        "level": level,
+                        "message": msg,
+                        "raw": result,
+                    }
+                )
 
             in_diff = file_path and file_path in diff_files
             in_hunk = True
@@ -135,10 +279,10 @@ def sarif_to_review(
 
     if error_count > 0:
         event = "REQUEST_CHANGES"
-        verdict = f"🚫 **{error_count} blocking finding(s)** found"
+        verdict = f"🚫 **{error_count} blocking {_finding_noun(error_count)}** found"
     elif warning_count > 0:
         event = "COMMENT"
-        verdict = f"⚠️ **{warning_count} warning(s)** found, no blockers"
+        verdict = f"⚠️ **{_count_phrase(warning_count, 'warning')}** found, no blockers"
     else:
         event = "COMMENT"
         verdict = "✅ No findings"
@@ -146,15 +290,20 @@ def sarif_to_review(
     body_lines = [
         f"## Eagle Eyed Dom — {verdict}",
         "",
-        f"**{total}** findings: {error_count} error, "
-        f"{warning_count} warning, {total - error_count - warning_count} note",
+        f"**{total}** {_finding_noun(total)}: {_count_phrase(error_count, 'error')}, "
+        f"{_count_phrase(warning_count, 'warning')}, "
+        f"{_count_phrase(total - error_count - warning_count, 'note')}",
         f"**{len(comments)}** inline, **{len(outside)}** outside diff",
     ]
+
+    body_lines.extend(_build_body_smart_plan(blockers))
 
     if outside:
         body_lines.append("")
         body_lines.append("<details>")
-        body_lines.append(f"<summary>{len(outside)} finding(s) outside the PR diff</summary>")
+        body_lines.append(
+            f"<summary>{len(outside)} {_finding_noun(len(outside))} outside the PR diff</summary>"
+        )
         body_lines.append("")
         body_lines.append("| File | Line | Rule | Level | Message |")
         body_lines.append("|------|------|------|-------|---------|")

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -6,6 +6,7 @@ Pure function: no I/O beyond reading template files.
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 import jinja2
@@ -58,6 +59,204 @@ _QUALITY_PLUGINS: set[str] = {
 def _plugin_is_security(plugin_name: str) -> bool:
     normalized = plugin_name.lower().replace("_", "-")
     return normalized in _SECURITY_PLUGINS
+
+
+def _collapse_excess_blank_lines(output: str) -> str:
+    while "\n\n\n" in output:
+        output = output.replace("\n\n\n", "\n\n")
+    return output
+
+
+def _compact_smart_spacing(output: str) -> str:
+    labels = {
+        "- What failed:",
+        "- Why it blocks:",
+        "- Fix:",
+        "- Done when:",
+        "- Verify:",
+    }
+    lines = output.splitlines()
+    compacted: list[str] = []
+    for index, line in enumerate(lines):
+        previous = compacted[-1] if compacted else ""
+        next_line = lines[index + 1] if index + 1 < len(lines) else ""
+        if (
+            line == ""
+            and next_line.startswith("  ")
+            and (previous in labels or previous.startswith("  "))
+        ):
+            continue
+        compacted.append(line)
+    return "\n".join(compacted) + ("\n" if output.endswith("\n") else "")
+
+
+def _wrap_lines(text: str, width: int = 96) -> list[str]:
+    return textwrap.wrap(
+        str(text),
+        width=width,
+        break_long_words=True,
+        break_on_hyphens=False,
+    ) or [""]
+
+
+def _finding_severity(finding: dict) -> str:
+    return str(finding.get("severity", "")).lower()
+
+
+def _finding_label(finding: dict) -> str:
+    rule = (
+        finding.get("rule") or finding.get("rule_id") or finding.get("id") or finding.get("check")
+    )
+    if rule:
+        return str(rule)
+    return "finding"
+
+
+def _finding_target(finding: dict) -> str:
+    file_path = finding.get("file") or finding.get("path")
+    line = finding.get("line") or finding.get("start_line")
+    if file_path:
+        return f"`{file_path}:{line}`" if line else f"`{file_path}`"
+    package = finding.get("package")
+    if package:
+        version = finding.get("version")
+        return f"`{package}@{version}`" if version else f"`{package}`"
+    return f"`{_finding_label(finding)}`"
+
+
+def _finding_message(finding: dict) -> str:
+    return str(
+        finding.get("message")
+        or finding.get("description")
+        or finding.get("summary")
+        or _finding_label(finding)
+    )
+
+
+def _remediation_for(plugin_name: str, finding: dict) -> str:
+    fixed_version = str(finding.get("fixed_version", "")).strip()
+    package = finding.get("package")
+    version = finding.get("version")
+    if fixed_version and package:
+        current = f" from `{version}`" if version else ""
+        return f"Upgrade `{package}`{current} to `{fixed_version}`."
+
+    label = _finding_label(finding).lower()
+    message = _finding_message(finding).lower()
+    if plugin_name == "gitleaks" or "secret" in label or "secret" in message or "key" in label:
+        return (
+            "Remove or rotate the secret, move it to the configured secret store, "
+            "and invalidate the exposed credential."
+        )
+    if plugin_name in {"trivy", "osv", "osv-scanner"} or package:
+        return (
+            "Replace the dependency, pin a safe alternative, or document an accepted risk "
+            "until upstream publishes a fixed release."
+        )
+    if plugin_name in {"kube-linter", "cdk-nag", "cfn-nag", "opa"}:
+        return "Update the affected manifest or policy input so this rule no longer matches."
+    return (
+        "Simplify the flagged code/config where possible, or make the intent explicit, "
+        "then change it so this rule no longer matches."
+    )
+
+
+def _blocking_results(results: list[PluginResult]) -> list[PluginResult]:
+    blockers = []
+    for result in results:
+        if result.category not in {"dependency", "supply_chain", "infra"}:
+            continue
+        if any(_finding_severity(f) in {"critical", "high"} for f in result.findings):
+            blockers.append(result)
+    return blockers
+
+
+def _build_block_reason(results: list[PluginResult]) -> str:
+    blockers = _blocking_results(results)
+    if not blockers:
+        return ""
+
+    parts = []
+    total = 0
+    for result in blockers[:3]:
+        count = sum(1 for f in result.findings if _finding_severity(f) in {"critical", "high"})
+        total += count
+        parts.append(f"{count} from {result.plugin_name}")
+    for result in blockers[3:]:
+        total += sum(1 for f in result.findings if _finding_severity(f) in {"critical", "high"})
+    suffix = "" if len(blockers) <= 3 else f" (+{len(blockers) - 3} more sources)"
+    noun = "finding" if total == 1 else "findings"
+    return (
+        f"Why blocked: {total} critical/high security {noun} ("
+        + ", ".join(parts)
+        + suffix
+        + ") must be fixed before merge."
+    )
+
+
+def _relevance_for(result: PluginResult, finding: dict) -> str:
+    label = _finding_label(finding).lower()
+    message = _finding_message(finding).lower()
+    if result.plugin_name == "gitleaks" or "secret" in label or "secret" in message:
+        return "Exposed credentials remain reusable outside this PR until removed and rotated."
+    if result.category == "dependency":
+        return "A vulnerable dependency can ship exploitable code with the application."
+    if result.category == "infra":
+        return "Unsafe infrastructure config can change deployed runtime security."
+    return f"{result.category} findings can ship security risk if merged."
+
+
+def _build_smart_plan(results: list[PluginResult]) -> list[dict[str, object]]:
+    plan: list[dict[str, object]] = []
+    for result in _blocking_results(results):
+        blocking_findings = [
+            f for f in result.findings if _finding_severity(f) in {"critical", "high"}
+        ]
+        if not blocking_findings:
+            continue
+        first = blocking_findings[0]
+        target = _finding_target(first)
+        label = _finding_label(first)
+        severity = _finding_severity(first).upper()
+        fields = [
+            {
+                "label": "What failed",
+                "lines": _wrap_lines(
+                    f"{result.plugin_name} reported {severity} `{label}` at {target}: "
+                    f"{_finding_message(first)}"
+                ),
+            },
+            {
+                "label": "Why it blocks",
+                "lines": _wrap_lines(_relevance_for(result, first)),
+            },
+            {
+                "label": "Fix",
+                "lines": _wrap_lines(_remediation_for(result.plugin_name, first)),
+            },
+            {
+                "label": "Done when",
+                "lines": _wrap_lines(
+                    f"{result.plugin_name} critical/high findings drop from "
+                    f"{len(blocking_findings)} to 0."
+                ),
+            },
+            {
+                "label": "Verify",
+                "lines": _wrap_lines(
+                    f"Rerun `uv run eedom review --repo-path . --all` after fixing {target}."
+                ),
+            },
+        ]
+        plan.append(
+            {
+                "label": "Required",
+                "source": result.plugin_name,
+                "count": len(blocking_findings),
+                "fields": fields,
+            }
+        )
+    return plan
 
 
 def calculate_severity_score(results: list[PluginResult]) -> float:
@@ -190,6 +389,8 @@ def render_comment(
     from eedom.core.actionability import classify_findings
 
     act_summary = classify_findings(results)
+    smart_plan = _build_smart_plan(results)
+    block_reason = _build_block_reason(results)
 
     footer_parts = []
     for r in results:
@@ -219,7 +420,11 @@ def render_comment(
         version=_VERSION,
         footer_stats=footer_stats,
         actionability=act_summary,
+        smart_plan=smart_plan,
+        block_reason=block_reason,
     )
+    output = _collapse_excess_blank_lines(output)
+    output = _compact_smart_spacing(output)
 
     if len(output) > _MAX_COMMENT_LENGTH:
         truncated = output[: _MAX_COMMENT_LENGTH - 100]
@@ -288,7 +493,9 @@ def _build_sections(
 def _default_render(result: PluginResult) -> str:
     if not result.findings:
         return ""
-    lines = [f"**{result.plugin_name}**: {len(result.findings)} findings"]
+    count = len(result.findings)
+    noun = "finding" if count == 1 else "findings"
+    lines = [f"**{result.plugin_name}**: {count} {noun}"]
     return "\n".join(lines)
 
 

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -360,12 +360,29 @@ def _build_monorepo_sections(
     return overall_verdict, summary_rows, sections
 
 
+def _scan_scope_rows(
+    scan_scope: str,
+    file_count: int,
+    repo_file_count: int | None,
+) -> list[tuple[str, str]]:
+    scope = (scan_scope or "repo").lower()
+    rows = [("Scan scope", scope)]
+    if scope == "diff" and repo_file_count is not None:
+        rows.append(("Changed files", str(file_count)))
+        rows.append(("Repo-wide files", f"{repo_file_count} total"))
+        return rows
+    rows.append(("Files scanned", str(file_count)))
+    return rows
+
+
 def render_comment(
     results: list[PluginResult],
     repo: str = "",
     pr_num: int = 0,
     title: str = "",
     file_count: int = 0,
+    scan_scope: str = "repo",
+    repo_file_count: int | None = None,
     template_dir: Path | None = None,
     plugin_renderers: dict[str, object] | None = None,
 ) -> str:
@@ -406,7 +423,7 @@ def render_comment(
         pr_num=pr_num,
         title=title,
         verdict=verdict,
-        file_count=file_count,
+        scan_scope_rows=_scan_scope_rows(scan_scope, file_count, repo_file_count),
         summary_rows=summary_rows,
         sections=sections,
         severity_score=severity_score,

--- a/src/eedom/plugins/complexity.py
+++ b/src/eedom/plugins/complexity.py
@@ -133,7 +133,9 @@ class ComplexityPlugin(ScannerPlugin):
         lines.append(
             f"<summary>📊 <b>Complexity: avg CCN {avg}, max {mx}, {nloc} NLOC</b></summary>\n"
         )
-        high_note = f", {ctx['high_count']} with CCN > 10" if ctx["high_count"] else ""
+        high_note = (
+            f", High complexity: {ctx['high_count']} with CCN > 10" if ctx["high_count"] else ""
+        )
         lines.append(
             f"**Top complex functions** — showing {ctx['shown_count']} of "
             f"{len(result.findings)}{high_note}.\n"

--- a/src/eedom/plugins/complexity.py
+++ b/src/eedom/plugins/complexity.py
@@ -1,15 +1,81 @@
 """Complexity plugin — Lizard CCN + Radon MI.
 # tested-by: tests/unit/test_plugin_registry.py
+# tested-by: tests/unit/test_complexity_plugin.py
+# tested-by: tests/unit/test_plugin_templates.py
 """
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
 from eedom.plugins._runners.complexity_runner import run_complexity as _run
 
 _CODE_EXTS = {".py", ".ts", ".js", ".tsx", ".jsx", ".go", ".java", ".rs", ".c", ".cpp"}
+_MAX_RENDERED_FUNCTIONS = 25
+_WRAP_WIDTH = 88
+
+
+def _wrap_lines(text: str, width: int = _WRAP_WIDTH) -> list[str]:
+    return textwrap.wrap(
+        str(text),
+        width=width,
+        break_long_words=True,
+        break_on_hyphens=False,
+    ) or [""]
+
+
+def _complexity_guidance(ccn: int) -> str:
+    if ccn > 10:
+        return (
+            f"CCN {ccn} means this function has enough branches to be hard to review "
+            "and test confidently."
+        )
+    return "This function is listed for context; it is below the high-complexity threshold."
+
+
+def _complexity_fix_hint(ccn: int) -> str:
+    if ccn > 10:
+        return (
+            "Split independent branches into smaller helpers, use guard clauses where they reduce "
+            "nesting, or add a short comment where the branching is intentional."
+        )
+    return "No required change; keep an eye on this if nearby edits add more branches."
+
+
+def _ccn_int(finding: dict) -> int:
+    try:
+        return int(finding.get("cyclomatic_complexity", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _entry_for(finding: dict) -> dict:
+    ccn = _ccn_int(finding)
+    mi = finding.get("maintainability_index", "?")
+    nloc = finding.get("nloc", "?")
+    return {
+        "function": finding.get("function", "<unknown>"),
+        "file": finding.get("file", "<unknown>"),
+        "ccn": ccn,
+        "mi": mi,
+        "nloc": nloc,
+        "why_lines": _wrap_lines(_complexity_guidance(ccn)),
+        "consider_lines": _wrap_lines(_complexity_fix_hint(ccn)),
+    }
+
+
+def _complexity_context(result: PluginResult) -> dict:
+    findings = result.findings[:_MAX_RENDERED_FUNCTIONS]
+    high_ccn = [f for f in result.findings if _ccn_int(f) > 10]
+    return {
+        "entries": [_entry_for(f) for f in findings],
+        "shown_count": len(findings),
+        "remaining_count": max(0, len(result.findings) - _MAX_RENDERED_FUNCTIONS),
+        "high_count": len(high_ccn),
+        "max_rendered_functions": _MAX_RENDERED_FUNCTIONS,
+    }
 
 
 class ComplexityPlugin(ScannerPlugin):
@@ -45,17 +111,9 @@ class ComplexityPlugin(ScannerPlugin):
             summary=data.get("summary", {}),
         )
 
-    @staticmethod
-    def _ccn_int(f: dict) -> int:
-        """Coerce cyclomatic_complexity to int; return 0 if unparseable."""
-        try:
-            return int(f.get("cyclomatic_complexity", 0))
-        except (TypeError, ValueError):
-            return 0
-
     def _template_context(self, result: PluginResult) -> dict:
         ctx = super()._template_context(result)
-        ctx["high_ccn"] = [f for f in result.findings if self._ccn_int(f) > 10]
+        ctx.update(_complexity_context(result))
         return ctx
 
     def _render_inline(
@@ -70,33 +128,29 @@ class ComplexityPlugin(ScannerPlugin):
         avg = s.get("avg_cyclomatic_complexity", 0)
         mx = s.get("max_cyclomatic_complexity", 0)
         nloc = s.get("total_nloc", 0)
+        ctx = _complexity_context(result)
         lines = ["<details>"]
         lines.append(
-            f"<summary>📊 <b>Complexity (avg CCN: {avg}, max: {mx}, {nloc} NLOC)</b></summary>\n"
+            f"<summary>📊 <b>Complexity: avg CCN {avg}, max {mx}, {nloc} NLOC</b></summary>\n"
         )
-        high = [f for f in result.findings if self._ccn_int(f) > 10]
-        if high:
-            lines.append("**⚠️ High complexity (CCN > 10):**\n")
-            lines.append("| Function | File | CCN | MI | NLOC |")
-            lines.append("|----------|------|-----|----|------|")
-            for f in high:
-                mi = f.get("maintainability_index", "?")
-                lines.append(
-                    f"| `{f['function']}` | `{f['file']}`"
-                    f" | {f['cyclomatic_complexity']}"
-                    f" | {mi} | {f['nloc']} |"
-                )
-            lines.append("")
-        max_rows = 25
-        lines.append("| Function | CCN | MI | NLOC |")
-        lines.append("|----------|-----|----|------|")
-        for f in result.findings[:max_rows]:
-            mi = f.get("maintainability_index", "?")
+        high_note = f", {ctx['high_count']} with CCN > 10" if ctx["high_count"] else ""
+        lines.append(
+            f"**Top complex functions** — showing {ctx['shown_count']} of "
+            f"{len(result.findings)}{high_note}.\n"
+        )
+        for entry in ctx["entries"]:
             lines.append(
-                f"| `{f['function']}` | {f['cyclomatic_complexity']} | {mi} | {f['nloc']} |"
+                f"- **`{entry['function']}`** — CCN {entry['ccn']}, "
+                f"MI {entry['mi']}, NLOC {entry['nloc']}"
             )
-        remaining = len(result.findings) - max_rows
-        if remaining > 0:
-            lines.append(f"\n*...{remaining} more functions (see SARIF for full list)*")
+            lines.append(f"  - File: `{entry['file']}`")
+            lines.append("  - Why it matters:")
+            lines.extend(f"    {line}" for line in entry["why_lines"])
+            lines.append("  - Consider:")
+            lines.extend(f"    {line}" for line in entry["consider_lines"])
+        if ctx["remaining_count"] > 0:
+            lines.append(
+                f"\n*...{ctx['remaining_count']} more functions; see SARIF for the full list.*"
+            )
         lines.append("\n</details>\n")
         return "\n".join(lines)

--- a/src/eedom/plugins/kube_linter.py
+++ b/src/eedom/plugins/kube_linter.py
@@ -4,10 +4,25 @@
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
 from eedom.plugins._runners.kube_linter_runner import run_kube_linter as _run
+
+_REVIEW_WIDTH = 88
+
+
+def _wrap_review_text(text: str, width: int = _REVIEW_WIDTH) -> list[str]:
+    normalized = " ".join(str(text).split())
+    if not normalized:
+        return []
+    return textwrap.wrap(
+        normalized,
+        width=width,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [normalized]
 
 
 class KubeLinterPlugin(ScannerPlugin):
@@ -39,21 +54,78 @@ class KubeLinterPlugin(ScannerPlugin):
             error=data.get("error", ""),
         )
 
+    def _template_context(self, result: PluginResult) -> dict:
+        ctx = super()._template_context(result)
+        ctx["entries"] = [self._guidance_entry(f) for f in result.findings[:15]]
+        return ctx
+
     def _render_inline(self, result: PluginResult) -> str:
         if result.error:
             return f"**kube-linter**: {result.error}"
         if not result.findings:
             return ""
         lines = ["<details open>"]
-        lines.append(f"<summary>☸️ <b>K8s/Helm ({len(result.findings)})</b></summary>\n")
-        for f in result.findings[:15]:
-            lines.append(
-                f"**{f.get('check', '?')}** —"
-                f" `{f.get('object_kind', '?')}/{f.get('object_name', '?')}`"
-            )
-            lines.append(f"> {f.get('message', '')[:200]}")
-            if f.get("remediation"):
-                lines.append(f"> 💡 {f['remediation'][:200]}")
+        lines.append(f"<summary>☸️ <b>K8s/Helm ({len(result.findings)})</b></summary>")
+        lines.append("")
+        for entry in (self._guidance_entry(f) for f in result.findings[:15]):
+            lines.extend(entry["lines"])
             lines.append("")
-        lines.append("</details>\n")
-        return "\n".join(lines)
+        lines.append("</details>")
+        return "\n".join(lines).rstrip()
+
+    def _guidance_entry(self, finding: dict) -> dict[str, list[str]]:
+        check = str(finding.get("check") or "kube-linter-check")
+        kind = str(finding.get("object_kind") or "object")
+        name = str(finding.get("object_name") or "resource")
+        message = str(finding.get("message") or "Kubernetes manifest failed kube-linter.")
+        remediation = str(finding.get("remediation") or "")
+        fix = remediation or "Update the manifest so kube-linter no longer reports this check."
+        if remediation:
+            fix = f"💡 {fix}"
+        return {
+            "lines": self._entry_lines(
+                target=f"`{kind}/{name}` ({check})",
+                what_failed=message,
+                why=(
+                    "Kubernetes and Helm findings affect runtime isolation, scheduling, "
+                    "or operational safety after the manifest is applied."
+                ),
+                fix=fix,
+                done_when=f"`{kind}/{name}` satisfies `{check}` in the rendered manifest.",
+                verify="Rerun kube-linter or `uv run eedom review --repo-path . --all`.",
+            )
+        }
+
+    def _entry_lines(
+        self,
+        *,
+        target: str,
+        what_failed: str,
+        why: str,
+        fix: str,
+        done_when: str,
+        verify: str,
+    ) -> list[str]:
+        lines = ["- ☸️ **Required:**"]
+        lines.extend(self._inline_field("Target", target))
+        lines.extend(self._block_field("What failed", what_failed))
+        lines.extend(self._block_field("Why it matters", why))
+        lines.extend(self._block_field("Fix", fix))
+        lines.extend(self._block_field("Done when", done_when))
+        lines.extend(self._block_field("Verify", verify))
+        return lines
+
+    @staticmethod
+    def _inline_field(label: str, text: str) -> list[str]:
+        prefix = f"  {label}: "
+        continuation = " " * len(prefix)
+        width = max(40, 110 - len(prefix))
+        wrapped = _wrap_review_text(text, width=width)
+        if not wrapped:
+            return []
+        return [f"{prefix}{wrapped[0]}", *[f"{continuation}{line}" for line in wrapped[1:]]]
+
+    @staticmethod
+    def _block_field(label: str, text: str) -> list[str]:
+        wrapped = _wrap_review_text(text)
+        return [f"  {label}:", *[f"    {line}" for line in wrapped]]

--- a/src/eedom/plugins/semgrep.py
+++ b/src/eedom/plugins/semgrep.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
 from eedom.plugins._runners.semgrep_runner import run_semgrep as _run
+
+_REVIEW_WIDTH = 88
 
 _CODE_EXTS = {
     ".py",
@@ -25,6 +28,18 @@ _CODE_EXTS = {
     ".yaml",
     ".yml",
 }
+
+
+def _wrap_review_text(text: str, width: int = _REVIEW_WIDTH) -> list[str]:
+    normalized = " ".join(str(text).split())
+    if not normalized:
+        return []
+    return textwrap.wrap(
+        normalized,
+        width=width,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [normalized]
 
 
 class SemgrepPlugin(ScannerPlugin):
@@ -81,6 +96,11 @@ class SemgrepPlugin(ScannerPlugin):
             summary={"total": len(findings)},
         )
 
+    def _template_context(self, result: PluginResult) -> dict:
+        ctx = super()._template_context(result)
+        ctx["entries"] = [self._guidance_entry(f) for f in result.findings]
+        return ctx
+
     def _render_inline(self, result: PluginResult) -> str:
         if result.error:
             return f"**semgrep**: {result.error}"
@@ -88,12 +108,104 @@ class SemgrepPlugin(ScannerPlugin):
             return ""
         lines = [
             "<details open>",
-            f"<summary>🔍 <b>Semgrep ({len(result.findings)})</b></summary>\n",
+            f"<summary>🔍 <b>Semgrep ({len(result.findings)})</b></summary>",
+            "",
         ]
-        for f in result.findings:
-            icon = {"ERROR": "🔴", "WARNING": "🟡", "INFO": "ℹ️"}.get(f["severity"], "?")
-            rule = f["rule_id"].split(".")[-1]
-            lines.append(f"{icon} **`{f['file']}:{f['start_line']}`** — **{rule}**")
-            lines.append(f"> {f['message'][:200]}\n")
-        lines.append("</details>\n")
-        return "\n".join(lines)
+        for entry in (self._guidance_entry(f) for f in result.findings):
+            lines.extend(entry["lines"])
+            lines.append("")
+        lines.append("</details>")
+        return "\n".join(lines).rstrip()
+
+    def _guidance_entry(self, finding: dict) -> dict[str, list[str]]:
+        severity = str(finding.get("severity") or "WARNING").upper()
+        icon = {"ERROR": "🔴", "WARNING": "🟡", "INFO": "ℹ️"}.get(severity, "•")
+        intent = {"ERROR": "Required", "WARNING": "Consider", "INFO": "FYI"}.get(
+            severity, "Consider"
+        )
+        rule_id = str(finding.get("rule_id") or "?")
+        rule = rule_id.split(".")[-1]
+        file = str(finding.get("file") or "?")
+        line = finding.get("start_line") or 0
+        message = str(finding.get("message") or "Semgrep matched this code pattern.")
+        return {
+            "lines": self._entry_lines(
+                icon=icon,
+                intent=intent,
+                target=f"`{file}:{line}` ({rule})",
+                what_failed=f"{message} Rule: `{rule_id}`.",
+                why=self._why_text(rule_id, message),
+                fix=self._fix_text(rule_id, message),
+                done_when=(
+                    f"`{file}:{line}` no longer matches `{rule_id}`, or the suppression "
+                    "is justified."
+                ),
+                verify="Rerun Semgrep or `uv run eedom review --repo-path . --all`.",
+            )
+        }
+
+    @staticmethod
+    def _why_text(rule_id: str, message: str) -> str:
+        lowered = f"{rule_id} {message}".lower()
+        if "sql" in lowered:
+            return (
+                "SQL construction in changed code can let input alter the query shape, "
+                "which turns reviewable data flow into an injection risk."
+            )
+        if "hash" in lowered or "md5" in lowered:
+            return (
+                "Weak hashes are not suitable for security-sensitive data because attackers "
+                "can brute-force or collide them more easily."
+            )
+        return (
+            "Semgrep matched a code pattern that reviewers should not have to infer from "
+            "scanner output alone."
+        )
+
+    @staticmethod
+    def _fix_text(rule_id: str, message: str) -> str:
+        lowered = f"{rule_id} {message}".lower()
+        if "sql" in lowered:
+            return "Use parameterized queries or the framework query builder for this path."
+        if "hash" in lowered or "md5" in lowered:
+            return "Use an approved password hashing or digest primitive for this use case."
+        return (
+            "Change the code so the rule no longer matches, or add a narrow suppression "
+            "with justification if this is a false positive."
+        )
+
+    def _entry_lines(
+        self,
+        *,
+        icon: str,
+        intent: str,
+        target: str,
+        what_failed: str,
+        why: str,
+        fix: str,
+        done_when: str,
+        verify: str,
+    ) -> list[str]:
+        lines = [f"- {icon} **{intent}:**"]
+        lines.extend(self._inline_field("Target", target))
+        lines.extend(self._block_field("What failed", what_failed))
+        lines.extend(self._block_field("Why it matters", why))
+        lines.extend(self._block_field("Fix", fix))
+        lines.extend(self._block_field("Done when", done_when))
+        lines.extend(self._block_field("Verify", verify))
+        return lines
+
+    @staticmethod
+    def _inline_field(label: str, text: str) -> list[str]:
+        prefix = f"  {label}: "
+        continuation = " " * len(prefix)
+        width = max(40, 110 - len(prefix))
+        wrapped = _wrap_review_text(text, width=width)
+        if not wrapped:
+            return []
+        return [f"{prefix}{wrapped[0]}", *[f"{continuation}{line}" for line in wrapped[1:]]]
+
+    @staticmethod
+    def _block_field(label: str, text: str) -> list[str]:
+        wrapped = _wrap_review_text(text)
+        return [f"  {label}:", *[f"    {line}" for line in wrapped]]

--- a/src/eedom/plugins/supply_chain.py
+++ b/src/eedom/plugins/supply_chain.py
@@ -307,7 +307,7 @@ class SupplyChainPlugin(ScannerPlugin):
                         "lockfile": lock,
                         "severity": "high",
                         "sha256": _sha256(Path(lock_dir) / lock),
-                        "message": (f"`{lock}` changed but {'/'.join(manifests)} did NOT"),
+                        "message": (f"`{lock}` changed, but {'/'.join(manifests)} was not changed"),
                     }
                 )
 
@@ -333,7 +333,7 @@ class SupplyChainPlugin(ScannerPlugin):
                                 "lockfile": lf,
                                 "severity": "medium",
                                 "sha256": _sha256(Path(manifest_dir) / lf),
-                                "message": (f"`{manifest}` changed but `{lf}` was NOT updated"),
+                                "message": (f"`{manifest}` changed, but `{lf}` was not updated"),
                             }
                         )
 

--- a/src/eedom/plugins/supply_chain.py
+++ b/src/eedom/plugins/supply_chain.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import textwrap
 from pathlib import Path
 
 import structlog
@@ -17,6 +18,8 @@ import yaml
 from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
 
 logger = structlog.get_logger(__name__)
+
+_REVIEW_WIDTH = 88
 
 _LOCKFILE_TO_MANIFEST: dict[str, list[str]] = {
     "package-lock.json": ["package.json"],
@@ -44,6 +47,18 @@ def _sha256(path: Path) -> str:
         return hashlib.sha256(path.read_bytes()).hexdigest()
     except OSError:
         return ""
+
+
+def _wrap_review_text(text: str, width: int = _REVIEW_WIDTH) -> list[str]:
+    normalized = " ".join(str(text).split())
+    if not normalized:
+        return []
+    return textwrap.wrap(
+        normalized,
+        width=width,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [normalized]
 
 
 def _is_dockerfile(name: str) -> bool:
@@ -376,9 +391,15 @@ class SupplyChainPlugin(ScannerPlugin):
 
     def _template_context(self, result: PluginResult) -> dict:
         ctx = super()._template_context(result)
-        ctx["unpinned"] = [f for f in result.findings if f.get("type") == "unpinned"]
-        ctx["locks"] = [f for f in result.findings if f.get("type") == "lockfile"]
-        ctx["docker"] = [f for f in result.findings if f.get("type") == "docker_latest"]
+        unpinned = [f for f in result.findings if f.get("type") == "unpinned"]
+        locks = [f for f in result.findings if f.get("type") == "lockfile"]
+        docker = [f for f in result.findings if f.get("type") == "docker_latest"]
+        ctx["unpinned"] = unpinned
+        ctx["locks"] = locks
+        ctx["docker"] = docker
+        ctx["unpinned_entries"] = [self._guidance_entry(f) for f in unpinned]
+        ctx["lock_entries"] = [self._guidance_entry(f) for f in locks]
+        ctx["docker_entries"] = [self._guidance_entry(f) for f in docker]
         return ctx
 
     def _render_inline(
@@ -395,36 +416,216 @@ class SupplyChainPlugin(ScannerPlugin):
 
         if unpinned:
             lines.append("<details open>")
-            lines.append(f"<summary>📌 <b>Unpinned Dependencies ({len(unpinned)})</b></summary>\n")
-            lines.append("| Package | Version | Ecosystem | Risk |")
-            lines.append("|---------|---------|-----------|------|")
-            for u in unpinned:
-                lines.append(
-                    f"| `{u['package']}` | `{u['version']}` | {u['ecosystem']} | {u['reason']} |"
-                )
-            lines.append("\n</details>\n")
+            lines.append(f"<summary>📌 <b>Unpinned Dependencies ({len(unpinned)})</b></summary>")
+            lines.append("")
+            for entry in (self._guidance_entry(f) for f in unpinned):
+                lines.extend(entry["lines"])
+                lines.append("")
+            lines.append("</details>")
+            lines.append("")
 
         if locks:
             lines.append("<details open>")
-            lines.append("<summary>🔒 <b>Lockfile Integrity</b></summary>\n")
-            for lf in locks:
-                icon = "🔴" if lf["severity"] == "high" else "🟡"
-                lines.append(f"{icon} {lf['message']}")
-                sha = lf.get("sha256", "")
-                if sha:
-                    lines.append(f"> SHA256: `{sha[:16]}...`\n")
-            lines.append("</details>\n")
+            lines.append("<summary>🔒 <b>Lockfile Integrity</b></summary>")
+            lines.append("")
+            for entry in (self._guidance_entry(f) for f in locks):
+                lines.extend(entry["lines"])
+                lines.append("")
+            lines.append("</details>")
+            lines.append("")
 
         if docker:
             lines.append("<details open>")
-            lines.append(
-                f"<summary>🐳 <b>Docker Floating Image Tags ({len(docker)})</b></summary>\n"
-            )
-            lines.append("| File | Description |")
-            lines.append("|------|-------------|")
-            for d in docker:
-                fname = Path(d["file"]).name
-                lines.append(f"| `{fname}` | {d['description']} |")
-            lines.append("\n</details>\n")
+            lines.append(f"<summary>🐳 <b>Docker Floating Image Tags ({len(docker)})</b></summary>")
+            lines.append("")
+            for entry in (self._guidance_entry(f) for f in docker):
+                lines.extend(entry["lines"])
+                lines.append("")
+            lines.append("</details>")
+            lines.append("")
 
-        return "\n".join(lines)
+        return "\n".join(lines).rstrip()
+
+    def _guidance_entry(self, finding: dict) -> dict[str, list[str]]:
+        kind = finding.get("type")
+        if kind == "unpinned":
+            lines = self._unpinned_guidance_lines(finding)
+        elif kind == "lockfile":
+            lines = self._lockfile_guidance_lines(finding)
+        elif kind == "docker_latest":
+            lines = self._docker_guidance_lines(finding)
+        else:
+            lines = self._generic_guidance_lines(finding)
+        return {"lines": lines}
+
+    def _generic_guidance_lines(self, finding: dict) -> list[str]:
+        intent = self._intent_label(finding)
+        message = (
+            finding.get("message") or finding.get("description") or "Supply-chain check failed."
+        )
+        return self._entry_lines(
+            intent=intent,
+            target="Supply-chain finding",
+            what_failed=str(message),
+            why=(
+                "Supply-chain findings change what code or runtime image is installed, "
+                "so they need a deterministic resolution before merge."
+            ),
+            fix="Update the manifest, lockfile, or image reference that produced this finding.",
+            done_when="The changed dependency input and the installed dependency output agree.",
+            verify=self._verify_text(),
+        )
+
+    def _unpinned_guidance_lines(self, finding: dict) -> list[str]:
+        package = str(finding.get("package") or "dependency")
+        manifest = str(finding.get("file") or "manifest")
+        version = str(finding.get("version") or "floating range")
+        ecosystem = str(finding.get("ecosystem") or "dependency manifest")
+        reason = str(finding.get("reason") or "floating version range")
+        severity = self._severity_evidence(finding)
+        what_failed = " ".join(
+            part
+            for part in (
+                severity,
+                f"The {ecosystem} dependency uses `{version}` ({reason}).",
+            )
+            if part
+        )
+        return self._entry_lines(
+            intent=self._intent_label(finding),
+            target=f"`{package}` in `{manifest}`",
+            what_failed=what_failed,
+            why=(
+                "Floating dependency ranges can resolve to different package versions in "
+                "later installs, so the reviewed code and installed code can diverge."
+            ),
+            fix=(
+                f"Pin `{package}` to an exact version and update the matching lockfile in "
+                "the same change."
+            ),
+            done_when=(
+                f"`{manifest}` uses an exact version for `{package}` and the lockfile "
+                "records that exact resolution."
+            ),
+            verify=self._verify_text(),
+        )
+
+    def _lockfile_guidance_lines(self, finding: dict) -> list[str]:
+        lockfile = str(finding.get("lockfile") or "lockfile")
+        message = self._review_sentence(
+            finding.get("message") or f"`{lockfile}` changed without its manifest."
+        )
+        evidence = self._sha_evidence(finding)
+        severity = self._severity_evidence(finding)
+        what_failed = " ".join(part for part in (severity, message, evidence) if part)
+        return self._entry_lines(
+            intent=self._intent_label(finding),
+            target=f"`{lockfile}`",
+            what_failed=what_failed,
+            why=(
+                "Manifest and lockfile drift means reviewers cannot tell which dependency "
+                "set is intended to be installed."
+            ),
+            fix=(
+                "Commit the matching manifest change, regenerate the lockfile from the "
+                "intended manifest, or revert lockfile churn that does not belong here."
+            ),
+            done_when=(
+                "The manifest and lockfile move together and describe the same dependency set."
+            ),
+            verify=self._verify_text(),
+        )
+
+    def _docker_guidance_lines(self, finding: dict) -> list[str]:
+        file_name = Path(str(finding.get("file") or "Dockerfile")).name
+        description = self._review_sentence(
+            finding.get("description")
+            or "Container image reference uses a floating tag or implicit latest."
+        )
+        severity = self._severity_evidence(finding)
+        what_failed = " ".join(part for part in (severity, description) if part)
+        return self._entry_lines(
+            intent=self._intent_label(finding),
+            target=f"`{file_name}`",
+            what_failed=what_failed,
+            why=(
+                "Floating image tags can pull a different base image after review, changing "
+                "OS packages and runtime behavior without a code diff."
+            ),
+            fix="Pin the image to a versioned tag or digest that the team intends to ship.",
+            done_when="Each changed image reference uses a non-floating tag or digest.",
+            verify=self._verify_text(),
+        )
+
+    @staticmethod
+    def _intent_label(finding: dict) -> str:
+        severity = str(finding.get("severity") or "").lower()
+        if severity in {"critical", "high"}:
+            return "Required"
+        if severity in {"medium", "low"}:
+            return "Consider"
+        return "Consider"
+
+    @staticmethod
+    def _verify_text() -> str:
+        return (
+            "Rerun `uv run eedom review --repo-path . --all` and confirm this "
+            "supply-chain item no longer appears."
+        )
+
+    @staticmethod
+    def _sha_evidence(finding: dict) -> str:
+        sha = str(finding.get("sha256") or "")
+        if not sha:
+            return ""
+        return f"SHA256 starts with `{sha[:16]}`."
+
+    @staticmethod
+    def _severity_evidence(finding: dict) -> str:
+        severity = str(finding.get("severity") or "").lower()
+        if not severity:
+            return ""
+        return f"Severity: {severity}."
+
+    @staticmethod
+    def _review_sentence(text: object) -> str:
+        sentence = " ".join(str(text).split())
+        sentence = sentence.replace("DID NOT", "was not")
+        if sentence and sentence[-1] not in ".!?":
+            return f"{sentence}."
+        return sentence
+
+    def _entry_lines(
+        self,
+        *,
+        intent: str,
+        target: str,
+        what_failed: str,
+        why: str,
+        fix: str,
+        done_when: str,
+        verify: str,
+    ) -> list[str]:
+        lines = [f"- **{intent}:**"]
+        lines.extend(self._inline_field("Target", target))
+        lines.extend(self._block_field("What failed", what_failed))
+        lines.extend(self._block_field("Why it matters", why))
+        lines.extend(self._block_field("Fix", fix))
+        lines.extend(self._block_field("Done when", done_when))
+        lines.extend(self._block_field("Verify", verify))
+        return lines
+
+    @staticmethod
+    def _inline_field(label: str, text: str) -> list[str]:
+        prefix = f"  {label}: "
+        continuation = " " * len(prefix)
+        width = max(40, 110 - len(prefix))
+        wrapped = _wrap_review_text(text, width=width)
+        if not wrapped:
+            return []
+        return [f"{prefix}{wrapped[0]}", *[f"{continuation}{line}" for line in wrapped[1:]]]
+
+    @staticmethod
+    def _block_field(label: str, text: str) -> list[str]:
+        wrapped = _wrap_review_text(text)
+        return [f"  {label}:", *[f"    {line}" for line in wrapped]]

--- a/src/eedom/templates/comment.md.j2
+++ b/src/eedom/templates/comment.md.j2
@@ -3,6 +3,9 @@
 
 {% if verdict == "blocked" %}
 > 🔴 **BLOCKED**
+{% if block_reason %}
+> {{ block_reason }}
+{% endif %}
 {% elif verdict == "incomplete" %}
 > 🟡 **INCOMPLETE** — one or more scanners failed
 {% elif verdict == "warnings" %}
@@ -28,10 +31,23 @@
 | Maintainability | {{ mi_icon }} {{ mi_grade }} ({{ mi_score }}/100) |
 {%- endif %}
 
-{% if actionability and (actionability.actionable_count > 0 or actionability.blocked_count > 0) %}
-### Actionability
+{% if actionability and (actionability.actionable_count > 0 or actionability.blocked_count > 0 or actionability.owner_action_count > 0) %}
+### Actionability: Fix Plan
 
 > {{ actionability.summary_text }}
+
+{% if smart_plan %}
+{% for item in smart_plan[:5] %}
+**{{ item.label }}:** {{ item.source }} — {{ item.count }} blocking finding{% if item.count != 1 %}s{% endif %}
+{% for field in item.fields %}
+- {{ field.label }}:
+{% for line in field.lines %}
+  {{ line }}
+{% endfor %}
+{% endfor %}
+
+{% endfor %}
+{% endif %}
 
 {% if actionability.actionable_count > 0 %}
 **{{ actionability.actionable_count }} fixable** — upgrade available:
@@ -43,10 +59,19 @@
 {% endif %}
 {% endif %}
 
+{% if actionability.owner_action_count > 0 %}
+**{{ actionability.owner_action_count }} finding{% if actionability.owner_action_count != 1 %}s{% endif %} require{% if actionability.owner_action_count == 1 %}s{% endif %} code/config changes** — fix in this PR:
+{% for source, findings in actionability.owner_action_by_source.items() %}
+{% set severities = findings | selectattr('severity', 'defined') | map(attribute='severity') | reject('equalto', '') | unique | join(', ') %}
+- **{{ source }}**: {{ findings | length }} finding{% if findings | length != 1 %}s{% endif %}{% if severities %} ({{ severities }}){% endif %}
+{%- endfor %}
+{% endif %}
+
 {% if actionability.blocked_count > 0 %}
 **{{ actionability.blocked_count }} blocked** — no fix available:
 {% for source, findings in actionability.blocked_by_source.items() %}
-- **{{ source }}**: {{ findings | length }} findings ({{ findings | map(attribute='severity') | unique | join(', ') }})
+{% set severities = findings | selectattr('severity', 'defined') | map(attribute='severity') | reject('equalto', '') | unique | join(', ') %}
+- **{{ source }}**: {{ findings | length }} finding{% if findings | length != 1 %}s{% endif %}{% if severities %} ({{ severities }}){% endif %}
 {%- endfor %}
 {% endif %}
 {% endif %}

--- a/src/eedom/templates/comment.md.j2
+++ b/src/eedom/templates/comment.md.j2
@@ -23,7 +23,9 @@
 {% endif %}
 | Plugin | Findings |
 |--------|----------|
-| Files scanned | {{ file_count }} |
+{%- for key, value in scan_scope_rows %}
+| {{ key }} | {{ value }} |
+{%- endfor %}
 {%- for key, value in summary_rows %}
 | {{ key }} | {{ value }} |
 {%- endfor %}

--- a/src/eedom/templates/complexity.md.j2
+++ b/src/eedom/templates/complexity.md.j2
@@ -1,23 +1,26 @@
 {% if error %}
 **complexity**: {{ error }}
 {% elif findings %}
-<details><summary>📊 <b>Complexity (avg CCN: {{ summary.get("avg_cyclomatic_complexity", 0) }}, max: {{ summary.get("max_cyclomatic_complexity", 0) }}, {{ summary.get("total_nloc", 0) }} NLOC)</b></summary>
+<details><summary>📊 <b>Complexity: avg CCN {{ summary.get("avg_cyclomatic_complexity", 0) }}, max {{ summary.get("max_cyclomatic_complexity", 0) }}, {{ summary.get("total_nloc", 0) }} NLOC</b></summary>
 
-{% if high_ccn %}
-**⚠️ High complexity (CCN > 10):**
+**Top complex functions** — showing {{ shown_count }} of {{ findings | length }}{% if high_count %}, {{ high_count }} with CCN > 10{% endif %}.
 
-| Function | File | CCN | MI | NLOC |
-|----------|------|-----|----|------|
-{% for f in high_ccn %}
-| `{{ f.function }}` | `{{ f.file }}` | {{ f.cyclomatic_complexity }} | {{ f.get("maintainability_index", "?") }} | {{ f.nloc }} |
+{% for entry in entries %}
+- **`{{ entry.function }}`** — CCN {{ entry.ccn }}, MI {{ entry.mi }}, NLOC {{ entry.nloc }}
+  - File: `{{ entry.file }}`
+  - Why it matters:
+{% for line in entry.why_lines %}
+    {{ line }}
 {% endfor %}
+  - Consider:
+{% for line in entry.consider_lines %}
+    {{ line }}
+{% endfor %}
+{% endfor %}
+{% if remaining_count > 0 %}
 
+*...{{ remaining_count }} more functions; see SARIF for the full list.*
 {% endif %}
-| Function | CCN | MI | NLOC |
-|----------|-----|----|------|
-{% for f in findings %}
-| `{{ f.function }}` | {{ f.cyclomatic_complexity }} | {{ f.get("maintainability_index", "?") }} | {{ f.nloc }} |
-{% endfor %}
 
 </details>
 

--- a/src/eedom/templates/complexity.md.j2
+++ b/src/eedom/templates/complexity.md.j2
@@ -3,7 +3,7 @@
 {% elif findings %}
 <details><summary>📊 <b>Complexity: avg CCN {{ summary.get("avg_cyclomatic_complexity", 0) }}, max {{ summary.get("max_cyclomatic_complexity", 0) }}, {{ summary.get("total_nloc", 0) }} NLOC</b></summary>
 
-**Top complex functions** — showing {{ shown_count }} of {{ findings | length }}{% if high_count %}, {{ high_count }} with CCN > 10{% endif %}.
+**Top complex functions** — showing {{ shown_count }} of {{ findings | length }}{% if high_count %}, High complexity: {{ high_count }} with CCN > 10{% endif %}.
 
 {% for entry in entries %}
 - **`{{ entry.function }}`** — CCN {{ entry.ccn }}, MI {{ entry.mi }}, NLOC {{ entry.nloc }}

--- a/src/eedom/templates/kube-linter.md.j2
+++ b/src/eedom/templates/kube-linter.md.j2
@@ -3,12 +3,10 @@
 {% elif findings %}
 <details open><summary>☸️ <b>K8s/Helm ({{ findings | length }})</b></summary>
 
-{% for f in findings[:15] %}
-**{{ f.get("check", "?") }}** — `{{ f.get("object_kind", "?") }}/{{ f.get("object_name", "?") }}`
-> {{ f.get("message", "") | truncate(200, true, "") }}
-{% if f.get("remediation") %}
-> 💡 {{ f.remediation | truncate(200, true, "") }}
-{% endif %}
+{% for entry in entries %}
+{% for line in entry.lines %}
+{{ line }}
+{% endfor %}
 
 {% endfor %}
 </details>

--- a/src/eedom/templates/semgrep.md.j2
+++ b/src/eedom/templates/semgrep.md.j2
@@ -3,9 +3,10 @@
 {% elif findings %}
 <details open><summary>🔍 <b>Semgrep ({{ findings | length }})</b></summary>
 
-{% for f in findings %}
-{% if f.severity == "ERROR" %}🔴{% elif f.severity == "WARNING" %}🟡{% elif f.severity == "INFO" %}ℹ️{% else %}?{% endif %} **`{{ f.file }}:{{ f.start_line }}`** — **{{ f.rule_id.split(".")|last }}**
-> {{ f.message | truncate(200, true, "") }}
+{% for entry in entries %}
+{% for line in entry.lines %}
+{{ line }}
+{% endfor %}
 
 {% endfor %}
 </details>

--- a/src/eedom/templates/supply-chain.md.j2
+++ b/src/eedom/templates/supply-chain.md.j2
@@ -4,24 +4,23 @@
 {% if unpinned %}
 <details open><summary>📌 <b>Unpinned Dependencies ({{ unpinned | length }})</b></summary>
 
-| Package | Version | Ecosystem | Risk |
-|---------|---------|-----------|------|
-{% for u in unpinned %}
-| `{{ u.package }}` | `{{ u.version }}` | {{ u.ecosystem }} | {{ u.reason }} |
+{% for entry in unpinned_entries %}
+{% for line in entry.lines %}
+{{ line }}
 {% endfor %}
 
+{% endfor %}
 </details>
 
 {% endif %}
 {% if locks %}
 <details open><summary>🔒 <b>Lockfile Integrity</b></summary>
 
-{% for lf in locks %}
-{% if lf.severity == "high" %}🔴{% else %}🟡{% endif %} {{ lf.message }}
-{% if lf.get("sha256") %}
-> SHA256: `{{ lf.sha256[:16] }}...`
+{% for entry in lock_entries %}
+{% for line in entry.lines %}
+{{ line }}
+{% endfor %}
 
-{% endif %}
 {% endfor %}
 </details>
 
@@ -29,12 +28,12 @@
 {% if docker %}
 <details open><summary>🐳 <b>Docker Floating Image Tags ({{ docker | length }})</b></summary>
 
-| File | Description |
-|------|-------------|
-{% for d in docker %}
-| `{{ d.file.split("/")[-1] }}` | {{ d.description }} |
+{% for entry in docker_entries %}
+{% for line in entry.lines %}
+{{ line }}
 {% endfor %}
 
+{% endfor %}
 </details>
 
 {% endif %}

--- a/tests/unit/prose_assertions.py
+++ b/tests/unit/prose_assertions.py
@@ -1,0 +1,65 @@
+"""Shared assertions for generated review prose."""
+
+from __future__ import annotations
+
+import re
+
+FORBIDDEN_PROSE = (
+    "Specific:",
+    "Measurable:",
+    "Actionable:",
+    "Relevant:",
+    "Targeted:",
+    "finding(s)",
+    "warning(s)",
+    "you forgot",
+    "bad code",
+    "obviously",
+)
+
+EMPTY_PLACEHOLDERS = (
+    r"\(\s*\)",
+    r"`\s*`",
+    r"\bNone\b",
+    r"\bnull\b",
+    r"\bundefined\b",
+    r"\bTBD\b",
+    r"\bN/A\b",
+)
+
+
+def assert_professional_review_prose(text: str) -> None:
+    for forbidden in FORBIDDEN_PROSE:
+        assert forbidden not in text
+
+
+def assert_no_empty_placeholders(text: str) -> None:
+    for pattern in EMPTY_PLACEHOLDERS:
+        assert re.search(pattern, text) is None, pattern
+
+
+def assert_scannable(text: str, max_width: int = 110) -> None:
+    assert "\n\n\n" not in text
+    long_lines = [
+        (line_no, line)
+        for line_no, line in enumerate(text.splitlines(), start=1)
+        if len(line) > max_width
+    ]
+    assert long_lines == []
+
+
+def assert_field_has_content(text: str, label: str) -> None:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() != f"{label}:":
+            continue
+        following = lines[index + 1 : index + 4]
+        assert any(candidate.strip() for candidate in following)
+        return
+    raise AssertionError(f"missing field: {label}")
+
+
+def assert_review_prose_contract(text: str) -> None:
+    assert_professional_review_prose(text)
+    assert_no_empty_placeholders(text)
+    assert_scannable(text)

--- a/tests/unit/test_actionability.py
+++ b/tests/unit/test_actionability.py
@@ -19,8 +19,9 @@ from eedom.core.plugin import PluginResult
 def _make_result(
     plugin_name: str,
     findings: list[dict],
+    category: str = "",
 ) -> PluginResult:
-    return PluginResult(plugin_name=plugin_name, findings=findings)
+    return PluginResult(plugin_name=plugin_name, findings=findings, category=category)
 
 
 def _vuln(
@@ -161,6 +162,24 @@ class TestClassifyFindingsNoFix:
         assert "trivy" in summary.blocked_by_source
         ids = [f["id"] for f in summary.blocked_by_source["trivy"]]
         assert "CVE-2024-0001" in ids
+
+    def test_secret_without_fixed_version_requires_owner_action_not_upstream(self) -> None:
+        finding = {
+            "severity": "critical",
+            "file": "src/settings.py",
+            "line": 12,
+            "rule": "generic-api-key",
+            "description": "Hardcoded API key detected",
+        }
+        result = _make_result("gitleaks", [finding], category="supply_chain")
+
+        summary = classify_findings([result])
+
+        assert summary.owner_action_count == 1
+        assert summary.blocked_count == 0
+        assert "gitleaks" in summary.owner_action_by_source
+        assert "upstream dependencies" not in summary.summary_text
+        assert "code/config" in summary.summary_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_actionability.py
+++ b/tests/unit/test_actionability.py
@@ -181,6 +181,23 @@ class TestClassifyFindingsNoFix:
         assert "upstream dependencies" not in summary.summary_text
         assert "code/config" in summary.summary_text
 
+    def test_policy_finding_requires_owner_action_not_upstream(self) -> None:
+        finding = {
+            "decision": "needs_review",
+            "triggered_rules": ["policy.manifest_review"],
+            "constraints": [],
+            "policy_version": "test",
+        }
+        result = _make_result("opa", [finding], category="dependency")
+
+        summary = classify_findings([result])
+
+        assert summary.owner_action_count == 1
+        assert summary.blocked_count == 0
+        assert "opa" in summary.owner_action_by_source
+        assert "upstream dependencies" not in summary.summary_text
+        assert "code/config" in summary.summary_text
+
 
 # ---------------------------------------------------------------------------
 # classify_findings — mixed results, multiple plugins

--- a/tests/unit/test_agent_prompt.py
+++ b/tests/unit/test_agent_prompt.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from eedom.agent.prompt import build_system_prompt
+from tests.unit.prose_assertions import assert_review_prose_contract
 
 _ALL_DIMENSIONS = [
     "NECESSITY",
@@ -73,3 +74,18 @@ def test_system_prompt_mentions_three_tools():
     assert "evaluate_change" in prompt
     assert "check_package" in prompt
     assert "scan_code" in prompt
+
+
+def test_system_prompt_requires_prescriptive_review_comments():
+    prompt = build_system_prompt(policy_version="1.0.0")
+
+    assert "**Required:**" in prompt
+    assert "**Consider:**" in prompt
+    assert "**FYI:**" in prompt
+    assert "Why it matters:" in prompt
+    assert "Fix:" in prompt
+    assert "Done when:" in prompt
+    assert "Verify:" in prompt
+    assert "comment about the code" in prompt
+    assert "not the developer" in prompt
+    assert_review_prose_contract(prompt)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1226,3 +1226,45 @@ class TestScopeFlag:
         runner = CliRunner()
         result = runner.invoke(cli, ["review", "--scope", "folder", "--repo-path", "."])
         assert result.exit_code != 0
+
+    def test_scope_diff_comment_shows_changed_and_repo_wide_counts(
+        self, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("print('hello')\n")
+        (src / "other.py").write_text("pass\n")
+        diff_path = tmp_path / "change.diff"
+        diff_path.write_text(
+            "diff --git a/src/app.py b/src/app.py\n"
+            "index 000..111 100644\n"
+            "--- a/src/app.py\n"
+            "+++ b/src/app.py\n"
+            "@@ -1 +1,2 @@\n"
+            "+print('hello')\n"
+        )
+
+        mock_registry = MagicMock()
+        mock_registry.run_all.return_value = []
+        mock_registry.list.return_value = []
+
+        with patch("eedom.cli.main.get_default_registry", return_value=mock_registry):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "review",
+                    "--all",
+                    "--repo-path",
+                    str(tmp_path),
+                    "--scope",
+                    "diff",
+                    "--diff",
+                    str(diff_path),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "| Scan scope | diff |" in result.output
+        assert "| Changed files | 1 |" in result.output
+        assert "| Repo-wide files | 2 total |" in result.output

--- a/tests/unit/test_complexity_plugin.py
+++ b/tests/unit/test_complexity_plugin.py
@@ -8,10 +8,15 @@ from eedom.core.plugin import PluginResult
 from eedom.plugins.complexity import ComplexityPlugin
 
 
-def _make_finding(name: str, ccn: int = 3, nloc: int = 10) -> dict:
+def _make_finding(
+    name: str,
+    ccn: int = 3,
+    nloc: int = 10,
+    file: str = "src/mod.py",
+) -> dict:
     return {
         "function": name,
-        "file": "src/mod.py",
+        "file": file,
         "cyclomatic_complexity": ccn,
         "maintainability_index": 85.0,
         "nloc": nloc,
@@ -34,8 +39,8 @@ class TestComplexityRenderCapping:
         )
         plugin = ComplexityPlugin()
         output = plugin._render_inline(result)
-        rows = [line for line in output.split("\n") if line.startswith("| `func_")]
-        assert len(rows) == 25
+        entries = [line for line in output.split("\n") if line.startswith("- **`func_")]
+        assert len(entries) == 25
 
     def test_render_shows_remaining_count(self) -> None:
         findings = [_make_finding(f"func_{i}") for i in range(40)]
@@ -65,9 +70,36 @@ class TestComplexityRenderCapping:
         )
         plugin = ComplexityPlugin()
         output = plugin._render_inline(result)
-        rows = [line for line in output.split("\n") if line.startswith("| `func_")]
-        assert len(rows) == 10
+        entries = [line for line in output.split("\n") if line.startswith("- **`func_")]
+        assert len(entries) == 10
         assert "more" not in output
+
+    def test_render_uses_readable_list_not_bunched_table(self) -> None:
+        result = PluginResult(
+            plugin_name="complexity",
+            findings=[
+                _make_finding(
+                    "validate_deeply_nested_configuration_with_many_branches",
+                    ccn=17,
+                    nloc=80,
+                    file="src/domain/really/long/path/configuration_validator.py",
+                )
+            ],
+            summary={
+                "avg_cyclomatic_complexity": 17,
+                "max_cyclomatic_complexity": 17,
+                "total_nloc": 80,
+            },
+        )
+        plugin = ComplexityPlugin()
+        output = plugin._render_inline(result)
+
+        assert "| Function | File | CCN | MI | NLOC |" not in output
+        assert "| Function | CCN | MI | NLOC |" not in output
+        assert "Top complex functions" in output
+        assert "Why it matters:" in output
+        assert "Consider:" in output
+        assert max(len(line) for line in output.splitlines()) <= 110
 
 
 class TestComplexityRenderTypeCoercion:

--- a/tests/unit/test_complexity_plugin.py
+++ b/tests/unit/test_complexity_plugin.py
@@ -72,7 +72,7 @@ class TestComplexityRenderCapping:
         output = plugin._render_inline(result)
         entries = [line for line in output.split("\n") if line.startswith("- **`func_")]
         assert len(entries) == 10
-        assert "more" not in output
+        assert "more functions" not in output
 
     def test_render_uses_readable_list_not_bunched_table(self) -> None:
         result = PluginResult(

--- a/tests/unit/test_gatekeeper_workflow.py
+++ b/tests/unit/test_gatekeeper_workflow.py
@@ -1,0 +1,18 @@
+"""Tests for user-facing prose in the GitHub gatekeeper workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WORKFLOW = Path(__file__).parent.parent.parent / ".github" / "workflows" / "gatekeeper.yml"
+
+
+def test_gatekeeper_status_comment_uses_readable_counts():
+    workflow = _WORKFLOW.read_text()
+
+    assert "error(s)" not in workflow
+    assert "warning(s)" not in workflow
+    assert "plugin(s)" not in workflow
+    assert "format_count()" in workflow
+    assert "${ERROR_TEXT}" in workflow
+    assert "${WARNING_TEXT}" in workflow

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -349,6 +349,28 @@ class TestSemgrepTemplate:
         assert "🔴" in out
         assert "🟡" in out
 
+    def test_semgrep_template_uses_prescriptive_guidance(self):
+        plugin = SemgrepPlugin()
+        out = plugin.render(_semgrep_result_with_findings(), template_dir=_TEMPLATES_DIR)
+
+        assert "**Required:**" in out
+        assert "**Consider:**" in out
+        assert "Why it matters:" in out
+        assert "Fix:" in out
+        assert "Done when:" in out
+        assert "Verify:" in out
+        assert_review_prose_contract(out)
+
+    def test_semgrep_inline_render_uses_prescriptive_guidance(self):
+        plugin = SemgrepPlugin()
+        out = plugin._render_inline(_semgrep_result_with_findings())
+
+        assert "**Required:**" in out
+        assert "**Consider:**" in out
+        assert "Why it matters:" in out
+        assert "Fix:" in out
+        assert_review_prose_contract(out)
+
 
 # ── Blast-Radius template tests ───────────────────────────────────────────────
 
@@ -524,6 +546,26 @@ class TestKubeLinterTemplate:
         plugin = KubeLinterPlugin()
         out = plugin.render(_kube_linter_result_with_findings(), template_dir=_TEMPLATES_DIR)
         assert "<details" in out
+
+    def test_kube_linter_template_uses_prescriptive_guidance(self):
+        plugin = KubeLinterPlugin()
+        out = plugin.render(_kube_linter_result_with_findings(), template_dir=_TEMPLATES_DIR)
+
+        assert "**Required:**" in out
+        assert "Why it matters:" in out
+        assert "Fix:" in out
+        assert "Done when:" in out
+        assert "Verify:" in out
+        assert_review_prose_contract(out)
+
+    def test_kube_linter_inline_render_uses_prescriptive_guidance(self):
+        plugin = KubeLinterPlugin()
+        out = plugin._render_inline(_kube_linter_result_with_findings())
+
+        assert "**Required:**" in out
+        assert "Why it matters:" in out
+        assert "Fix:" in out
+        assert_review_prose_contract(out)
 
 
 # ── SupplyChain template tests ────────────────────────────────────────────────

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -152,7 +152,7 @@ def _supply_chain_result_with_findings() -> PluginResult:
                 "lockfile": "package-lock.json",
                 "severity": "high",
                 "sha256": "abc123def456" + "0" * 52,
-                "message": "`package-lock.json` changed but package.json did NOT",
+                "message": "`package-lock.json` changed, but package.json was not changed",
             },
             {
                 "type": "docker_latest",

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -185,6 +185,10 @@ class TestTemplateFilesExist:
     def test_templates_dir_has_init(self):
         assert (_TEMPLATES_DIR / "__init__.py").exists()
 
+    def test_no_stale_top_level_templates_dir(self):
+        stale_dir = Path(__file__).parent.parent.parent / "src" / "templates"
+        assert not stale_dir.exists()
+
 
 # ── Base render() template-loading contract ──────────────────────────────────
 

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -409,6 +409,8 @@ class TestComplexityTemplate:
         out = plugin.render(_complexity_result_with_findings(), template_dir=_TEMPLATES_DIR)
         assert "parse_manifest" in out
         assert "15" in out  # CCN value
+        assert "| Function | File | CCN | MI | NLOC |" not in out
+        assert "Top complex functions" in out
 
     def test_renders_summary_stats(self):
         plugin = ComplexityPlugin()
@@ -442,6 +444,33 @@ class TestComplexityTemplate:
         plugin = ComplexityPlugin()
         out = plugin.render(_complexity_result_with_findings(), template_dir=_TEMPLATES_DIR)
         assert "<details" in out
+
+    def test_complexity_template_wraps_long_entries(self):
+        plugin = ComplexityPlugin()
+        result = PluginResult(
+            plugin_name="complexity",
+            findings=[
+                {
+                    "function": "validate_deeply_nested_configuration_with_many_branches",
+                    "file": "src/domain/really/long/path/configuration_validator.py",
+                    "cyclomatic_complexity": 17,
+                    "maintainability_index": 45,
+                    "nloc": 80,
+                }
+            ],
+            summary={
+                "avg_cyclomatic_complexity": 17,
+                "max_cyclomatic_complexity": 17,
+                "total_nloc": 80,
+            },
+        )
+
+        out = plugin.render(result, template_dir=_TEMPLATES_DIR)
+
+        assert "| Function |" not in out
+        assert "Why it matters:" in out
+        assert "Consider:" in out
+        assert max(len(line) for line in out.splitlines()) <= 110
 
 
 # ── KubeLinter template tests ─────────────────────────────────────────────────

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -16,7 +16,6 @@ from eedom.plugins.complexity import ComplexityPlugin
 from eedom.plugins.kube_linter import KubeLinterPlugin
 from eedom.plugins.semgrep import SemgrepPlugin
 from eedom.plugins.supply_chain import SupplyChainPlugin
-
 from tests.unit.prose_assertions import assert_review_prose_contract
 
 _TEMPLATES_DIR = Path(__file__).parent.parent.parent / "src" / "eedom" / "templates"

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -157,7 +157,10 @@ def _supply_chain_result_with_findings() -> PluginResult:
                 "type": "docker_latest",
                 "file": "/repo/Dockerfile",
                 "severity": "medium",
-                "description": "Dockerfile FROM uses floating image `node` — pin to a specific digest or version tag",
+                "description": (
+                    "Dockerfile FROM uses floating image `node` — pin to a specific digest "
+                    "or version tag"
+                ),
             },
         ],
         summary={"unpinned": 1, "lockfile_issues": 1, "docker_latest": 1},
@@ -620,8 +623,9 @@ class TestRegressionOutputUnchanged:
         assert "<details" in out
         assert "📊" in out
         assert "CCN" in out
-        # Table headers
-        assert "Function" in out
+        assert "Top complex functions" in out
+        assert "Why it matters:" in out
+        assert "Consider:" in out
         assert "MI" in out or "Maintainability" in out
 
     def test_blast_radius_structure_preserved(self):

--- a/tests/unit/test_plugin_templates.py
+++ b/tests/unit/test_plugin_templates.py
@@ -17,6 +17,8 @@ from eedom.plugins.kube_linter import KubeLinterPlugin
 from eedom.plugins.semgrep import SemgrepPlugin
 from eedom.plugins.supply_chain import SupplyChainPlugin
 
+from tests.unit.prose_assertions import assert_review_prose_contract
+
 _TEMPLATES_DIR = Path(__file__).parent.parent.parent / "src" / "eedom" / "templates"
 
 
@@ -566,6 +568,30 @@ class TestSupplyChainTemplate:
         out = plugin.render(_supply_chain_result_with_findings(), template_dir=_TEMPLATES_DIR)
         # high severity → 🔴
         assert "🔴" in out or "high" in out.lower()
+
+    def test_supply_chain_template_uses_guidance_lists_not_tables(self):
+        plugin = SupplyChainPlugin()
+        out = plugin.render(_supply_chain_result_with_findings(), template_dir=_TEMPLATES_DIR)
+
+        assert "| Package | Version | Ecosystem | Risk |" not in out
+        assert "| File | Description |" not in out
+        assert "**Required:**" in out
+        assert "**Consider:**" in out
+        assert "Why it matters:" in out
+        assert "Fix:" in out
+        assert "Done when:" in out
+        assert "Verify:" in out
+        assert_review_prose_contract(out)
+
+    def test_supply_chain_inline_render_uses_same_guidance_contract(self):
+        plugin = SupplyChainPlugin()
+        out = plugin._render_inline(_supply_chain_result_with_findings())
+
+        assert "| Package | Version | Ecosystem | Risk |" not in out
+        assert "| File | Description |" not in out
+        assert "**Required:**" in out
+        assert "**Consider:**" in out
+        assert_review_prose_contract(out)
 
 
 # ── Regression: output unchanged from inline render ──────────────────────────

--- a/tests/unit/test_pr_review.py
+++ b/tests/unit/test_pr_review.py
@@ -212,6 +212,13 @@ class TestSarifToReviewWithHunks:
         assert "sql-injection" in body
         assert "error" in body
         assert "User input concatenated" in body
+        assert "Specific:" in body
+        assert "Measurable:" in body
+        assert "Actionable:" in body
+        assert "Relevant:" in body
+        assert "Targeted:" in body
+        assert "Fix:" in body
+        assert "Verify:" in body
 
     def test_smart_comment_includes_fix_hint_when_available(self):
         sarif_data = _sarif(
@@ -241,6 +248,28 @@ class TestSarifToReviewWithHunks:
 
         body = review.comments[0].body
         assert "environment variable" in body.lower()
+
+    def test_review_body_lists_smart_fix_plan_for_blockers(self):
+        sarif = _sarif(
+            [
+                _finding(
+                    file="src/settings.py",
+                    line=12,
+                    level="error",
+                    rule="hardcoded-secret",
+                    msg="Hardcoded API key detected",
+                )
+            ],
+            tool="gitleaks",
+        )
+        review = sarif_to_review(sarif, diff_files={"src/settings.py"})
+
+        assert review.event == "REQUEST_CHANGES"
+        assert "S.M.A.R.T. Fix Plan" in review.body
+        assert "Why blocked" in review.body
+        assert "`src/settings.py:12`" in review.body
+        assert "hardcoded-secret" in review.body
+        assert "Verify:" in review.body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pr_review.py
+++ b/tests/unit/test_pr_review.py
@@ -209,16 +209,22 @@ class TestSarifToReviewWithHunks:
         review = sarif_to_review(sarif, diff_files={"src/app.py"}, diff_hunks=diff_hunks)
 
         body = review.comments[0].body
+        assert "**Required:**" in body
         assert "sql-injection" in body
         assert "error" in body
         assert "User input concatenated" in body
-        assert "Specific:" in body
-        assert "Measurable:" in body
-        assert "Actionable:" in body
-        assert "Relevant:" in body
-        assert "Targeted:" in body
+        assert "What failed:" in body
+        assert "Why it blocks:" in body
+        assert "Concatenated input can let request data change the SQL query structure." in body
         assert "Fix:" in body
+        assert "Done when:" in body
+        assert "Where:" in body
         assert "Verify:" in body
+        assert "Specific:" not in body
+        assert "Measurable:" not in body
+        assert "Actionable:" not in body
+        assert "Relevant:" not in body
+        assert "Targeted:" not in body
 
     def test_smart_comment_includes_fix_hint_when_available(self):
         sarif_data = _sarif(
@@ -265,11 +271,54 @@ class TestSarifToReviewWithHunks:
         review = sarif_to_review(sarif, diff_files={"src/settings.py"})
 
         assert review.event == "REQUEST_CHANGES"
-        assert "S.M.A.R.T. Fix Plan" in review.body
+        assert "Blocking Fix Plan" in review.body
         assert "Why blocked" in review.body
+        assert "**Required:** `hardcoded-secret`" in review.body
         assert "`src/settings.py:12`" in review.body
         assert "hardcoded-secret" in review.body
+        assert "Exposed credentials can be reused" in review.body
         assert "Verify:" in review.body
+        assert "finding(s)" not in review.body
+
+    def test_warning_comment_is_labeled_consider_not_required(self):
+        sarif = _sarif(
+            [
+                _finding(
+                    file="src/app.py",
+                    line=7,
+                    level="warning",
+                    rule="complex-branch",
+                    msg="Branch is difficult to follow",
+                )
+            ]
+        )
+        review = sarif_to_review(sarif, diff_files={"src/app.py"})
+
+        body = review.comments[0].body
+        assert "**Consider:**" in body
+        assert "Why it matters:" in body
+        assert "Why it blocks:" not in body
+        assert "Simplify the flagged code/config where possible" in body
+
+    def test_inline_smart_comment_wraps_long_lines_for_github_width(self):
+        sarif = _sarif(
+            [
+                _finding(
+                    file="src/settings.py",
+                    line=12,
+                    level="error",
+                    rule="hardcoded-secret",
+                    msg=(
+                        "Hardcoded API key detected in a configuration module with a very long "
+                        "description that would otherwise make the pull request comment scroll "
+                        "sideways"
+                    ),
+                )
+            ]
+        )
+        review = sarif_to_review(sarif, diff_files={"src/settings.py"})
+
+        assert max(len(line) for line in review.comments[0].body.splitlines()) <= 110
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -106,6 +106,35 @@ class TestRenderComment:
         )
         assert "BLOCKED" in md
 
+    def test_blocked_comment_includes_smart_fix_plan(self):
+        result = PluginResult(
+            plugin_name="gitleaks",
+            category="supply_chain",
+            findings=[
+                {
+                    "severity": "critical",
+                    "file": "src/settings.py",
+                    "line": 12,
+                    "rule": "generic-api-key",
+                    "description": "Hardcoded API key detected",
+                }
+            ],
+        )
+
+        md = render_comment([result], repo="org/repo", pr_num=1, title="test")
+
+        assert "S.M.A.R.T. Fix Plan" in md
+        assert "Why blocked" in md
+        assert "Specific:" in md
+        assert "Measurable:" in md
+        assert "Actionable:" in md
+        assert "Relevant:" in md
+        assert "Targeted:" in md
+        assert "`src/settings.py:12`" in md
+        assert "Remove or rotate the secret" in md
+        assert "uv run eedom review --repo-path . --all" in md
+        assert "upstream dependencies" not in md
+
     def test_verdict_warnings_on_non_critical(self):
         result = PluginResult(
             plugin_name="semgrep",

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -123,17 +123,69 @@ class TestRenderComment:
 
         md = render_comment([result], repo="org/repo", pr_num=1, title="test")
 
-        assert "S.M.A.R.T. Fix Plan" in md
+        assert "Actionability: Fix Plan" in md
         assert "Why blocked" in md
-        assert "Specific:" in md
-        assert "Measurable:" in md
-        assert "Actionable:" in md
-        assert "Relevant:" in md
-        assert "Targeted:" in md
+        assert "**Required:** gitleaks" in md
+        assert "What failed:" in md
+        assert "Why it blocks:" in md
+        assert "Fix:" in md
+        assert "Done when:" in md
+        assert "Verify:" in md
+        assert "Exposed credentials remain reusable" in md
+        assert "Specific:" not in md
+        assert "Measurable:" not in md
+        assert "Actionable:" not in md
+        assert "Relevant:" not in md
+        assert "Targeted:" not in md
         assert "`src/settings.py:12`" in md
         assert "Remove or rotate the secret" in md
         assert "uv run eedom review --repo-path . --all" in md
+        assert "1 findings" not in md
         assert "upstream dependencies" not in md
+
+    def test_smart_fix_plan_wraps_long_lines_for_github_width(self):
+        result = PluginResult(
+            plugin_name="gitleaks",
+            category="supply_chain",
+            findings=[
+                {
+                    "severity": "critical",
+                    "file": "src/settings.py",
+                    "line": 12,
+                    "rule": "generic-api-key",
+                    "description": (
+                        "Hardcoded API key detected in a configuration module with a very long "
+                        "description that would otherwise make the pull request comment scroll "
+                        "sideways"
+                    ),
+                }
+            ],
+        )
+
+        md = render_comment([result], repo="org/repo", pr_num=1, title="test")
+        smart_section = md.split("### Actionability: Fix Plan", 1)[1]
+        smart_section = smart_section.split("**1 finding requires code/config changes**", 1)[0]
+
+        assert max(len(line) for line in smart_section.splitlines()) <= 110
+
+    def test_owner_action_without_severity_omits_empty_parentheses(self):
+        result = PluginResult(
+            plugin_name="opa",
+            category="dependency",
+            findings=[
+                {
+                    "decision": "needs_review",
+                    "triggered_rules": ["policy.manifest_review"],
+                    "constraints": [],
+                    "policy_version": "test",
+                }
+            ],
+        )
+
+        md = render_comment([result], repo="org/repo", pr_num=1, title="test")
+
+        assert "- **opa**: 1 finding" in md
+        assert "- **opa**: 1 finding (" not in md
 
     def test_verdict_warnings_on_non_critical(self):
         result = PluginResult(

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -212,6 +212,22 @@ class TestRenderComment:
         assert "| cspell | skipped |" in md
         assert "| Files scanned | 5 |" in md
 
+    def test_summary_table_shows_diff_scope_repo_context(self):
+        md = render_comment(
+            [_empty_result()],
+            repo="org/repo",
+            pr_num=1,
+            title="test",
+            file_count=3,
+            scan_scope="diff",
+            repo_file_count=42,
+        )
+
+        assert "| Scan scope | diff |" in md
+        assert "| Changed files | 3 |" in md
+        assert "| Repo-wide files | 42 total |" in md
+        assert "| Files scanned | 3 |" not in md
+
     def test_error_plugin_shows_error(self):
         md = render_comment(
             [_error_result()],

--- a/tests/unit/test_supply_chain_latest.py
+++ b/tests/unit/test_supply_chain_latest.py
@@ -229,6 +229,19 @@ class TestLockfileShaPath:
             f"Expected {expected_sha}, got {lockfile_findings[0]['sha256']!r}"
         )
 
+    def test_lockfile_message_uses_professional_prose(self, tmp_path):
+        pkg_dir = tmp_path / "apps" / "web"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "package-lock.json").write_text('{"lockfileVersion": 2}')
+
+        plugin = SupplyChainPlugin()
+        findings = plugin._check_lockfiles([str(pkg_dir / "package-lock.json")], tmp_path)
+
+        assert findings
+        message = findings[0]["message"]
+        assert "DID NOT" not in message
+        assert "was not" in message
+
 
 # ── Unpinned severity tests ──────────────────────────────────────────────────
 

--- a/tests/unit/test_supply_chain_latest.py
+++ b/tests/unit/test_supply_chain_latest.py
@@ -181,7 +181,7 @@ class TestLockfileShaPath:
     """Verify _check_lockfiles uses per-directory paths, not repo root."""
 
     def test_lockfile_sha_uses_lockfile_directory(self, tmp_path):
-        """When package-lock.json is at apps/web/, SHA should hash apps/web/package-lock.json not repo/package-lock.json."""
+        """SHA should hash apps/web/package-lock.json, not repo/package-lock.json."""
         import hashlib
 
         web_dir = tmp_path / "apps" / "web"
@@ -200,9 +200,10 @@ class TestLockfileShaPath:
             lockfile_findings
         ), "Expected a lockfile finding for package-lock.json without manifest"
         expected_sha = hashlib.sha256(lockfile_content).hexdigest()
-        assert (
-            lockfile_findings[0]["sha256"] == expected_sha
-        ), f"SHA should come from apps/web/package-lock.json, got {lockfile_findings[0]['sha256']!r}"
+        assert lockfile_findings[0]["sha256"] == expected_sha, (
+            "SHA should come from apps/web/package-lock.json, got "
+            f"{lockfile_findings[0]['sha256']!r}"
+        )
 
     def test_lockfile_sha_uses_package_dir_not_repo_root(self, tmp_path):
         """_check_lockfiles: SHA is from the actual lock file in its subdirectory."""
@@ -323,9 +324,10 @@ class TestUnpinnedSeverity:
         uv_findings = [
             f for f in findings if f.get("type") == "lockfile" and f.get("lockfile") == "uv.lock"
         ]
-        assert (
-            len(uv_findings) == 1
-        ), f"Expected 1 uv.lock medium finding (manifest changed, lock not updated), got {uv_findings}"
+        assert len(uv_findings) == 1, (
+            "Expected 1 uv.lock medium finding "
+            f"(manifest changed, lock not updated), got {uv_findings}"
+        )
         expected_sha = hashlib.sha256(lock_content.encode()).hexdigest()
         assert uv_findings[0]["sha256"] == expected_sha, (
             f"SHA computed from wrong path. "


### PR DESCRIPTION
## Summary
- Make Dom review output prescriptive without exposing SMART as a visible rubric.
- Add Required/Consider/FYI intent labels plus What failed, Why, Fix, Done when, Where, and Verify fields for PR body and inline review comments.
- Rework complexity, supply-chain, Semgrep, and kube-linter summaries away from dense scanner/table dumps.
- Align the Gatekeeper prompt and GitHub workflow wrapper with the same review prose contract.
- Stack on #282 and show scan scope explicitly in review comments, including changed-file and repo-wide context counts for `--scope diff`.
- Remove/guard against stale template drift and lock in prose behavior with shared assertions.

## Verification
- `podman run --rm -v /Users/samfakhreddine/repos/eedom-dom-review-prose:/workspace:ro -w /workspace -e EEDOM_ALLOW_GLOBAL=1 --entrypoint /opt/test-venv/bin/python eedom-test:latest -m pytest tests/unit/test_actionability.py tests/unit/test_renderer.py tests/unit/test_pr_review.py tests/unit/test_plugin_templates.py tests/unit/test_agent_prompt.py tests/unit/test_gatekeeper_workflow.py tests/unit/test_supply_chain_latest.py tests/unit/test_complexity_plugin.py tests/unit/test_cli.py::TestScopeFlag tests/unit/test_plugin_registry.py::TestRepoFilesRouting tests/unit/test_use_cases.py -q`
  - Result: 265 passed
- `podman run --rm -v /Users/samfakhreddine/repos/eedom-dom-review-prose:/workspace:ro -w /workspace -e EEDOM_ALLOW_GLOBAL=1 --entrypoint /opt/test-venv/bin/python eedom-test:latest -m ruff check --cache-dir /tmp/ruff-cache src/eedom/cli/main.py src/eedom/core/renderer.py tests/unit/test_renderer.py tests/unit/test_cli.py`
  - Result: passed

## Dogfood
- `eedom review --repo-path /workspace --all --scope diff --diff - --format markdown` against `origin/feat/scan-scope...HEAD`
  - Result: rendered successfully as `INCOMPLETE` because the test image is missing scanner binaries (`gitleaks`, `opengrep`, `kube-linter`, `lizard`, `pmd`, `cspell`, etc.).
  - Scope prose now renders as:
    - `Scan scope | diff`
    - `Changed files | 25`
    - `Repo-wide files | 244 total`

## Notes
- This PR is stacked on #282 (`feat/scan-scope`) so GitHub only shows the prose work above the scope feature.
- `make test` is not used here because this repo/container path still attempts to write `uv.lock` through a read-only mount; direct container pytest is the working validation path.
