### PR TITLE
Route contract changes through fast CI

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -20,9 +20,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
-  statuses: write
 
 env:
   UV_CACHE_DIR: /tmp/uv-cache
@@ -46,6 +43,8 @@ jobs:
     timeout-minutes: 2
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      api_contract: ${{ steps.classify.outputs.api_contract }}
+      api_contract_reason: ${{ steps.classify.outputs.api_contract_reason }}
       full_e2e: ${{ steps.classify.outputs.full_e2e }}
       full_e2e_reason: ${{ steps.classify.outputs.full_e2e_reason }}
     steps:
@@ -67,12 +66,12 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           fi
 
-          FULL_E2E_CHANGES=""
+          API_CONTRACT_CHANGES=""
           while IFS= read -r changed_path; do
             case "$changed_path" in
-              tests/e2e/*|\
-              src/eedom/plugins/*|\
-              src/eedom/data/scanners/*|\
+              tests/contract/*|\
+              src/eedom/cli/main.py|\
+              src/eedom/core/actionability.py|\
               src/eedom/core/bootstrap.py|\
               src/eedom/core/config.py|\
               src/eedom/core/diff.py|\
@@ -81,14 +80,43 @@ jobs:
               src/eedom/core/manifest_discovery.py|\
               src/eedom/core/orchestrator.py|\
               src/eedom/core/pipeline.py|\
+              src/eedom/core/pipeline_helpers.py|\
+              src/eedom/core/plugin.py|\
               src/eedom/core/registry.py|\
               src/eedom/core/renderer.py|\
               src/eedom/core/repo_config.py|\
               src/eedom/core/sarif.py|\
+              src/eedom/core/use_cases.py|\
+              src/eedom/plugins/blast_radius.py|\
+              src/eedom/plugins/supply_chain.py)
+                API_CONTRACT_CHANGES="${API_CONTRACT_CHANGES}${changed_path}"$'\n'
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          FULL_E2E_CHANGES=""
+          while IFS= read -r changed_path; do
+            case "$changed_path" in
+              tests/e2e/*|\
+              src/eedom/data/scanners/*|\
               src/eedom/core/subprocess_runner.py|\
               src/eedom/core/tool_runner.py|\
-              src/eedom/core/use_cases.py|\
-              src/eedom/cli/main.py|\
+              src/eedom/plugins/_runners/*|\
+              src/eedom/plugins/cdk_nag.py|\
+              src/eedom/plugins/cfn_nag.py|\
+              src/eedom/plugins/clamav.py|\
+              src/eedom/plugins/complexity.py|\
+              src/eedom/plugins/cpd.py|\
+              src/eedom/plugins/cspell.py|\
+              src/eedom/plugins/gitleaks.py|\
+              src/eedom/plugins/kube_linter.py|\
+              src/eedom/plugins/ls_lint.py|\
+              src/eedom/plugins/mypy.py|\
+              src/eedom/plugins/osv_scanner.py|\
+              src/eedom/plugins/scancode.py|\
+              src/eedom/plugins/semgrep.py|\
+              src/eedom/plugins/syft.py|\
+              src/eedom/plugins/trivy.py|\
               policies/*|\
               Dockerfile|\
               Dockerfile.test|\
@@ -100,6 +128,25 @@ jobs:
                 ;;
             esac
           done <<< "$CHANGED_FILES"
+          if [ -n "$API_CONTRACT_CHANGES" ]; then
+            echo "api_contract=true" >> "$GITHUB_OUTPUT"
+            echo "api_contract_reason=contract_path" >> "$GITHUB_OUTPUT"
+            echo "::notice::API contract tests required by contract path changes"
+            {
+              echo "### API contract tests required"
+              echo ""
+              echo "Contract-sensitive paths changed:"
+              printf '%s\n' "$API_CONTRACT_CHANGES" | sed 's/^/- `/' | sed 's/$/`/'
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$API_CONTRACT_LABEL_PRESENT" = "true" ]; then
+            echo "api_contract=true" >> "$GITHUB_OUTPUT"
+            echo "api_contract_reason=api-contract-needed_label" >> "$GITHUB_OUTPUT"
+            echo "::notice::API contract tests required by api-contract-needed label"
+          else
+            echo "api_contract=false" >> "$GITHUB_OUTPUT"
+            echo "api_contract_reason=not_required" >> "$GITHUB_OUTPUT"
+          fi
+
           if [ -n "$FULL_E2E_CHANGES" ]; then
             echo "full_e2e=true" >> "$GITHUB_OUTPUT"
             echo "full_e2e_reason=runtime_path" >> "$GITHUB_OUTPUT"
@@ -121,6 +168,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          API_CONTRACT_LABEL_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'api-contract-needed') }}
           E2E_LABEL_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-needed') }}
 
   # ── Push to main: stamp release key only (PR already validated) ──
@@ -131,6 +179,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -212,6 +263,44 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest tests/unit/ -v --tb=short
+        env:
+          EEDOM_ALLOW_HOST_TESTS: "1"
+
+  api_contract:
+    name: API Contract Tests
+    needs: preflight
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.preflight.outputs.docs_only != 'true' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          needs.preflight.outputs.api_contract == 'true'
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Cache uv packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /tmp/uv-cache
+          key: uv-api-contract-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-api-contract-
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run API contract tests
+        run: uv run pytest tests/contract/ -v --tb=short
         env:
           EEDOM_ALLOW_HOST_TESTS: "1"
 
@@ -424,7 +513,7 @@ jobs:
 
   gate:
     name: Gate
-    needs: [preflight, lint, test, e2e_smoke, e2e_full, review]
+    needs: [preflight, lint, test, api_contract, e2e_smoke, e2e_full, review]
     if: >-
       always() &&
       !cancelled() &&
@@ -434,6 +523,11 @@ jobs:
       needs.preflight.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -444,6 +538,7 @@ jobs:
           FAILED=""
           [ "$LINT" != "success" ] && FAILED="$FAILED lint($LINT)"
           [ "$TEST" != "success" ] && FAILED="$FAILED test($TEST)"
+          [ "$API_CONTRACT" != "success" ] && [ "$API_CONTRACT" != "skipped" ] && FAILED="$FAILED api-contract($API_CONTRACT)"
           [ "$E2E_SMOKE" != "success" ] && FAILED="$FAILED e2e-smoke($E2E_SMOKE)"
           [ "$E2E_FULL" != "success" ] && [ "$E2E_FULL" != "failure" ] && [ "$E2E_FULL" != "skipped" ] && FAILED="$FAILED e2e-full($E2E_FULL)"
           [ "$E2E_FULL" = "failure" ] && echo "::warning::Full e2e tests failed — not blocking gate (scanner binary compat issues on GH runners)"
@@ -458,6 +553,7 @@ jobs:
         env:
           LINT: ${{ needs.lint.result }}
           TEST: ${{ needs.test.result }}
+          API_CONTRACT: ${{ needs.api_contract.result }}
           E2E_SMOKE: ${{ needs.e2e_smoke.result }}
           E2E_FULL: ${{ needs.e2e_full.result }}
           REVIEW: ${{ needs.review.result }}
@@ -545,6 +641,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Lint:** ${{ needs.lint.result }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tests:** ${{ needs.test.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **API contract:** ${{ needs.api_contract.result }} (${{ needs.preflight.outputs.api_contract_reason }})" >> "$GITHUB_STEP_SUMMARY"
           echo "- **E2E smoke:** ${{ needs.e2e_smoke.result }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **E2E full:** ${{ needs.e2e_full.result }} (${{ needs.preflight.outputs.full_e2e_reason }})" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Review errors (critical/high):** $ERRORS" >> "$GITHUB_STEP_SUMMARY"
@@ -689,7 +786,7 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.upstream.outputs.upstream_ok }}" != "true" ]; then
-            echo "::error::GATEKEEPER fail-closed — upstream job(s) failed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, e2e_smoke=${{ needs.e2e_smoke.result }}, e2e_full=${{ needs.e2e_full.result }}, review=${{ needs.review.result }})"
+            echo "::error::GATEKEEPER fail-closed — upstream job(s) failed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, api_contract=${{ needs.api_contract.result }}, e2e_smoke=${{ needs.e2e_smoke.result }}, e2e_full=${{ needs.e2e_full.result }}, review=${{ needs.review.result }})"
             exit 1
           fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,6 @@ line-length = 100
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "contract: pure API contract tests that run without scanner binaries, network, or containers",
+]

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Pure API contract tests."""

--- a/tests/contract/test_review_api_contracts.py
+++ b/tests/contract/test_review_api_contracts.py
@@ -1,0 +1,111 @@
+# tested-by: self (contract)
+"""Pure review API contracts that must not need scanner binaries or E2E fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
+from eedom.core.registry import PluginRegistry
+from eedom.core.use_cases import ReviewOptions, review_repository
+
+pytestmark = pytest.mark.contract
+
+
+class RecordingPlugin(ScannerPlugin):
+    def __init__(self, name: str, category: PluginCategory) -> None:
+        self._name = name
+        self._category = category
+        self.received_files: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"{self._name} contract test plugin"
+
+    @property
+    def category(self) -> PluginCategory:
+        return self._category
+
+    def can_run(self, files: list[str], repo_path: Path) -> bool:
+        return True
+
+    def run(self, files: list[str], repo_path: Path) -> PluginResult:
+        self.received_files = list(files)
+        return PluginResult(plugin_name=self.name, findings=[])
+
+
+class FakeAnalyzerRegistry:
+    def __init__(self, results: list[PluginResult]) -> None:
+        self.results = results
+        self.calls: list[dict[str, object]] = []
+
+    def run_all(self, files: list[str], repo_path: Path, **kwargs: object) -> list[PluginResult]:
+        self.calls.append({"files": files, "repo_path": repo_path, **kwargs})
+        return self.results
+
+
+def test_registry_diff_scope_keeps_repo_wide_plugins_on_repo_files(tmp_path: Path) -> None:
+    changed_files = ["src/eedom/core/use_cases.py"]
+    repo_files = ["pyproject.toml", "src/eedom/core/use_cases.py", "Dockerfile"]
+    quality_plugin = RecordingPlugin("quality-contract", PluginCategory.quality)
+    dependency_plugin = RecordingPlugin("dependency-contract", PluginCategory.dependency)
+
+    registry = PluginRegistry()
+    registry.register(quality_plugin)
+    registry.register(dependency_plugin)
+
+    registry.run_all(changed_files, tmp_path, repo_files=repo_files)
+
+    assert quality_plugin.received_files == changed_files
+    assert dependency_plugin.received_files == repo_files
+
+
+def test_review_repository_forwards_filter_contract_and_derives_blocked_verdict(
+    tmp_path: Path,
+) -> None:
+    result = PluginResult(
+        plugin_name="dependency-contract",
+        category="dependency",
+        findings=[
+            {
+                "id": "CVE-contract",
+                "severity": "high",
+                "message": "contract finding",
+            }
+        ],
+    )
+    registry = FakeAnalyzerRegistry([result])
+    context = SimpleNamespace(analyzer_registry=registry)
+    options = ReviewOptions(
+        scanners=["dependency-contract"],
+        disabled={"slow-scanner"},
+        enabled={"dependency-contract"},
+    )
+
+    review_result = review_repository(
+        context,  # type: ignore[arg-type]
+        ["src/eedom/core/use_cases.py"],
+        tmp_path,
+        options,
+        repo_files=["pyproject.toml"],
+    )
+
+    assert review_result.verdict == "blocked"
+    assert registry.calls == [
+        {
+            "files": ["src/eedom/core/use_cases.py"],
+            "repo_path": tmp_path,
+            "names": ["dependency-contract"],
+            "categories": None,
+            "disabled_names": {"slow-scanner"},
+            "enabled_names": {"dependency-contract"},
+            "repo_files": ["pyproject.toml"],
+        }
+    ]

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -207,6 +207,7 @@ def test_pull_request_ci_skips_draft_prs_and_runs_when_ready_for_review() -> Non
 
 def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
     workflow = _load_yaml(_WORKFLOWS / "gatekeeper.yml")
+    assert workflow.get("permissions") == {"contents": "read"}
     on_block = _github_on(workflow)
     assert isinstance(on_block, dict)
     pull_request = _as_mapping(on_block.get("pull_request"))
@@ -217,6 +218,8 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
 
     jobs = _as_mapping(workflow.get("jobs"))
     preflight = _as_mapping(jobs.get("preflight"))
+    release_key = _as_mapping(jobs.get("release-key"))
+    contract = _as_mapping(jobs.get("api_contract"))
     smoke = _as_mapping(jobs.get("e2e_smoke"))
     full = _as_mapping(jobs.get("e2e_full"))
     gate = _as_mapping(jobs.get("gate"))
@@ -224,41 +227,76 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
         step for step in _job_steps(preflight) if step.get("name") == "Classify PR changes"
     )
 
+    assert release_key.get("permissions") == {"contents": "read", "statuses": "write"}
+    assert gate.get("permissions") == {
+        "contents": "read",
+        "issues": "write",
+        "pull-requests": "write",
+        "statuses": "write",
+    }
+
     outputs = _as_mapping(preflight.get("outputs"))
+    assert outputs.get("api_contract") == "${{ steps.classify.outputs.api_contract }}"
+    assert outputs.get("api_contract_reason") == "${{ steps.classify.outputs.api_contract_reason }}"
     assert outputs.get("full_e2e") == "${{ steps.classify.outputs.full_e2e }}"
     assert outputs.get("full_e2e_reason") == "${{ steps.classify.outputs.full_e2e_reason }}"
     classify_env = _as_mapping(classify_step.get("env"))
+    assert (
+        classify_env.get("API_CONTRACT_LABEL_PRESENT")
+        == "${{ contains(github.event.pull_request.labels.*.name, 'api-contract-needed') }}"
+    )
     assert (
         classify_env.get("E2E_LABEL_PRESENT")
         == "${{ contains(github.event.pull_request.labels.*.name, 'e2e-needed') }}"
     )
 
     preflight_run = _job_run_text(preflight)
-    for required_path in (
+    for contract_path in (
+        "tests/contract/",
+        "src/eedom/core/use_cases.py",
+        "src/eedom/core/registry.py",
+        "src/eedom/core/renderer.py",
+        "src/eedom/plugins/supply_chain.py",
+    ):
+        assert contract_path in preflight_run
+
+    for full_e2e_path in (
         "tests/e2e/",
-        "src/eedom/plugins/",
         "src/eedom/data/scanners/",
+        "src/eedom/plugins/_runners/",
+        "src/eedom/plugins/cspell.py",
         ".github/workflows/gatekeeper.yml",
         "uv.lock",
     ):
-        assert required_path in preflight_run
+        assert full_e2e_path in preflight_run
+    assert "src/eedom/plugins/*" not in preflight_run
 
+    contract_step_names = {
+        step.get("name") for step in _job_steps(contract) if isinstance(step.get("name"), str)
+    }
     smoke_step_names = {
         step.get("name") for step in _job_steps(smoke) if isinstance(step.get("name"), str)
     }
     full_step_names = {
         step.get("name") for step in _job_steps(full) if isinstance(step.get("name"), str)
     }
+    assert "Run API contract tests" in contract_step_names
     assert "Run smoke e2e tests" in smoke_step_names
     assert "Cache scanner binaries" not in smoke_step_names
     assert "Add scanners to PATH and warm trivy DB" not in smoke_step_names
     assert "Cache scanner binaries" in full_step_names
     assert "Add scanners to PATH and warm trivy DB" in full_step_names
 
+    contract_run = _job_run_text(contract)
     smoke_run = _job_run_text(smoke)
     full_run = _job_run_text(full)
+    assert "tests/contract/ -v --tb=short" in contract_run
     assert "tests/e2e/test_smoke_review.py" in smoke_run
     assert "tests/e2e/ -v --tb=short" in full_run
+
+    contract_condition = str(contract.get("if", ""))
+    assert "github.event_name == 'workflow_dispatch'" in contract_condition
+    assert "needs.preflight.outputs.api_contract == 'true'" in contract_condition
 
     full_condition = str(full.get("if", ""))
     assert "github.event_name == 'workflow_dispatch'" in full_condition
@@ -268,13 +306,16 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
         "preflight",
         "lint",
         "test",
+        "api_contract",
         "e2e_smoke",
         "e2e_full",
         "review",
     ]
     gate_run = _job_run_text(gate)
+    assert "API_CONTRACT" in gate_run
     assert "E2E_SMOKE" in gate_run
     assert "E2E_FULL" in gate_run
+    assert "api-contract($API_CONTRACT)" in gate_run
     assert "e2e-smoke($E2E_SMOKE)" in gate_run
     assert "e2e-full($E2E_FULL)" in gate_run
 

--- a/uv.lock
+++ b/uv.lock
@@ -116,7 +116,7 @@ wheels = [
 
 [[package]]
 name = "eedom"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add pure API contract tests for review filtering and repo-wide scanner routing
- add an API Contract Tests workflow lane and label/path classifier
- narrow Full E2E triggers to runtime/scanner-sensitive paths while keeping smoke E2E on normal PRs
- reduce default workflow token permissions to read-only and grant writes only to release/gate jobs

## Validation
- UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/contract/ tests/unit/test_github_actions_policy.py -v --tb=short
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/contract tests/unit/test_github_actions_policy.py
- UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/contract tests/unit/test_github_actions_policy.py
- git diff --check
- UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/unit/ tests/contract/ -v --tb=short