### PR TITLE
Move full E2E to release candidates

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -45,8 +45,6 @@ jobs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
       api_contract: ${{ steps.classify.outputs.api_contract }}
       api_contract_reason: ${{ steps.classify.outputs.api_contract_reason }}
-      full_e2e: ${{ steps.classify.outputs.full_e2e }}
-      full_e2e_reason: ${{ steps.classify.outputs.full_e2e_reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -94,40 +92,6 @@ jobs:
             esac
           done <<< "$CHANGED_FILES"
 
-          FULL_E2E_CHANGES=""
-          while IFS= read -r changed_path; do
-            case "$changed_path" in
-              tests/e2e/*|\
-              src/eedom/data/scanners/*|\
-              src/eedom/core/subprocess_runner.py|\
-              src/eedom/core/tool_runner.py|\
-              src/eedom/plugins/_runners/*|\
-              src/eedom/plugins/cdk_nag.py|\
-              src/eedom/plugins/cfn_nag.py|\
-              src/eedom/plugins/clamav.py|\
-              src/eedom/plugins/complexity.py|\
-              src/eedom/plugins/cpd.py|\
-              src/eedom/plugins/cspell.py|\
-              src/eedom/plugins/gitleaks.py|\
-              src/eedom/plugins/kube_linter.py|\
-              src/eedom/plugins/ls_lint.py|\
-              src/eedom/plugins/mypy.py|\
-              src/eedom/plugins/osv_scanner.py|\
-              src/eedom/plugins/scancode.py|\
-              src/eedom/plugins/semgrep.py|\
-              src/eedom/plugins/syft.py|\
-              src/eedom/plugins/trivy.py|\
-              policies/*|\
-              Dockerfile|\
-              Dockerfile.test|\
-              Makefile|\
-              pyproject.toml|\
-              uv.lock|\
-              .github/workflows/gatekeeper.yml)
-                FULL_E2E_CHANGES="${FULL_E2E_CHANGES}${changed_path}"$'\n'
-                ;;
-            esac
-          done <<< "$CHANGED_FILES"
           if [ -n "$API_CONTRACT_CHANGES" ]; then
             echo "api_contract=true" >> "$GITHUB_OUTPUT"
             echo "api_contract_reason=contract_path" >> "$GITHUB_OUTPUT"
@@ -146,30 +110,10 @@ jobs:
             echo "api_contract=false" >> "$GITHUB_OUTPUT"
             echo "api_contract_reason=not_required" >> "$GITHUB_OUTPUT"
           fi
-
-          if [ -n "$FULL_E2E_CHANGES" ]; then
-            echo "full_e2e=true" >> "$GITHUB_OUTPUT"
-            echo "full_e2e_reason=runtime_path" >> "$GITHUB_OUTPUT"
-            echo "::notice::Full e2e required by runtime path changes"
-            {
-              echo "### Full e2e required"
-              echo ""
-              echo "Runtime-sensitive paths changed:"
-              printf '%s\n' "$FULL_E2E_CHANGES" | sed 's/^/- `/' | sed 's/$/`/'
-            } >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$E2E_LABEL_PRESENT" = "true" ]; then
-            echo "full_e2e=true" >> "$GITHUB_OUTPUT"
-            echo "full_e2e_reason=e2e-needed_label" >> "$GITHUB_OUTPUT"
-            echo "::notice::Full e2e required by e2e-needed label"
-          else
-            echo "full_e2e=false" >> "$GITHUB_OUTPUT"
-            echo "full_e2e_reason=not_required" >> "$GITHUB_OUTPUT"
-          fi
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           API_CONTRACT_LABEL_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'api-contract-needed') }}
-          E2E_LABEL_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-needed') }}
 
   # ── Push to main: stamp release key only (PR already validated) ──
 
@@ -339,17 +283,7 @@ jobs:
   e2e_full:
     name: E2E Full
     needs: preflight
-    if: >-
-      github.event_name != 'push' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      needs.preflight.outputs.docs_only != 'true' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event_name == 'pull_request' &&
-          needs.preflight.outputs.full_e2e == 'true'
-        )
-      )
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -540,8 +474,7 @@ jobs:
           [ "$TEST" != "success" ] && FAILED="$FAILED test($TEST)"
           [ "$API_CONTRACT" != "success" ] && [ "$API_CONTRACT" != "skipped" ] && FAILED="$FAILED api-contract($API_CONTRACT)"
           [ "$E2E_SMOKE" != "success" ] && FAILED="$FAILED e2e-smoke($E2E_SMOKE)"
-          [ "$E2E_FULL" != "success" ] && [ "$E2E_FULL" != "failure" ] && [ "$E2E_FULL" != "skipped" ] && FAILED="$FAILED e2e-full($E2E_FULL)"
-          [ "$E2E_FULL" = "failure" ] && echo "::warning::Full e2e tests failed — not blocking gate (scanner binary compat issues on GH runners)"
+          [ "$E2E_FULL" != "success" ] && [ "$E2E_FULL" != "skipped" ] && FAILED="$FAILED e2e-full($E2E_FULL)"
           [ "$REVIEW" != "success" ] && FAILED="$FAILED review($REVIEW)"
 
           if [ -n "$FAILED" ]; then
@@ -643,7 +576,7 @@ jobs:
           echo "- **Tests:** ${{ needs.test.result }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **API contract:** ${{ needs.api_contract.result }} (${{ needs.preflight.outputs.api_contract_reason }})" >> "$GITHUB_STEP_SUMMARY"
           echo "- **E2E smoke:** ${{ needs.e2e_smoke.result }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **E2E full:** ${{ needs.e2e_full.result }} (${{ needs.preflight.outputs.full_e2e_reason }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **E2E full:** ${{ needs.e2e_full.result }} (release/manual only)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Review errors (critical/high):** $ERRORS" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Review warnings (medium):** $WARNINGS" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Skipped plugins (not installed):** $SKIPPED" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,299 @@
+name: Daily Release Candidate
+
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: "Base SemVer for the release candidate, for example 0.2.30. Defaults to next patch from pyproject.toml."
+        required: false
+        type: string
+      candidate_number:
+        description: "Candidate ordinal for today's RC. Defaults to next available number."
+        required: false
+        type: string
+      dry_run:
+        description: "Run the release gate without creating a prerelease."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: daily-release-candidate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  UV_CACHE_DIR: /tmp/uv-cache
+  SCANNER_BIN: /tmp/scanner-bin
+  TRIVY_CACHE_DIR: /tmp/trivy-cache
+  SCANNER_VERSIONS: trivy=0.70.0 osv=2.3.5 kube-linter=0.8.3 gitleaks=8.30.1 pmd=7.9.0 opengrep=1.20.0 syft=1.43.0 scancode=32.3.0
+
+jobs:
+  release_candidate:
+    name: Release Candidate Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      tag_name: ${{ steps.metadata.outputs.tag_name }}
+      base_version: ${{ steps.metadata.outputs.base_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare candidate metadata
+        id: metadata
+        run: |
+          python3 << 'PY'
+          import datetime as dt
+          import os
+          import re
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          version_re = re.compile(r"^\d+\.\d+\.\d+$")
+          ordinal_re = re.compile(r"^[1-9]\d*$")
+
+          raw_base_version = os.environ.get("INPUT_BASE_VERSION", "").strip()
+          if raw_base_version:
+              if not version_re.fullmatch(raw_base_version):
+                  raise SystemExit(f"base_version must be MAJOR.MINOR.PATCH, got {raw_base_version!r}")
+              base_version = raw_base_version
+          else:
+              pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+              current = pyproject["project"]["version"]
+              major, minor, patch = (int(part) for part in current.split("."))
+              base_version = f"{major}.{minor}.{patch + 1}"
+
+          run_date = dt.datetime.now(dt.UTC).strftime("%Y%m%d")
+          raw_candidate = os.environ.get("INPUT_CANDIDATE_NUMBER", "").strip()
+          if raw_candidate:
+              if not ordinal_re.fullmatch(raw_candidate):
+                  raise SystemExit(f"candidate_number must be a positive integer, got {raw_candidate!r}")
+              candidate_number = int(raw_candidate)
+          else:
+              prefix = f"v{base_version}-rc.{run_date}."
+              existing = subprocess.run(
+                  ["git", "tag", "--list", f"{prefix}*"],
+                  check=True,
+                  text=True,
+                  capture_output=True,
+              ).stdout.splitlines()
+              used_numbers = []
+              for tag in existing:
+                  suffix = tag.removeprefix(prefix)
+                  if suffix.isdigit():
+                      used_numbers.append(int(suffix))
+              candidate_number = max(used_numbers, default=0) + 1
+
+          tag_name = f"v{base_version}-rc.{run_date}.{candidate_number}"
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"tag_name={tag_name}\n")
+              out.write(f"base_version={base_version}\n")
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env:
+              env.write(f"TAG_NAME={tag_name}\n")
+              env.write(f"BASE_VERSION={base_version}\n")
+              env.write(f"RUN_DATE={run_date}\n")
+              env.write(f"CANDIDATE_NUMBER={candidate_number}\n")
+          PY
+        env:
+          INPUT_BASE_VERSION: ${{ inputs.base_version }}
+          INPUT_CANDIDATE_NUMBER: ${{ inputs.candidate_number }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+
+      - name: Cache uv packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /tmp/uv-cache
+          key: uv-release-candidate-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-release-candidate-
+
+      - name: Cache scanner binaries
+        id: scanner-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /tmp/scanner-bin
+          key: scanners-${{ env.SCANNER_VERSIONS }}
+
+      - name: Cache trivy DB
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /tmp/trivy-cache
+          key: trivy-db-${{ github.run_id }}
+          restore-keys: trivy-db-
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev
+          uv pip install lizard mypy scancode-toolkit==32.3.0 || true
+          npm install -g cspell --no-fund --no-audit || true
+
+      - name: Install scanner binaries
+        if: steps.scanner-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$SCANNER_BIN"
+          curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-64bit.tar.gz" | tar xz -C "$SCANNER_BIN" trivy || true
+          curl -sSfL -o "$SCANNER_BIN/osv-scanner" "https://github.com/google/osv-scanner/releases/download/v2.3.5/osv-scanner_linux_amd64" && chmod +x "$SCANNER_BIN/osv-scanner" || true
+          curl -sSfL -o "$SCANNER_BIN/kube-linter" "https://github.com/stackrox/kube-linter/releases/download/v0.8.3/kube-linter-linux" && chmod +x "$SCANNER_BIN/kube-linter" || true
+          curl -sSfL "https://github.com/pmd/pmd/releases/download/pmd_releases%2F7.9.0/pmd-dist-7.9.0-bin.zip" -o /tmp/pmd.zip && unzip -qo /tmp/pmd.zip -d /tmp && cp /tmp/pmd-bin-7.9.0/bin/pmd "$SCANNER_BIN/pmd" && cp -r /tmp/pmd-bin-7.9.0 "$SCANNER_BIN/pmd-bin-7.9.0" || true
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" | tar xz -C "$SCANNER_BIN" gitleaks || true
+          curl -sSfL -o "$SCANNER_BIN/opengrep" "https://github.com/opengrep/opengrep/releases/download/v1.20.0/opengrep_manylinux_x86" && chmod +x "$SCANNER_BIN/opengrep" || true
+          curl -sSfL "https://github.com/anchore/syft/releases/download/v1.43.0/syft_1.43.0_linux_amd64.tar.gz" | tar xz -C "$SCANNER_BIN" syft || true
+
+      - name: Add scanners to PATH and warm trivy DB
+        run: |
+          echo "$SCANNER_BIN" >> "$GITHUB_PATH"
+          if [ -f "$SCANNER_BIN/pmd-bin-7.9.0/bin/pmd" ]; then
+            echo "$SCANNER_BIN/pmd-bin-7.9.0/bin" >> "$GITHUB_PATH"
+          fi
+          "$SCANNER_BIN/trivy" fs --download-db-only --cache-dir "$TRIVY_CACHE_DIR" || true
+
+      - name: Run full e2e tests
+        run: uv run pytest tests/e2e/ -v --tb=short
+        env:
+          EEDOM_ALLOW_HOST_TESTS: "1"
+          EEDOM_E2E: "1"
+
+      - name: Run full Dom review
+        run: |
+          mkdir -p .temp
+          uv run eedom review --repo-path . --all --format sarif --output .temp/release-review.sarif
+          uv run eedom review --repo-path . --all --output .temp/release-review.md
+
+      - name: Enforce Dom release verdict
+        run: |
+          python3 << 'PY'
+          import json
+          import os
+          import re
+
+          errors = 0
+          crashed = 0
+          skipped = 0
+          warnings = 0
+
+          sarif_path = ".temp/release-review.sarif"
+          md_path = ".temp/release-review.md"
+
+          if os.path.isfile(sarif_path):
+              with open(sarif_path, encoding="utf-8") as f:
+                  sarif = json.load(f)
+              for run in sarif.get("runs", []):
+                  plugin_errored = False
+                  for result in run.get("results", []):
+                      if result.get("ruleId") == "eedom-plugin-error":
+                          crashed += 1
+                          plugin_errored = True
+                          break
+                  if plugin_errored:
+                      continue
+                  for result in run.get("results", []):
+                      if result.get("level") == "error":
+                          errors += 1
+                      elif result.get("level") == "warning":
+                          warnings += 1
+
+          if os.path.isfile(md_path):
+              with open(md_path, encoding="utf-8") as f:
+                  markdown = f.read()
+              if crashed == 0:
+                  crashed = len(re.findall(r"BINARY_CRASHED", markdown))
+              skipped = len(re.findall(r"NOT_INSTALLED", markdown))
+              warnings += len(re.findall(r"\[TIMEOUT\]", markdown))
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Dom release verdict\n\n")
+              summary.write(f"- **Errors:** {errors}\n")
+              summary.write(f"- **Warnings:** {warnings}\n")
+              summary.write(f"- **Skipped plugins:** {skipped}\n")
+              summary.write(f"- **Crashed plugins:** {crashed}\n")
+
+          if errors > 0 or crashed > 0:
+              raise SystemExit(
+                  f"Release candidate blocked by Dom review: {errors} errors, {crashed} crashed plugins"
+              )
+          PY
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Write release notes
+        run: |
+          mkdir -p .temp
+          PREVIOUS_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -Ev '-' | head -1 || true)
+          {
+            echo "# ${TAG_NAME}"
+            echo ""
+            echo "Daily release candidate for ${BASE_VERSION}."
+            echo ""
+            echo "## Validation"
+            echo "- Full E2E passed"
+            echo "- Full Dom review passed"
+            echo "- Distribution build passed"
+            echo ""
+            if [ -n "$PREVIOUS_TAG" ]; then
+              echo "## Collected changes since ${PREVIOUS_TAG}"
+              git log --first-parent --oneline "${PREVIOUS_TAG}..HEAD"
+            else
+              echo "## Collected changes"
+              git log --first-parent --oneline -20
+            fi
+          } > .temp/release-notes.md
+
+      - name: Upload release-candidate artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-candidate-${{ steps.metadata.outputs.tag_name }}
+          path: |
+            .temp/release-review.sarif
+            .temp/release-review.md
+            .temp/release-notes.md
+            dist/*
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Summarize candidate
+        run: |
+          echo "## Release candidate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag:** ${TAG_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Base version:** ${BASE_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Dry run:** ${DRY_RUN}" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+
+  publish_prerelease:
+    name: Publish Prerelease
+    needs: release_candidate
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Download release-candidate artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-candidate-${{ needs.release_candidate.outputs.tag_name }}
+          path: .release-candidate
+
+      - name: Create GitHub prerelease
+        run: |
+          gh release create "$TAG_NAME" \
+            --target "$GITHUB_SHA" \
+            --prerelease \
+            --title "$TAG_NAME" \
+            --notes-file .release-candidate/.temp/release-notes.md
+          gh release upload "$TAG_NAME" .release-candidate/dist/*.whl .release-candidate/dist/*.tar.gz --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.release_candidate.outputs.tag_name }}

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -198,14 +198,17 @@ def test_pull_request_ci_skips_draft_prs_and_runs_when_ready_for_review() -> Non
         for job_name, raw_job in _as_mapping(workflow.get("jobs")).items():
             job = _as_mapping(raw_job)
             condition = str(job.get("if", ""))
-            if condition.strip() == "github.event_name == 'push'":
+            if condition.strip() in {
+                "github.event_name == 'push'",
+                "github.event_name == 'workflow_dispatch'",
+            }:
                 continue
             assert (
                 "github.event.pull_request.draft == false" in condition
             ), f"{path.relative_to(_ROOT)} job {job_name} must skip draft PRs"
 
 
-def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
+def test_gatekeeper_keeps_pr_ci_fast_and_full_e2e_manual_only() -> None:
     workflow = _load_yaml(_WORKFLOWS / "gatekeeper.yml")
     assert workflow.get("permissions") == {"contents": "read"}
     on_block = _github_on(workflow)
@@ -213,8 +216,8 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
     pull_request = _as_mapping(on_block.get("pull_request"))
     pr_types = pull_request.get("types")
     assert isinstance(pr_types, list)
-    assert "labeled" in pr_types, "adding e2e-needed must trigger a new CI evaluation"
-    assert "unlabeled" in pr_types, "removing e2e-needed must trigger a new CI evaluation"
+    assert "labeled" in pr_types, "adding api-contract-needed must trigger CI evaluation"
+    assert "unlabeled" in pr_types, "removing api-contract-needed must trigger CI evaluation"
 
     jobs = _as_mapping(workflow.get("jobs"))
     preflight = _as_mapping(jobs.get("preflight"))
@@ -238,17 +241,14 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
     outputs = _as_mapping(preflight.get("outputs"))
     assert outputs.get("api_contract") == "${{ steps.classify.outputs.api_contract }}"
     assert outputs.get("api_contract_reason") == "${{ steps.classify.outputs.api_contract_reason }}"
-    assert outputs.get("full_e2e") == "${{ steps.classify.outputs.full_e2e }}"
-    assert outputs.get("full_e2e_reason") == "${{ steps.classify.outputs.full_e2e_reason }}"
+    assert "full_e2e" not in outputs
+    assert "full_e2e_reason" not in outputs
     classify_env = _as_mapping(classify_step.get("env"))
     assert (
         classify_env.get("API_CONTRACT_LABEL_PRESENT")
         == "${{ contains(github.event.pull_request.labels.*.name, 'api-contract-needed') }}"
     )
-    assert (
-        classify_env.get("E2E_LABEL_PRESENT")
-        == "${{ contains(github.event.pull_request.labels.*.name, 'e2e-needed') }}"
-    )
+    assert "E2E_LABEL_PRESENT" not in classify_env
 
     preflight_run = _job_run_text(preflight)
     for contract_path in (
@@ -260,15 +260,13 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
     ):
         assert contract_path in preflight_run
 
-    for full_e2e_path in (
+    for release_only_path in (
         "tests/e2e/",
         "src/eedom/data/scanners/",
         "src/eedom/plugins/_runners/",
         "src/eedom/plugins/cspell.py",
-        ".github/workflows/gatekeeper.yml",
-        "uv.lock",
     ):
-        assert full_e2e_path in preflight_run
+        assert release_only_path not in preflight_run
     assert "src/eedom/plugins/*" not in preflight_run
 
     contract_step_names = {
@@ -299,8 +297,7 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
     assert "needs.preflight.outputs.api_contract == 'true'" in contract_condition
 
     full_condition = str(full.get("if", ""))
-    assert "github.event_name == 'workflow_dispatch'" in full_condition
-    assert "needs.preflight.outputs.full_e2e == 'true'" in full_condition
+    assert full_condition.strip() == "github.event_name == 'workflow_dispatch'"
 
     assert _as_sequence(gate.get("needs")) == [
         "preflight",
@@ -318,6 +315,106 @@ def test_gatekeeper_splits_smoke_e2e_from_conditional_full_e2e() -> None:
     assert "api-contract($API_CONTRACT)" in gate_run
     assert "e2e-smoke($E2E_SMOKE)" in gate_run
     assert "e2e-full($E2E_FULL)" in gate_run
+    assert "release/manual only" in gate_run
+    assert "not blocking gate" not in gate_run
+
+
+def test_daily_release_candidate_runs_full_e2e_and_creates_prerelease() -> None:
+    workflow = _load_yaml(_WORKFLOWS / "release-candidate.yml")
+
+    assert workflow.get("permissions") == {"contents": "read"}
+    events = _workflow_events(workflow)
+    assert "schedule" in events
+    assert "workflow_dispatch" in events
+    assert "pull_request" not in events
+
+    on_block = _github_on(workflow)
+    assert isinstance(on_block, dict)
+    schedule = _as_sequence(on_block.get("schedule"))
+    assert schedule
+    assert any(_as_mapping(entry).get("cron") == "0 23 * * *" for entry in schedule)
+
+    dispatch = _as_mapping(on_block.get("workflow_dispatch"))
+    inputs = _as_mapping(dispatch.get("inputs"))
+    assert {"base_version", "candidate_number", "dry_run"}.issubset(inputs)
+
+    jobs = _as_mapping(workflow.get("jobs"))
+    release_candidate = _as_mapping(jobs.get("release_candidate"))
+    publish_prerelease = _as_mapping(jobs.get("publish_prerelease"))
+    assert release_candidate.get("timeout-minutes") == 25
+    outputs = _as_mapping(release_candidate.get("outputs"))
+    assert outputs.get("tag_name") == "${{ steps.metadata.outputs.tag_name }}"
+    assert outputs.get("base_version") == "${{ steps.metadata.outputs.base_version }}"
+    assert publish_prerelease.get("needs") == "release_candidate"
+    assert publish_prerelease.get("if") == "inputs.dry_run != true"
+    assert publish_prerelease.get("timeout-minutes") == 5
+    assert publish_prerelease.get("permissions") == {"contents": "write"}
+
+    release_step_names = {
+        step.get("name")
+        for step in _job_steps(release_candidate)
+        if isinstance(step.get("name"), str)
+    }
+    publish_step_names = {
+        step.get("name")
+        for step in _job_steps(publish_prerelease)
+        if isinstance(step.get("name"), str)
+    }
+    assert "Run full e2e tests" in release_step_names
+    assert "Run full Dom review" in release_step_names
+    assert "Enforce Dom release verdict" in release_step_names
+    assert "Build distributions" in release_step_names
+    assert "Upload release-candidate artifacts" in release_step_names
+    assert "Create GitHub prerelease" not in release_step_names
+    assert "Download release-candidate artifacts" in publish_step_names
+    assert "Create GitHub prerelease" in publish_step_names
+
+    release_run_text = _job_run_text(release_candidate)
+    publish_run_text = _job_run_text(publish_prerelease)
+    run_text = f"{release_run_text}\n{publish_run_text}"
+    assert "tag_name={tag_name}" in run_text
+    assert 'f"v{base_version}-rc.{run_date}.{candidate_number}"' in run_text
+    assert "uv run pytest tests/e2e/ -v --tb=short" in run_text
+    assert "uv run eedom review --repo-path . --all --format sarif" in run_text
+    assert "uv run eedom review --repo-path . --all --output" in run_text
+    assert 'result.get("ruleId") == "eedom-plugin-error"' in run_text
+    assert 're.findall(r"BINARY_CRASHED", markdown)' in run_text
+    assert "Release candidate blocked by Dom review" in run_text
+    assert "uv build" in run_text
+    assert 'gh release create "$TAG_NAME"' in run_text
+    assert "--prerelease" in run_text
+    assert (
+        'gh release upload "$TAG_NAME" .release-candidate/dist/*.whl '
+        ".release-candidate/dist/*.tar.gz --clobber"
+    ) in run_text
+
+    metadata_step = next(
+        step
+        for step in _job_steps(release_candidate)
+        if step.get("name") == "Prepare candidate metadata"
+    )
+    metadata_env = _as_mapping(metadata_step.get("env"))
+    assert metadata_env.get("INPUT_BASE_VERSION") == "${{ inputs.base_version }}"
+    assert metadata_env.get("INPUT_CANDIDATE_NUMBER") == "${{ inputs.candidate_number }}"
+
+    download_step = next(
+        step
+        for step in _job_steps(publish_prerelease)
+        if step.get("name") == "Download release-candidate artifacts"
+    )
+    download_with = _as_mapping(download_step.get("with"))
+    assert (
+        download_with.get("name")
+        == "release-candidate-${{ needs.release_candidate.outputs.tag_name }}"
+    )
+
+    create_step = next(
+        step
+        for step in _job_steps(publish_prerelease)
+        if step.get("name") == "Create GitHub prerelease"
+    )
+    create_env = _as_mapping(create_step.get("env"))
+    assert create_env.get("TAG_NAME") == "${{ needs.release_candidate.outputs.tag_name }}"
 
 
 def test_pull_request_target_workflows_do_not_checkout_or_execute_pr_head() -> None:


### PR DESCRIPTION
## Summary
- stop path-triggering full E2E from PR Gatekeeper runs; PR CI keeps smoke E2E and API contract routing
- add a daily Release Candidate workflow that runs full E2E, full Dom review, builds distributions, uploads RC artifacts, and creates a GitHub prerelease tag like v0.2.30-rc.YYYYMMDD.N
- keep the expensive RC validation job read-only and isolate contents:write to the small publish job

## Validation
- UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/unit/test_github_actions_policy.py tests/contract/ -v --tb=short
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/unit/test_github_actions_policy.py
- UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/unit/test_github_actions_policy.py
- git diff --check