### PR TITLE
ci: split e2e smoke and full lanes

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -2,7 +2,7 @@ name: GATEKEEPER — Dependency & Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches: [main]
 
@@ -45,27 +45,83 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      docs_only: ${{ steps.docs.outputs.docs_only }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      full_e2e: ${{ steps.classify.outputs.full_e2e }}
+      full_e2e_reason: ${{ steps.classify.outputs.full_e2e_reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - name: Detect docs-only PR
+      - name: Classify PR changes
         if: github.event_name == 'pull_request'
-        id: docs
+        id: classify
         run: |
-          CODE_CHANGES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" | grep -cvE '\.(md|txt)$|^docs/|^LICENSE|^CODEOWNERS|^\.github/ISSUE_TEMPLATE/' || true)
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          CODE_CHANGES=$(printf '%s\n' "$CHANGED_FILES" | grep -cvE '\.(md|txt)$|^docs/|^LICENSE|^CODEOWNERS|^\.github/ISSUE_TEMPLATE/' || true)
           if [ "$CODE_CHANGES" -eq 0 ]; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Docs-only PR — skipping review"
           else
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           fi
+
+          FULL_E2E_CHANGES=""
+          while IFS= read -r changed_path; do
+            case "$changed_path" in
+              tests/e2e/*|\
+              src/eedom/plugins/*|\
+              src/eedom/data/scanners/*|\
+              src/eedom/core/bootstrap.py|\
+              src/eedom/core/config.py|\
+              src/eedom/core/diff.py|\
+              src/eedom/core/ignore.py|\
+              src/eedom/core/json_report.py|\
+              src/eedom/core/manifest_discovery.py|\
+              src/eedom/core/orchestrator.py|\
+              src/eedom/core/pipeline.py|\
+              src/eedom/core/registry.py|\
+              src/eedom/core/renderer.py|\
+              src/eedom/core/repo_config.py|\
+              src/eedom/core/sarif.py|\
+              src/eedom/core/subprocess_runner.py|\
+              src/eedom/core/tool_runner.py|\
+              src/eedom/core/use_cases.py|\
+              src/eedom/cli/main.py|\
+              policies/*|\
+              Dockerfile|\
+              Dockerfile.test|\
+              Makefile|\
+              pyproject.toml|\
+              uv.lock|\
+              .github/workflows/gatekeeper.yml)
+                FULL_E2E_CHANGES="${FULL_E2E_CHANGES}${changed_path}"$'\n'
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+          if [ -n "$FULL_E2E_CHANGES" ]; then
+            echo "full_e2e=true" >> "$GITHUB_OUTPUT"
+            echo "full_e2e_reason=runtime_path" >> "$GITHUB_OUTPUT"
+            echo "::notice::Full e2e required by runtime path changes"
+            {
+              echo "### Full e2e required"
+              echo ""
+              echo "Runtime-sensitive paths changed:"
+              printf '%s\n' "$FULL_E2E_CHANGES" | sed 's/^/- `/' | sed 's/$/`/'
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$E2E_LABEL_PRESENT" = "true" ]; then
+            echo "full_e2e=true" >> "$GITHUB_OUTPUT"
+            echo "full_e2e_reason=e2e-needed_label" >> "$GITHUB_OUTPUT"
+            echo "::notice::Full e2e required by e2e-needed label"
+          else
+            echo "full_e2e=false" >> "$GITHUB_OUTPUT"
+            echo "full_e2e_reason=not_required" >> "$GITHUB_OUTPUT"
+          fi
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          E2E_LABEL_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-needed') }}
 
   # ── Push to main: stamp release key only (PR already validated) ──
 
@@ -159,13 +215,52 @@ jobs:
         env:
           EEDOM_ALLOW_HOST_TESTS: "1"
 
-  e2e:
-    name: E2E Tests
+  e2e_smoke:
+    name: E2E Smoke
     needs: preflight
     if: >-
       github.event_name != 'push' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.preflight.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Cache uv packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /tmp/uv-cache
+          key: uv-e2e-smoke-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-e2e-smoke-
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run smoke e2e tests
+        run: uv run pytest tests/e2e/test_smoke_review.py -v --tb=short
+        env:
+          EEDOM_ALLOW_HOST_TESTS: "1"
+          EEDOM_E2E: "1"
+
+  e2e_full:
+    name: E2E Full
+    needs: preflight
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.preflight.outputs.docs_only != 'true' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          needs.preflight.outputs.full_e2e == 'true'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -179,8 +274,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: /tmp/uv-cache
-          key: uv-e2e-${{ hashFiles('uv.lock') }}
-          restore-keys: uv-e2e-
+          key: uv-e2e-full-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-e2e-full-
 
       - name: Cache scanner binaries
         id: scanner-cache
@@ -329,7 +424,7 @@ jobs:
 
   gate:
     name: Gate
-    needs: [preflight, lint, test, e2e, review]
+    needs: [preflight, lint, test, e2e_smoke, e2e_full, review]
     if: >-
       always() &&
       !cancelled() &&
@@ -349,8 +444,9 @@ jobs:
           FAILED=""
           [ "$LINT" != "success" ] && FAILED="$FAILED lint($LINT)"
           [ "$TEST" != "success" ] && FAILED="$FAILED test($TEST)"
-          [ "$E2E" != "success" ] && [ "$E2E" != "failure" ] && FAILED="$FAILED e2e($E2E)"
-          [ "$E2E" = "failure" ] && echo "::warning::E2E tests failed — not blocking gate (scanner binary compat issues on GH runners)"
+          [ "$E2E_SMOKE" != "success" ] && FAILED="$FAILED e2e-smoke($E2E_SMOKE)"
+          [ "$E2E_FULL" != "success" ] && [ "$E2E_FULL" != "failure" ] && [ "$E2E_FULL" != "skipped" ] && FAILED="$FAILED e2e-full($E2E_FULL)"
+          [ "$E2E_FULL" = "failure" ] && echo "::warning::Full e2e tests failed — not blocking gate (scanner binary compat issues on GH runners)"
           [ "$REVIEW" != "success" ] && FAILED="$FAILED review($REVIEW)"
 
           if [ -n "$FAILED" ]; then
@@ -362,7 +458,8 @@ jobs:
         env:
           LINT: ${{ needs.lint.result }}
           TEST: ${{ needs.test.result }}
-          E2E: ${{ needs.e2e.result }}
+          E2E_SMOKE: ${{ needs.e2e_smoke.result }}
+          E2E_FULL: ${{ needs.e2e_full.result }}
           REVIEW: ${{ needs.review.result }}
 
       - name: Download review artifacts
@@ -448,7 +545,8 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Lint:** ${{ needs.lint.result }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tests:** ${{ needs.test.result }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **E2E:** ${{ needs.e2e.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **E2E smoke:** ${{ needs.e2e_smoke.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **E2E full:** ${{ needs.e2e_full.result }} (${{ needs.preflight.outputs.full_e2e_reason }})" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Review errors (critical/high):** $ERRORS" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Review warnings (medium):** $WARNINGS" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Skipped plugins (not installed):** $SKIPPED" >> "$GITHUB_STEP_SUMMARY"
@@ -591,7 +689,7 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.upstream.outputs.upstream_ok }}" != "true" ]; then
-            echo "::error::GATEKEEPER fail-closed — upstream job(s) failed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, e2e=${{ needs.e2e.result }}, review=${{ needs.review.result }})"
+            echo "::error::GATEKEEPER fail-closed — upstream job(s) failed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, e2e_smoke=${{ needs.e2e_smoke.result }}, e2e_full=${{ needs.e2e_full.result }}, review=${{ needs.review.result }})"
             exit 1
           fi
 

--- a/tests/e2e/test_smoke_review.py
+++ b/tests/e2e/test_smoke_review.py
@@ -1,0 +1,32 @@
+# tested-by: self (e2e)
+"""E2E smoke: CLI review path with a built-in scanner only."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import (
+    E2E_ENABLED,
+    breakpoint_dump,
+    get_all_findings,
+    run_review,
+)
+
+pytestmark = pytest.mark.skipif(not E2E_ENABLED, reason="E2E tests require EEDOM_E2E=1")
+
+
+class TestSmokeReview:
+    def test_supply_chain_smoke_clean_repo(self, clean_repo: Path, tmp_path: Path) -> None:
+        result, parsed = run_review(
+            clean_repo,
+            scanners="supply-chain",
+            output_format="json",
+        )
+        breakpoint_dump(tmp_path, "smoke_supply_chain_clean_repo", parsed)
+
+        assert result.exit_code == 0, f"Exit code {result.exit_code}: {result.output}"
+
+        all_findings = get_all_findings(parsed)
+        assert all_findings == []

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -94,8 +94,17 @@ def _workflow_steps(workflow: dict[object, object]) -> list[dict[object, object]
     return steps
 
 
+def _job_steps(job: dict[object, object]) -> list[dict[object, object]]:
+    return [step for raw_step in _as_sequence(job.get("steps")) if (step := _as_mapping(raw_step))]
+
+
 def _run_text(workflow: dict[object, object]) -> str:
     runs = [step["run"] for step in _workflow_steps(workflow) if isinstance(step.get("run"), str)]
+    return "\n".join(runs)
+
+
+def _job_run_text(job: dict[object, object]) -> str:
+    runs = [step["run"] for step in _job_steps(job) if isinstance(step.get("run"), str)]
     return "\n".join(runs)
 
 
@@ -194,6 +203,80 @@ def test_pull_request_ci_skips_draft_prs_and_runs_when_ready_for_review() -> Non
             assert (
                 "github.event.pull_request.draft == false" in condition
             ), f"{path.relative_to(_ROOT)} job {job_name} must skip draft PRs"
+
+
+def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
+    workflow = _load_yaml(_WORKFLOWS / "gatekeeper.yml")
+    on_block = _github_on(workflow)
+    assert isinstance(on_block, dict)
+    pull_request = _as_mapping(on_block.get("pull_request"))
+    pr_types = pull_request.get("types")
+    assert isinstance(pr_types, list)
+    assert "labeled" in pr_types, "adding e2e-needed must trigger a new CI evaluation"
+    assert "unlabeled" in pr_types, "removing e2e-needed must trigger a new CI evaluation"
+
+    jobs = _as_mapping(workflow.get("jobs"))
+    preflight = _as_mapping(jobs.get("preflight"))
+    smoke = _as_mapping(jobs.get("e2e_smoke"))
+    full = _as_mapping(jobs.get("e2e_full"))
+    gate = _as_mapping(jobs.get("gate"))
+    classify_step = next(
+        step for step in _job_steps(preflight) if step.get("name") == "Classify PR changes"
+    )
+
+    outputs = _as_mapping(preflight.get("outputs"))
+    assert outputs.get("full_e2e") == "${{ steps.classify.outputs.full_e2e }}"
+    assert outputs.get("full_e2e_reason") == "${{ steps.classify.outputs.full_e2e_reason }}"
+    classify_env = _as_mapping(classify_step.get("env"))
+    assert (
+        classify_env.get("E2E_LABEL_PRESENT")
+        == "${{ contains(github.event.pull_request.labels.*.name, 'e2e-needed') }}"
+    )
+
+    preflight_run = _job_run_text(preflight)
+    for required_path in (
+        "tests/e2e/",
+        "src/eedom/plugins/",
+        "src/eedom/data/scanners/",
+        ".github/workflows/gatekeeper.yml",
+        "uv.lock",
+    ):
+        assert required_path in preflight_run
+
+    smoke_step_names = {
+        step.get("name") for step in _job_steps(smoke) if isinstance(step.get("name"), str)
+    }
+    full_step_names = {
+        step.get("name") for step in _job_steps(full) if isinstance(step.get("name"), str)
+    }
+    assert "Run smoke e2e tests" in smoke_step_names
+    assert "Cache scanner binaries" not in smoke_step_names
+    assert "Add scanners to PATH and warm trivy DB" not in smoke_step_names
+    assert "Cache scanner binaries" in full_step_names
+    assert "Add scanners to PATH and warm trivy DB" in full_step_names
+
+    smoke_run = _job_run_text(smoke)
+    full_run = _job_run_text(full)
+    assert "tests/e2e/test_smoke_review.py" in smoke_run
+    assert "tests/e2e/ -v --tb=short" in full_run
+
+    full_condition = str(full.get("if", ""))
+    assert "github.event_name == 'workflow_dispatch'" in full_condition
+    assert "needs.preflight.outputs.full_e2e == 'true'" in full_condition
+
+    assert _as_sequence(gate.get("needs")) == [
+        "preflight",
+        "lint",
+        "test",
+        "e2e_smoke",
+        "e2e_full",
+        "review",
+    ]
+    gate_run = _job_run_text(gate)
+    assert "E2E_SMOKE" in gate_run
+    assert "E2E_FULL" in gate_run
+    assert "e2e-smoke($E2E_SMOKE)" in gate_run
+    assert "e2e-full($E2E_FULL)" in gate_run
 
 
 def test_pull_request_target_workflows_do_not_checkout_or_execute_pr_head() -> None:


### PR DESCRIPTION
## Summary
- add a blocking PR E2E smoke lane that runs only the lightweight supply-chain smoke test
- make full scanner E2E conditional on runtime-sensitive path changes, the e2e-needed label, or manual workflow_dispatch
- add deterministic workflow policy coverage for the split, label trigger, path trigger, and gate wiring

## Validation
- EEDOM_ALLOW_HOST_TESTS=1 EEDOM_E2E=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/test_github_actions_policy.py tests/e2e/test_smoke_review.py -v --tb=short
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/unit/test_github_actions_policy.py tests/e2e/test_smoke_review.py
- UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/unit/test_github_actions_policy.py tests/e2e/test_smoke_review.py
- git diff --check