### PR TITLE
fix: skip CI for draft PRs

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -2,6 +2,7 @@ name: GATEKEEPER — Dependency & Code Review
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
 
@@ -35,7 +36,12 @@ jobs:
 
   preflight:
     name: Preflight
-    if: github.event_name == 'push' || !startsWith(github.head_ref || '', 'release-please--')
+    if: >-
+      github.event_name != 'pull_request' ||
+      (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref || '', 'release-please--')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -95,6 +101,7 @@ jobs:
     needs: preflight
     if: >-
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.preflight.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -126,6 +133,7 @@ jobs:
     needs: preflight
     if: >-
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.preflight.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -156,6 +164,7 @@ jobs:
     needs: preflight
     if: >-
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.preflight.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -224,6 +233,7 @@ jobs:
     needs: preflight
     if: >-
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.preflight.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -324,6 +334,7 @@ jobs:
       always() &&
       !cancelled() &&
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.preflight.result == 'success' &&
       needs.preflight.outputs.docs_only != 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-policy.yml
+++ b/.github/workflows/workflow-policy.yml
@@ -2,6 +2,7 @@ name: Workflow Policy
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/actions-allowlist.yml"
       - ".github/dependabot.yml"
@@ -16,6 +17,7 @@ permissions:
 jobs:
   policy:
     name: Workflow policy checks
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -27,4 +29,4 @@ jobs:
             -e EEDOM_ALLOW_GLOBAL=1 \
             -e UV_PROJECT_ENVIRONMENT=/tmp/eedom-policy-venv \
             docker.io/library/python@sha256:d384a24aebd583543abb00fa47b2a434ec3a96559c6f244cc3cfcbe9e136a798 \
-            sh -c "python -m pip install --disable-pip-version-check --no-cache-dir uv==0.11.8 && uv run pytest tests/unit/test_github_actions_policy.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py -q"
+            sh -c "python -m pip install --disable-pip-version-check --no-cache-dir uv==0.11.8 && uv run --frozen pytest tests/unit/test_github_actions_policy.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py -q"

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -164,7 +164,36 @@ def test_workflow_policy_runs_read_only_policy_checks() -> None:
     assert "docker.io/library/python@sha256:" in run_text
     assert '-v "$GITHUB_WORKSPACE:/workspace:ro"' in run_text
     assert "UV_PROJECT_ENVIRONMENT=/tmp/eedom-policy-venv" in run_text
+    assert "uv run --frozen pytest" in run_text
     assert "EEDOM_ALLOW_HOST_TESTS" not in run_text
+
+
+def test_pull_request_ci_skips_draft_prs_and_runs_when_ready_for_review() -> None:
+    pr_ci_workflows = [
+        _WORKFLOWS / "gatekeeper.yml",
+        _WORKFLOWS / "workflow-policy.yml",
+    ]
+
+    for path in pr_ci_workflows:
+        workflow = _load_yaml(path)
+        on_block = _github_on(workflow)
+        assert isinstance(on_block, dict), f"{path.relative_to(_ROOT)} must define events"
+        pull_request = on_block.get("pull_request")
+        assert isinstance(
+            pull_request, dict
+        ), f"{path.relative_to(_ROOT)} must configure pull_request"
+        assert "ready_for_review" in pull_request.get(
+            "types", []
+        ), f"{path.relative_to(_ROOT)} must run CI when a draft PR is marked ready"
+
+        for job_name, raw_job in _as_mapping(workflow.get("jobs")).items():
+            job = _as_mapping(raw_job)
+            condition = str(job.get("if", ""))
+            if condition.strip() == "github.event_name == 'push'":
+                continue
+            assert (
+                "github.event.pull_request.draft == false" in condition
+            ), f"{path.relative_to(_ROOT)} job {job_name} must skip draft PRs"
 
 
 def test_pull_request_target_workflows_do_not_checkout_or_execute_pr_head() -> None:


### PR DESCRIPTION
## Summary
- skip PR CI jobs while a pull request is in draft state
- run the PR CI workflows again when a draft is marked ready for review
- add a deterministic workflow policy guard for the draft skip behavior

## Test Plan
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/unit/test_github_actions_policy.py
- UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/unit/test_github_actions_policy.py
- python3 YAML policy smoke for ready_for_review + draft guards