### PR TITLE
Rename release candidates to nightly cadence

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -12,7 +12,7 @@ metadata:
 
 You are the eedom Release Manager. Treat every release as a production event:
 methodical, deterministic, evidence-backed, and careful about irreversible
-actions. Use this agent for release automation, daily release-candidate
+actions. Use this agent for release automation, nightly release-candidate
 validation, release-please stable-release work, version/changelog evidence,
 release documentation, and release incident follow-up.
 
@@ -25,7 +25,7 @@ record. Do not infer completion from a nearby success signal.
 
 Start every task by reading the relevant local source of truth before editing:
 
-- `.github/workflows/release-candidate.yml` for daily prerelease candidates.
+- `.github/workflows/release-candidate.yml` for nightly prerelease candidates.
 - `.github/workflows/release-please.yml` for stable release PRs and PyPI publishing.
 - `.github/workflows/gatekeeper.yml` for PR validation and release-key status.
 - `tests/unit/test_github_actions_policy.py` for workflow policy contracts.
@@ -48,13 +48,13 @@ Start every task by reading the relevant local source of truth before editing:
 ## Operating Rules
 
 - Keep PR CI fast. Do not reintroduce path-triggered full E2E on pull requests.
-  Full E2E belongs in manual release validation and daily release candidates.
+  Full E2E belongs in manual release validation and nightly release candidates.
 - Treat merge status, CI status, release-candidate status, and stable publish
   status as separate facts. Verify and report them separately.
 - Stable package publication stays behind release-please and the release-key
   verification path. Treat the release-key verification path as mandatory and
   do not bypass release-key checks.
-- Daily release candidates use the `v<base>-rc.<YYYYMMDD>.<N>` tag shape and
+- Nightly release candidates use the `v<base>-rc.<YYYYMMDD>.<N>` tag shape and
   must run full E2E, full Dom review, distribution build, artifact upload, and
   GitHub prerelease creation.
 - GitHub immutable releases must stay enabled for this repository. Immutable
@@ -151,8 +151,8 @@ For release automation changes:
 
 For release-candidate operations:
 
-- Verify the daily release-candidate workflow exists on the default branch.
-- Run or inspect `Daily Release Candidate` with explicit inputs when needed.
+- Verify the nightly release-candidate workflow exists on the default branch.
+- Run or inspect `Nightly Release Candidate` with explicit inputs when needed.
 - Confirm full E2E, full Dom review, distribution build, artifact upload, and
   GitHub prerelease creation individually.
 - Confirm the prerelease tag and release URL match the expected

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,4 +1,4 @@
-name: Daily Release Candidate
+name: Nightly Release Candidate
 
 on:
   schedule:
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
       candidate_number:
-        description: "Candidate ordinal for today's RC. Defaults to next available number."
+        description: "Candidate ordinal for this nightly RC. Defaults to next available number."
         required: false
         type: string
       dry_run:
@@ -20,7 +20,7 @@ on:
         type: boolean
 
 concurrency:
-  group: daily-release-candidate
+  group: nightly-release-candidate
   cancel-in-progress: false
 
 permissions:
@@ -232,7 +232,7 @@ jobs:
           {
             echo "# ${TAG_NAME}"
             echo ""
-            echo "Daily release candidate for ${BASE_VERSION}."
+            echo "Nightly release candidate for ${BASE_VERSION}."
             echo ""
             echo "## Validation"
             echo "- Full E2E passed"

--- a/tests/unit/test_copilot_agent_profiles.py
+++ b/tests/unit/test_copilot_agent_profiles.py
@@ -65,6 +65,8 @@ def test_release_manager_agent_preserves_release_safety_contract() -> None:
         "Treat merge status, CI status, release-candidate status, and stable publish",
         "release-key verification path",
         "v<base>-rc.<YYYYMMDD>.<N>",
+        "Nightly release candidates",
+        "Nightly Release Candidate",
         "GitHub immutable releases must stay enabled",
         "Do not upload assets to a GitHub release after it is published",
         "gh api repos/gitrdunhq/eedom/immutable-releases --jq .",
@@ -86,3 +88,4 @@ def test_release_manager_agent_preserves_release_safety_contract() -> None:
 
     assert "UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest" in body
     assert "tests/unit/test_copilot_agent_profiles.py" in body
+    assert "daily release" not in normalized_body.lower()

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -320,9 +320,14 @@ def test_gatekeeper_keeps_pr_ci_fast_and_full_e2e_manual_only() -> None:
     assert "not blocking gate" not in gate_run
 
 
-def test_daily_release_candidate_runs_full_e2e_and_creates_prerelease() -> None:
+def test_nightly_release_candidate_runs_full_e2e_and_creates_prerelease() -> None:
     workflow = _load_yaml(_WORKFLOWS / "release-candidate.yml")
 
+    assert workflow.get("name") == "Nightly Release Candidate"
+    assert workflow.get("concurrency") == {
+        "group": "nightly-release-candidate",
+        "cancel-in-progress": False,
+    }
     assert workflow.get("permissions") == {"contents": "read"}
     events = _workflow_events(workflow)
     assert "schedule" in events
@@ -381,6 +386,8 @@ def test_daily_release_candidate_runs_full_e2e_and_creates_prerelease() -> None:
     assert 'result.get("ruleId") == "eedom-plugin-error"' in run_text
     assert 're.findall(r"BINARY_CRASHED", markdown)' in run_text
     assert "Release candidate blocked by Dom review" in run_text
+    assert "Nightly release candidate for ${BASE_VERSION}." in run_text
+    assert "Daily release candidate" not in run_text
     assert "uv build" in run_text
     assert 'gh release create "$TAG_NAME"' in run_text
     assert ".release-candidate/dist/*.whl" in run_text


### PR DESCRIPTION
## Summary
- rename the scheduled release-candidate workflow from Daily Release Candidate to Nightly Release Candidate
- update Release Manager agent instructions to describe nightly release candidates
- add deterministic policy assertions so workflow/agent cadence text does not drift back to daily

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache EEDOM_ALLOW_HOST_TESTS=1 uv run pytest tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py tests/unit/test_deterministic_workflow_guards.py tests/unit/test_deterministic_release_key_guards.py -v --tb=short` -> 12 passed, 4 xfailed, 9 xpassed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py` -> passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run black --check tests/unit/test_github_actions_policy.py tests/unit/test_copilot_agent_profiles.py` -> passed
- `git diff --check` -> passed