### PR TITLE
fix: add concurrency group to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Prevents branch race when multiple pushes to main trigger parallel release-please runs. Serializes without cancelling queued runs.