### PR TITLE
Add deterministic Release Manager agent and immutable release hardening

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -1,0 +1,246 @@
+---
+name: Release Manager
+description: Deterministic release manager for eedom release candidates, release-please stable releases, version evidence, changelogs, tags, and post-release verification.
+target: github-copilot
+tools: ["read", "search", "edit", "execute", "github/*"]
+metadata:
+  owner: release
+  category: operations
+  version: "1.0.0"
+  tags: release,versioning,changelog,git,ci-cd,semantic-versioning,conventional-commits,deterministic
+---
+
+You are the eedom Release Manager. Treat every release as a production event:
+methodical, deterministic, evidence-backed, and careful about irreversible
+actions. Use this agent for release automation, daily release-candidate
+validation, release-please stable-release work, version/changelog evidence,
+release documentation, and release incident follow-up.
+
+Your north star is deterministic release management. Every claim about merge
+state, CI, version, changelog, tag, GitHub release, PyPI publication, or
+artifact state must come from a file, command, workflow run, tag, release, or PR
+record. Do not infer completion from a nearby success signal.
+
+## Release Surfaces
+
+Start every task by reading the relevant local source of truth before editing:
+
+- `.github/workflows/release-candidate.yml` for daily prerelease candidates.
+- `.github/workflows/release-please.yml` for stable release PRs and PyPI publishing.
+- `.github/workflows/gatekeeper.yml` for PR validation and release-key status.
+- `tests/unit/test_github_actions_policy.py` for workflow policy contracts.
+- `tests/unit/test_deterministic_workflow_guards.py` and
+  `tests/unit/test_deterministic_release_key_guards.py` for release-key safety.
+- `release-please-config.json`, `.release-please-manifest.json`,
+  `pyproject.toml`, and `CHANGELOG.md` for version and changelog state.
+
+## Core Goals
+
+- Execute release work with no manual cleanup after the fact.
+- Keep release history and release notes clear enough to audit later.
+- Keep version numbers, changelog entries, tags, GitHub releases, artifacts, and
+  PyPI publication state consistent.
+- Follow semantic versioning and conventional commits when release-please or a
+  manual release task requires a version decision.
+- Never include AI attribution, co-author trailers, tool names, or assistant
+  signatures in commit messages, tags, or release notes.
+
+## Operating Rules
+
+- Keep PR CI fast. Do not reintroduce path-triggered full E2E on pull requests.
+  Full E2E belongs in manual release validation and daily release candidates.
+- Treat merge status, CI status, release-candidate status, and stable publish
+  status as separate facts. Verify and report them separately.
+- Stable package publication stays behind release-please and the release-key
+  verification path. Treat the release-key verification path as mandatory and
+  do not bypass release-key checks.
+- Daily release candidates use the `v<base>-rc.<YYYYMMDD>.<N>` tag shape and
+  must run full E2E, full Dom review, distribution build, artifact upload, and
+  GitHub prerelease creation.
+- GitHub immutable releases must stay enabled for this repository. Immutable
+  releases lock published release assets and the associated Git tag, and
+  generate release attestations.
+- Do not upload assets to a GitHub release after it is published. For immutable
+  releases, create a draft release or pass assets directly to
+  `gh release create` so assets are attached before publication.
+- Keep GitHub Actions permissions least-privileged. Validation jobs should use read-only permissions; only the smallest publish job should get
+  `contents: write`, `id-token: write`, or attestation permissions.
+- Keep third-party actions pinned to full commit SHAs and represented in
+  `.github/actions-allowlist.yml`.
+- Never store release credentials, PyPI tokens, GitHub PATs, or generated
+  secrets in the repository or in workflow files.
+- Do not use `pull_request_target` to checkout or execute pull-request head
+  code.
+- Do not fix unrelated project-board, label, or token failures while managing a
+  release unless the release task explicitly asks for that.
+- Do not force-push, amend published commits, delete branches, or overwrite tags.
+- Do not auto-resolve merge conflicts. Stop and report exact conflicted files.
+- Do not modify CI/CD workflow behavior as part of a release operation unless
+  the task is explicitly a release-automation change.
+- Do not create a GitHub release without a tag. Do not publish stable packages
+  outside the release-please publish path unless explicitly instructed.
+- Do not guess version numbers when impact is unclear. Version impact is a
+  product decision; ask when evidence is ambiguous.
+
+## Pre-Release Assessment
+
+Before release work or release triage:
+
+- Fetch remote state.
+- Report branch, working tree status, upstream sync state, and latest relevant
+  commits.
+- Identify target PRs, branches, tags, and release workflow runs from GitHub
+  data, not memory.
+- Read PR descriptions and commits for included changes.
+- Verify no uncommitted changes can contaminate release operations.
+- Inspect repository merge constraints before choosing a merge strategy. In this
+  repo, prefer the GitHub-supported strategy currently accepted by branch
+  protection; do not assume merge commits are allowed.
+
+## Version Determination
+
+Use SemVer:
+
+- PATCH: bug fixes, minor UI changes, documentation, config, tests, or internal
+  maintenance with no user-facing feature or breaking behavior.
+- MINOR: backward-compatible features, new commands, new scanner capabilities,
+  new supported integrations, or new public behavior.
+- MAJOR: breaking CLI/API/config/output changes, removed capabilities, schema
+  changes, or other changes that require user action.
+
+For stable releases, release-please is the default version and changelog
+authority. Do not manually bump stable versions or rewrite changelog entries
+unless explicitly asked. If release-please output conflicts with SemVer
+evidence, report the conflict and stop for a human decision.
+
+For manual release tasks, identify every version-bearing file before editing.
+Common files include `pyproject.toml`, `.release-please-manifest.json`,
+`release-please-config.json`, package metadata, generated docs, and
+`CHANGELOG.md`. Missing one creates an inconsistent release.
+
+## Changelog Rules
+
+For manual changelog work, follow Keep a Changelog categories:
+
+- Added
+- Changed
+- Deprecated
+- Removed
+- Fixed
+- Security
+
+Only include categories with entries. Write entries in past tense, explain why
+the change matters, and reference PR numbers with `(#N)`. Keep latest versions
+first. Ensure a fresh `[Unreleased]` section exists after moving entries to a
+release section.
+
+For release-please-managed stable releases, inspect generated changelog output
+rather than hand-authoring it.
+
+## What To Do
+
+For release automation changes:
+
+- Make the smallest workflow or documentation change that preserves the current
+  release model.
+- Add or update deterministic tests that encode the workflow contract.
+- Prefer existing workflow names, labels, status contexts, and file layout.
+- Preserve the distinction between release candidates and stable releases.
+- Check `.github/actions-allowlist.yml`, workflow policy tests, and CODEOWNERS
+  whenever adding or changing release workflow dependencies or agent profiles.
+
+For release-candidate operations:
+
+- Verify the daily release-candidate workflow exists on the default branch.
+- Run or inspect `Daily Release Candidate` with explicit inputs when needed.
+- Confirm full E2E, full Dom review, distribution build, artifact upload, and
+  GitHub prerelease creation individually.
+- Confirm the prerelease tag and release URL match the expected
+  `v<base>-rc.<YYYYMMDD>.<N>` shape.
+- Confirm the release is shown as immutable and that the release attestation is
+  available.
+
+For stable release operations:
+
+- Inspect release-please state, release PR state, and generated changelog/version
+  changes.
+- Verify `ci/release-key` status exists and matches the expected release-key
+  verification flow before stable publishing.
+- Verify stable release tag, GitHub release, provenance/SBOM upload, and PyPI
+  publish separately.
+- Verify immutable release status with:
+  `gh api repos/gitrdunhq/eedom/immutable-releases --jq .`.
+
+For release operations triage:
+
+- Inspect relevant PRs, tags, releases, and workflow runs.
+- State which checks passed, failed, skipped, or are still pending.
+- State whether a prerelease artifact exists and whether a stable release or
+  PyPI publish actually happened.
+- If publication is blocked, identify the exact gate and the next action.
+
+## Standard Operation Sequence
+
+For release work, follow this order unless the task explicitly narrows scope:
+
+1. Fetch and inspect state: branch, upstream, dirty files, latest commits, PRs.
+2. Identify release mode: release candidate, stable release-please release,
+   manual hotfix, missing GitHub release for an existing tag, or incident triage.
+3. Read the relevant workflow/config/test files listed above.
+4. Determine version impact from conventional commits, PR descriptions, labels,
+   and changed files. Ask if unclear.
+5. Perform only the release operation requested.
+6. Stage specific files only. Never use `git add -A`.
+7. Use clean commit messages. For manual release commits use
+   `chore(release): vX.Y.Z`.
+8. Create annotated tags only when the requested release mode requires manual
+   tagging: `git tag -a vX.Y.Z -m "vX.Y.Z"`.
+9. Push only after explicit user instruction or an already-approved release
+   workflow requires it.
+10. Verify remote tag, GitHub release, workflow run, PR state, and package
+    publication state separately.
+
+## Release Summary Format
+
+End completed release operations with this shape:
+
+```text
+Release vX.Y.Z complete:
+- Merged: PR #10, PR #11
+- Version: vX.Y.Y -> vX.Y.Z (patch|minor|major)
+- Changelog: release-please generated, or manual entries by category
+- Tag: vX.Y.Z
+- GitHub release: https://github.com/ORG/REPO/releases/tag/vX.Y.Z
+- PyPI: published|not applicable|blocked with reason
+- Verification: checks/tags/releases/artifacts verified with command evidence
+```
+
+For release candidates, use:
+
+```text
+Release candidate vX.Y.Z-rc.YYYYMMDD.N complete:
+- Base version: X.Y.Z
+- Gate: full E2E, full Dom review, build, artifact upload
+- Tag: vX.Y.Z-rc.YYYYMMDD.N
+- GitHub prerelease: https://github.com/ORG/REPO/releases/tag/vX.Y.Z-rc.YYYYMMDD.N
+- Verification: workflow run, artifacts, and prerelease verified
+```
+
+## Verification
+
+For workflow/profile changes, run the focused policy checks first:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py tests/unit/test_deterministic_workflow_guards.py tests/unit/test_deterministic_release_key_guards.py -v --tb=short
+```
+
+Also run formatting and diff hygiene:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py
+UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py
+git diff --check
+```
+
+When feasible, run the broader repo test command required by the repository.
+Always report the exact commands and results in the pull request.

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -289,11 +289,14 @@ jobs:
       - name: Create GitHub prerelease
         run: |
           gh release create "$TAG_NAME" \
+            .release-candidate/dist/*.whl \
+            .release-candidate/dist/*.tar.gz \
+            .release-candidate/.temp/release-review.sarif \
+            .release-candidate/.temp/release-review.md \
             --target "$GITHUB_SHA" \
             --prerelease \
             --title "$TAG_NAME" \
             --notes-file .release-candidate/.temp/release-notes.md
-          gh release upload "$TAG_NAME" .release-candidate/dist/*.whl .release-candidate/dist/*.tar.gz --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.release_candidate.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,8 +53,8 @@ jobs:
           STORED=$(gh api repos/${{ github.repository }}/commits/"$SHA"/status \
             --jq '[.statuses[] | select(.context == "ci/release-key")] | first | .description')
           if [ -z "$STORED" ] || [ "$STORED" = "null" ]; then
-            echo "WARNING: No ci/release-key status found for $SHA — skipping verification" >&2
-            exit 0
+            echo "ERROR: No ci/release-key status found for $SHA — blocking publication" >&2
+            exit 1
           fi
           EXPECTED=$(python3 -c "import hmac,hashlib,os; print(hmac.new(os.environ['RELEASE_UNLOCK_WORD'].encode(), os.environ['VERIFY_SHA'].encode(), hashlib.sha256).hexdigest())")
           if [ "$STORED" = "$EXPECTED" ]; then
@@ -87,25 +87,26 @@ jobs:
         run: uv build
 
       - name: Generate SBOM
-        continue-on-error: true
         run: |
           uv tool install cyclonedx-bom --force
           cyclonedx-py environment -o sbom.cdx.json --of json
-          gh release upload ${{ needs.release-please.outputs.tag_name }} sbom.cdx.json
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Attest build provenance (SLSA)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: dist/*
 
+      - name: Upload stable release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-release-${{ needs.release-please.outputs.tag_name }}
+          path: |
+            dist/*
+            sbom.cdx.json
+          retention-days: 30
+          if-no-files-found: error
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           print-hash: true
-
-      - name: Upload to release
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*.whl dist/*.tar.gz
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/workflow-policy.yml
+++ b/.github/workflows/workflow-policy.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - ".github/agents/**"
       - ".github/actions-allowlist.yml"
       - ".github/dependabot.yml"
       - ".github/workflows/**"
+      - "tests/unit/test_copilot_agent_profiles.py"
       - "tests/unit/test_dependabot_policy.py"
       - "tests/unit/test_github_actions_policy.py"
       - "tests/unit/test_ruff_policy.py"
@@ -29,4 +31,4 @@ jobs:
             -e EEDOM_ALLOW_GLOBAL=1 \
             -e UV_PROJECT_ENVIRONMENT=/tmp/eedom-policy-venv \
             docker.io/library/python@sha256:d384a24aebd583543abb00fa47b2a434ec3a96559c6f244cc3cfcbe9e136a798 \
-            sh -c "python -m pip install --disable-pip-version-check --no-cache-dir uv==0.11.8 && uv run --frozen pytest tests/unit/test_github_actions_policy.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py -q"
+            sh -c "python -m pip install --disable-pip-version-check --no-cache-dir uv==0.11.8 && uv run --frozen pytest tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py tests/unit/test_dependabot_policy.py tests/unit/test_ruff_policy.py -q"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,8 +12,10 @@ policies/ @samfakhreddine
 action.yml @samfakhreddine
 
 # Workflow policy guardrails
+.github/agents/ @samfakhreddine
 .github/actions-allowlist.yml @samfakhreddine
 .github/workflows/workflow-policy.yml @samfakhreddine
+tests/unit/test_copilot_agent_profiles.py @samfakhreddine
 tests/unit/test_github_actions_policy.py @samfakhreddine
 tests/unit/test_dependabot_policy.py @samfakhreddine
 tests/unit/test_ruff_policy.py @samfakhreddine

--- a/tests/unit/test_copilot_agent_profiles.py
+++ b/tests/unit/test_copilot_agent_profiles.py
@@ -1,0 +1,88 @@
+# tested-by: tests/unit/test_copilot_agent_profiles.py
+"""Policy guards for repository Copilot custom agents."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_AGENTS = _ROOT / ".github" / "agents"
+_RELEASE_MANAGER = _AGENTS / "release-manager.agent.md"
+_FRONTMATTER = re.compile(r"\A---\n(?P<yaml>.*?)\n---\n(?P<body>.*)\Z", re.DOTALL)
+
+
+def _load_agent(path: Path) -> tuple[dict[str, Any], str]:
+    raw = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER.match(raw)
+    assert match, f"{path.relative_to(_ROOT)} must use YAML frontmatter"
+
+    metadata = yaml.safe_load(match.group("yaml")) or {}
+    assert isinstance(metadata, dict), "agent frontmatter must parse to a mapping"
+    return metadata, match.group("body")
+
+
+def test_release_manager_agent_profile_is_valid_and_scoped() -> None:
+    assert _RELEASE_MANAGER.exists(), "release-manager Copilot agent must be checked in"
+
+    metadata, body = _load_agent(_RELEASE_MANAGER)
+
+    assert metadata["name"] == "Release Manager"
+    assert metadata["target"] == "github-copilot"
+    assert "release" in metadata["description"].lower()
+    assert "deterministic" in metadata["description"].lower()
+    assert metadata["tools"] == ["read", "search", "edit", "execute", "github/*"]
+    profile_metadata = metadata["metadata"]
+    assert profile_metadata["owner"] == "release"
+    assert profile_metadata["category"] == "operations"
+    assert profile_metadata["version"] == "1.0.0"
+    assert "deterministic" in profile_metadata["tags"]
+
+    for required_path in (
+        ".github/workflows/release-candidate.yml",
+        ".github/workflows/release-please.yml",
+        ".github/workflows/gatekeeper.yml",
+        "tests/unit/test_github_actions_policy.py",
+        "tests/unit/test_deterministic_workflow_guards.py",
+        "tests/unit/test_deterministic_release_key_guards.py",
+        "release-please-config.json",
+        ".release-please-manifest.json",
+        "pyproject.toml",
+        "CHANGELOG.md",
+    ):
+        assert required_path in body
+
+
+def test_release_manager_agent_preserves_release_safety_contract() -> None:
+    _metadata, body = _load_agent(_RELEASE_MANAGER)
+    normalized_body = re.sub(r"\s+", " ", body)
+
+    required_release_rules = (
+        "Do not reintroduce path-triggered full E2E",
+        "Treat merge status, CI status, release-candidate status, and stable publish",
+        "release-key verification path",
+        "v<base>-rc.<YYYYMMDD>.<N>",
+        "GitHub immutable releases must stay enabled",
+        "Do not upload assets to a GitHub release after it is published",
+        "gh api repos/gitrdunhq/eedom/immutable-releases --jq .",
+        "Validation jobs should use read-only permissions",
+        "`contents: write`",
+        "third-party actions pinned to full commit SHAs",
+        "Never store release credentials",
+        "Do not use `pull_request_target` to checkout or execute pull-request head",
+        "Do not force-push",
+        "Do not auto-resolve merge conflicts",
+        "Do not guess version numbers",
+        "Never include AI attribution",
+        "release-please is the default version and changelog authority",
+        "Every claim about merge state, CI, version, changelog, tag, GitHub release",
+        "Never use `git add -A`",
+    )
+    for required_rule in required_release_rules:
+        assert required_rule in normalized_body
+
+    assert "UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest" in body
+    assert "tests/unit/test_copilot_agent_profiles.py" in body

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -168,6 +168,7 @@ def test_workflow_policy_runs_read_only_policy_checks() -> None:
 
     run_text = _run_text(workflow)
     assert "tests/unit/test_github_actions_policy.py" in run_text
+    assert "tests/unit/test_copilot_agent_profiles.py" in run_text
     assert "tests/unit/test_dependabot_policy.py" in run_text
     assert "tests/unit/test_ruff_policy.py" in run_text
     assert "docker.io/library/python@sha256:" in run_text
@@ -382,11 +383,12 @@ def test_daily_release_candidate_runs_full_e2e_and_creates_prerelease() -> None:
     assert "Release candidate blocked by Dom review" in run_text
     assert "uv build" in run_text
     assert 'gh release create "$TAG_NAME"' in run_text
+    assert ".release-candidate/dist/*.whl" in run_text
+    assert ".release-candidate/dist/*.tar.gz" in run_text
+    assert ".release-candidate/.temp/release-review.sarif" in run_text
+    assert ".release-candidate/.temp/release-review.md" in run_text
     assert "--prerelease" in run_text
-    assert (
-        'gh release upload "$TAG_NAME" .release-candidate/dist/*.whl '
-        ".release-candidate/dist/*.tar.gz --clobber"
-    ) in run_text
+    assert "gh release upload" not in publish_run_text
 
     metadata_step = next(
         step
@@ -417,6 +419,35 @@ def test_daily_release_candidate_runs_full_e2e_and_creates_prerelease() -> None:
     assert create_env.get("TAG_NAME") == "${{ needs.release_candidate.outputs.tag_name }}"
 
 
+def test_release_please_is_compatible_with_immutable_releases() -> None:
+    workflow = _load_yaml(_WORKFLOWS / "release-please.yml")
+    jobs = _as_mapping(workflow.get("jobs"))
+    publish = _as_mapping(jobs.get("publish"))
+
+    step_names = {
+        step.get("name") for step in _job_steps(publish) if isinstance(step.get("name"), str)
+    }
+    assert "Generate SBOM" in step_names
+    assert "Upload stable release artifacts" in step_names
+    assert "Upload to release" not in step_names
+
+    publish_run = _job_run_text(publish)
+    assert "gh release upload" not in publish_run
+    assert "cyclonedx-py environment -o sbom.cdx.json --of json" in publish_run
+
+    artifact_step = next(
+        step
+        for step in _job_steps(publish)
+        if step.get("name") == "Upload stable release artifacts"
+    )
+    artifact_with = _as_mapping(artifact_step.get("with"))
+    assert (
+        artifact_with.get("name") == "stable-release-${{ needs.release-please.outputs.tag_name }}"
+    )
+    assert "dist/*" in str(artifact_with.get("path", ""))
+    assert "sbom.cdx.json" in str(artifact_with.get("path", ""))
+
+
 def test_pull_request_target_workflows_do_not_checkout_or_execute_pr_head() -> None:
     for path in _workflow_paths():
         workflow = _load_yaml(path)
@@ -444,8 +475,10 @@ def test_policy_artifacts_are_codeowned_and_documented() -> None:
 
     codeowners = _CODEOWNERS.read_text(encoding="utf-8")
     required_paths = [
+        ".github/agents/",
         ".github/actions-allowlist.yml",
         ".github/workflows/workflow-policy.yml",
+        "tests/unit/test_copilot_agent_profiles.py",
         "tests/unit/test_github_actions_policy.py",
         "tests/unit/test_dependabot_policy.py",
         "tests/unit/test_ruff_policy.py",


### PR DESCRIPTION
## Summary
- add a deterministic GitHub Copilot Release Manager agent profile for eedom release operations
- make release-candidate GitHub prerelease creation attach assets during `gh release create` instead of mutating the release afterward
- make stable release publishing compatible with immutable releases by blocking absent release-key status and preserving dist/SBOM as workflow artifacts instead of post-publication `gh release upload`
- add policy tests plus CODEOWNERS/workflow-policy coverage for `.github/agents/**`

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py tests/unit/test_deterministic_workflow_guards.py tests/unit/test_deterministic_release_key_guards.py -v --tb=short` -> 12 passed, 4 xfailed, 9 xpassed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py` -> passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py` -> passed
- `git diff --check` -> passed

## Follow-up after merge
- enable immutable releases for `gitrdunhq/eedom`
- verify with `gh api repos/gitrdunhq/eedom/immutable-releases --jq .`