### PR TITLE
chore: add GitHub Actions update vetting policy

### DIFF
--- a/.github/actions-allowlist.yml
+++ b/.github/actions-allowlist.yml
@@ -1,0 +1,9 @@
+actions:
+  - actions/attest
+  - actions/attest-build-provenance
+  - actions/checkout
+  - actions/github-script
+  - actions/upload-artifact
+  - astral-sh/setup-uv
+  - googleapis/release-please-action
+  - pypa/gh-action-pypi-publish

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,8 @@ updates:
       day: "monday"
       time: "08:30"
       timezone: "America/Edmonton"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/workflows/workflow-policy.yml
+++ b/.github/workflows/workflow-policy.yml
@@ -1,0 +1,29 @@
+name: Workflow Policy
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions-allowlist.yml"
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
+      - "tests/unit/test_dependabot_policy.py"
+      - "tests/unit/test_github_actions_policy.py"
+      - "tests/unit/test_ruff_policy.py"
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    name: Workflow policy checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+      - name: Run workflow policy tests
+        run: >
+          uv run pytest
+          tests/unit/test_github_actions_policy.py
+          tests/unit/test_dependabot_policy.py
+          tests/unit/test_ruff_policy.py
+          -q

--- a/.github/workflows/workflow-policy.yml
+++ b/.github/workflows/workflow-policy.yml
@@ -19,11 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - name: Run workflow policy tests
-        run: >
-          uv run pytest
-          tests/unit/test_github_actions_policy.py
-          tests/unit/test_dependabot_policy.py
-          tests/unit/test_ruff_policy.py
-          -q
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -w /workspace \
+            -e EEDOM_ALLOW_GLOBAL=1 \
+            -e UV_PROJECT_ENVIRONMENT=/tmp/eedom-policy-venv \
+            docker.io/library/python@sha256:d384a24aebd583543abb00fa47b2a434ec3a96559c6f244cc3cfcbe9e136a798 \
+            sh -c "python -m pip install --disable-pip-version-check --no-cache-dir uv==0.11.8 && uv run pytest tests/unit/test_github_actions_policy.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py -q"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,11 @@ policies/ @samfakhreddine
 # GitHub Actions
 .github/ @samfakhreddine
 action.yml @samfakhreddine
+
+# Workflow policy guardrails
+.github/actions-allowlist.yml @samfakhreddine
+.github/workflows/workflow-policy.yml @samfakhreddine
+tests/unit/test_github_actions_policy.py @samfakhreddine
+tests/unit/test_dependabot_policy.py @samfakhreddine
+tests/unit/test_ruff_policy.py @samfakhreddine
+docs/adr/005-github-actions-update-vetting-policy.md @samfakhreddine

--- a/docs/adr/005-github-actions-update-vetting-policy.md
+++ b/docs/adr/005-github-actions-update-vetting-policy.md
@@ -1,0 +1,58 @@
+# ADR-005: GitHub Actions Update Vetting Policy
+
+## Status
+
+Accepted
+
+## Context
+
+GitHub Actions updates are CI supply-chain changes. A compromised or unsafe
+action can run with repository credentials, publish artifacts, or influence the
+result of a protected check. Dependabot should still propose updates, but those
+updates need deterministic review gates before they land.
+
+The repository already pins third-party actions to full commit SHAs. That is the
+right baseline, but it needs supporting policy so updates stay reviewable:
+
+1. reviewers need to know which actions are approved for use,
+2. SHA pins need a human-readable upstream version comment,
+3. `pull_request_target` workflows must not checkout or execute untrusted PR
+   head code, and
+4. the policy check itself must run read-only.
+
+Dependabot supports delaying version updates with `cooldown`, but security
+updates bypass cooldown. Dependabot configuration also does not provide a CVSS
+threshold that would express "only bypass delay for CVE 10" in this file.
+
+## Decision
+
+Dependabot will open GitHub Actions update PRs for the repository root. Those
+PRs must pass a read-only `Workflow Policy` check before review.
+
+The policy requires:
+
+- every remote action reference to be listed in `.github/actions-allowlist.yml`,
+- every remote action reference to be pinned to a full 40-character commit SHA,
+- every SHA-pinned action line to include a same-line version comment such as
+  `# v4`,
+- GitHub Actions Dependabot updates to use the `github-actions` label and a
+  14-day cooldown for version updates,
+- `pull_request_target` workflows to avoid checkout and PR head execution
+  patterns, and
+- workflow policy files and tests to be owned in `CODEOWNERS`.
+
+Branch protection should require the `Workflow Policy` status check and
+CODEOWNERS review for changes to workflow policy files. That setting lives in
+GitHub repository configuration rather than in this source tree.
+
+## Consequences
+
+- GitHub Actions updates are slower, but they are reviewable and deterministic.
+- Adding a new third-party action requires an allowlist change in the same PR.
+- Version comments make SHA-only diffs auditable by humans.
+- The workflow policy check can run on untrusted PRs because it has read-only
+  permissions and only executes repository tests.
+- The existing Gatekeeper workflow still mixes `pull_request`, self-hosted
+  runners, and write scopes. Fixing that requires a workflow split and should be
+  handled as a separate CI hardening task rather than hidden inside this policy
+  PR.

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -161,6 +161,10 @@ def test_workflow_policy_runs_read_only_policy_checks() -> None:
     assert "tests/unit/test_github_actions_policy.py" in run_text
     assert "tests/unit/test_dependabot_policy.py" in run_text
     assert "tests/unit/test_ruff_policy.py" in run_text
+    assert "docker.io/library/python@sha256:" in run_text
+    assert '-v "$GITHUB_WORKSPACE:/workspace:ro"' in run_text
+    assert "UV_PROJECT_ENVIRONMENT=/tmp/eedom-policy-venv" in run_text
+    assert "EEDOM_ALLOW_HOST_TESTS" not in run_text
 
 
 def test_pull_request_target_workflows_do_not_checkout_or_execute_pr_head() -> None:

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -1,0 +1,201 @@
+# tested-by: tests/unit/test_github_actions_policy.py
+"""GitHub Actions update vetting policy guards."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS = _ROOT / ".github" / "workflows"
+_ALLOWLIST = _ROOT / ".github" / "actions-allowlist.yml"
+_WORKFLOW_POLICY = _WORKFLOWS / "workflow-policy.yml"
+_ADR = _ROOT / "docs" / "adr" / "005-github-actions-update-vetting-policy.md"
+_CODEOWNERS = _ROOT / "CODEOWNERS"
+
+_USE_LINE = re.compile(r"^\s*uses:\s*(?P<uses>['\"]?[^'\"\s#]+['\"]?)(?P<comment>\s+#.*)?$")
+_ACTION_REF = re.compile(r"^(?P<action>[^/@\s]+/[^@\s]+)@(?P<ref>[^@\s]+)$")
+_FULL_SHA = re.compile(r"^[A-Fa-f0-9]{40}$")
+_VERSION_COMMENT = re.compile(r"#\s*v\d")
+_PULL_REQUEST_TARGET_HEAD_PATTERNS = (
+    "github.event.pull_request.head",
+    "github.head_ref",
+    "github.event.pull_request.head.ref",
+    "github.event.pull_request.head.sha",
+)
+
+
+def _load_yaml(path: Path) -> dict[object, object]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    assert isinstance(data, dict), f"{path.relative_to(_ROOT)} must parse to a YAML mapping"
+    return data
+
+
+def _as_mapping(value: object) -> dict[object, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_sequence(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _github_on(workflow: dict[object, object]) -> object:
+    # PyYAML follows YAML 1.1, so the GitHub Actions key "on" can parse as True.
+    return workflow.get("on", workflow.get(True, {}))
+
+
+def _workflow_events(workflow: dict[object, object]) -> set[str]:
+    on_block = _github_on(workflow)
+    if isinstance(on_block, str):
+        return {on_block}
+    if isinstance(on_block, list):
+        return {event for event in on_block if isinstance(event, str)}
+    if isinstance(on_block, dict):
+        return {str(event) for event in on_block}
+    return set()
+
+
+def _workflow_paths() -> list[Path]:
+    return sorted(_WORKFLOWS.glob("*.yml"))
+
+
+def _allowlisted_actions() -> list[str]:
+    data = _load_yaml(_ALLOWLIST)
+    actions = data.get("actions")
+    assert isinstance(actions, list), ".github/actions-allowlist.yml must define an actions list"
+    assert all(isinstance(action, str) for action in actions), "allowlisted actions must be strings"
+    return actions
+
+
+def _remote_uses_lines(path: Path) -> list[tuple[int, str, str]]:
+    lines: list[tuple[int, str, str]] = []
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        match = _USE_LINE.match(raw_line)
+        if not match:
+            continue
+        uses = match.group("uses").strip("'\"")
+        if uses.startswith("./"):
+            continue
+        comment = match.group("comment") or ""
+        lines.append((line_number, uses, comment))
+    return lines
+
+
+def _workflow_steps(workflow: dict[object, object]) -> list[dict[object, object]]:
+    steps: list[dict[object, object]] = []
+    for raw_job in _as_mapping(workflow.get("jobs")).values():
+        job = _as_mapping(raw_job)
+        for raw_step in _as_sequence(job.get("steps")):
+            step = _as_mapping(raw_step)
+            if step:
+                steps.append(step)
+    return steps
+
+
+def _run_text(workflow: dict[object, object]) -> str:
+    runs = [step["run"] for step in _workflow_steps(workflow) if isinstance(step.get("run"), str)]
+    return "\n".join(runs)
+
+
+def test_action_allowlist_is_sorted_and_unique() -> None:
+    actions = _allowlisted_actions()
+
+    assert actions == sorted(actions), "Keep action allowlist sorted for reviewable diffs"
+    assert len(actions) == len(set(actions)), "Action allowlist must not contain duplicates"
+
+
+def test_workflows_use_only_sha_pinned_allowlisted_actions() -> None:
+    allowlist = set(_allowlisted_actions())
+
+    for path in _workflow_paths():
+        for line_number, uses, comment in _remote_uses_lines(path):
+            location = f"{path.relative_to(_ROOT)}:{line_number}"
+            assert not uses.startswith("docker://"), f"{location} uses an unpinned docker action"
+
+            match = _ACTION_REF.match(uses)
+            assert match is not None, f"{location} must use owner/repo@ref syntax"
+
+            action = match.group("action")
+            assert action in allowlist, f"{location} uses {action}, which is not in the allowlist"
+
+            ref = match.group("ref")
+            assert _FULL_SHA.fullmatch(ref), f"{location} must pin {action} to a full commit SHA"
+            assert _VERSION_COMMENT.search(comment), (
+                f"{location} must include a same-line version comment like '# v4'"
+            )
+
+
+def test_dependabot_updates_github_actions_with_review_labels() -> None:
+    dependabot = _load_yaml(_ROOT / ".github" / "dependabot.yml")
+    updates = dependabot.get("updates")
+    assert isinstance(updates, list), "dependabot.yml must define updates"
+
+    github_actions_updates = [
+        update
+        for update in updates
+        if isinstance(update, dict) and update.get("package-ecosystem") == "github-actions"
+    ]
+    assert github_actions_updates, "Dependabot must propose GitHub Actions updates"
+
+    root_update = next(
+        update for update in github_actions_updates if update.get("directory") == "/"
+    )
+    labels = root_update.get("labels")
+    assert isinstance(labels, list), "GitHub Actions Dependabot updates must define labels"
+    assert "github-actions" in labels
+
+    cooldown = root_update.get("cooldown")
+    assert isinstance(cooldown, dict), "GitHub Actions updates must define a cooldown"
+    assert cooldown.get("default-days") == 14
+
+
+def test_workflow_policy_runs_read_only_policy_checks() -> None:
+    workflow = _load_yaml(_WORKFLOW_POLICY)
+
+    assert "pull_request" in _workflow_events(workflow)
+    assert workflow.get("permissions") == {"contents": "read"}
+
+    run_text = _run_text(workflow)
+    assert "tests/unit/test_github_actions_policy.py" in run_text
+    assert "tests/unit/test_dependabot_policy.py" in run_text
+    assert "tests/unit/test_ruff_policy.py" in run_text
+
+
+def test_pull_request_target_workflows_do_not_checkout_or_execute_pr_head() -> None:
+    for path in _workflow_paths():
+        workflow = _load_yaml(path)
+        if "pull_request_target" not in _workflow_events(workflow):
+            continue
+
+        for step in _workflow_steps(workflow):
+            uses = step.get("uses")
+            if isinstance(uses, str):
+                assert not uses.startswith("actions/checkout@"), (
+                    f"{path.relative_to(_ROOT)} must not checkout code under pull_request_target"
+                )
+
+            run = step.get("run")
+            if isinstance(run, str):
+                for pattern in _PULL_REQUEST_TARGET_HEAD_PATTERNS:
+                    assert pattern not in run, (
+                        f"{path.relative_to(_ROOT)} must not execute pull_request_target code "
+                        f"from {pattern}"
+                    )
+
+
+def test_policy_artifacts_are_codeowned_and_documented() -> None:
+    assert _ADR.exists(), "Record the GitHub Actions update vetting policy in an ADR"
+
+    codeowners = _CODEOWNERS.read_text(encoding="utf-8")
+    required_paths = [
+        ".github/actions-allowlist.yml",
+        ".github/workflows/workflow-policy.yml",
+        "tests/unit/test_github_actions_policy.py",
+        "tests/unit/test_dependabot_policy.py",
+        "tests/unit/test_ruff_policy.py",
+        "docs/adr/005-github-actions-update-vetting-policy.md",
+    ]
+    for required_path in required_paths:
+        assert required_path in codeowners, f"CODEOWNERS must cover {required_path}"

--- a/tests/unit/test_ruff_policy.py
+++ b/tests/unit/test_ruff_policy.py
@@ -1,0 +1,40 @@
+# tested-by: tests/unit/test_ruff_policy.py
+"""Ruff configuration sanity guards."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pyproject() -> dict[str, object]:
+    with (_ROOT / "pyproject.toml").open("rb") as file:
+        data = tomllib.load(file)
+    assert isinstance(data, dict), "pyproject.toml must parse to a TOML mapping"
+    return data
+
+
+def _as_mapping(value: object) -> dict[object, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def test_ruff_lint_preferences_stay_conservative() -> None:
+    tool = _as_mapping(_pyproject().get("tool"))
+    ruff = _as_mapping(tool.get("ruff"))
+    lint = _as_mapping(ruff.get("lint"))
+
+    assert ruff.get("target-version") == "py312"
+    assert ruff.get("line-length") == 100
+    assert ruff.get("preview") is not True
+    assert lint.get("preview") is not True
+
+    selected = lint.get("select")
+    assert isinstance(selected, list), "Ruff lint rules must use an explicit select list"
+    assert "ALL" not in selected, "Do not enable every Ruff rule family at once"
+    assert set(selected) == {"E", "F", "W", "I", "N", "UP", "B", "SIM"}
+
+    assert lint.get("per-file-ignores") == {}, (
+        "Keep global lint policy simple; add scoped ignores only when the repo needs them"
+    )


### PR DESCRIPTION
## Summary
- Add active policy guards for GitHub Actions SHA pinning, action allowlisting, same-line version comments, `pull_request_target` safety, workflow-policy ownership, and sane Ruff preferences.
- Add `.github/actions-allowlist.yml`, a read-only `Workflow Policy` PR workflow, CODEOWNERS coverage, and ADR-005 for the update-vetting policy.
- Add a 14-day cooldown for normal GitHub Actions version updates now that PR #284 added Dependabot config.
- Run the workflow-policy check inside a pinned Python container so it honors the repo rule that tests run in containers.

## Security Update Note
- GitHub documents `cooldown` as applying to version updates, not security updates.
- `dependabot.yml` does not expose a CVSS/CVE severity predicate, so this cannot encode "only CVSS 10 bypasses cooldown." The effective behavior is: normal version updates wait 14 days; Dependabot security updates bypass the cooldown.
- Branch protection should require the `Workflow Policy` status check and CODEOWNERS review for workflow policy files; ADR-005 records that repo-setting requirement.

## Verification
- RED check: new policy tests failed before policy artifacts were added.
  - Result: 5 failed, 2 passed; failures were missing allowlist, missing workflow, missing ADR/CODEOWNERS, and missing GitHub Actions cooldown.
- Post-rebase focused policy tests:
  - `podman run --rm -v /Users/samfakhreddine/repos/eedom-dependabot-fixture-exclusions:/workspace:ro -w /workspace -e EEDOM_ALLOW_GLOBAL=1 --entrypoint /opt/test-venv/bin/python eedom-test:latest -m pytest tests/unit/test_github_actions_policy.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py -q`
  - Result: 10 passed
- Post-rebase Ruff:
  - `podman run --rm -v /Users/samfakhreddine/repos/eedom-dependabot-fixture-exclusions:/workspace:ro -w /workspace -e EEDOM_ALLOW_GLOBAL=1 --entrypoint /opt/test-venv/bin/python eedom-test:latest -m ruff check --cache-dir /tmp/ruff-cache tests/unit/test_github_actions_policy.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py`
  - Result: passed
- Workflow-policy CI after container fix:
  - Result: passed on GitHub Actions run `25116486726`, job `73604890721`.
- `make test`
  - Result: did not reach pytest; local Podman build rejected Dockerfile `RUN --security=insecure` with `RUN only supports the --mount and --network flag`.
- Post-rebase full container pytest:
  - `podman run --rm -v /Users/samfakhreddine/repos/eedom-dependabot-fixture-exclusions:/workspace:ro -w /workspace -e EEDOM_ALLOW_GLOBAL=1 --entrypoint /opt/test-venv/bin/python eedom-test:latest -m pytest tests/ -q`
  - Result: 1653 passed, 63 skipped, 35 xfailed, 7 xpassed
- Clean-clone dogfood on final branch head:
  - `UV_PROJECT_ENVIRONMENT=/tmp/eedom-self-review-clean-venv uv run eedom review --repo-path . --scope diff --all --diff <(git diff origin/main...HEAD)`
  - Result: pass with warnings, security 100/100, gitleaks 0. Remaining warnings were info-level complexity/spelling/license output plus missing/degraded local scanners.
- Exact pinned-container workflow command on this local host:
  - Result: reached `uv` install but segfaulted under amd64 image emulation on the local arm64 machine; the same path passed on the GitHub amd64 runner.
