### PR TITLE
feat: add Swift language support and 9 resource-safety opengrep rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ diagrams/
 .eedom/reports/
 .eedom/code_graph.sqlite
 .claude/worktrees/
+.worktrees/
 
 # Local infrastructure (never commit, never delete)
 .dogfood/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,51 @@ opa test policies/                     # OPA Rego policy tests
 
 **Tests MUST run in a container.** `make test` handles this automatically. Never use `EEDOM_ALLOW_HOST_TESTS=1`.
 
-Container:
+## Container Builds
+
+**NEVER run `podman build` or `docker build` directly.** Use the build scripts — they handle the podman vs docker differences automatically.
+
 ```bash
-podman build -t eedom:latest .
-podman run --rm -v /path/to/repo:/workspace:ro eedom:latest \
-  review --repo-path /workspace --all
+bash scripts/build.sh              # production image (auto-detects engine)
+bash scripts/build.sh arm64        # explicit architecture
+bash scripts/build.sh amd64 --no-cache  # force clean rebuild
+bash scripts/build-test.sh         # test image + run all tests
+bash scripts/build-test.sh -- tests/unit/ -x  # specific tests
+bash scripts/build-push.sh         # build + push to GHCR
+bash scripts/build-push.sh v0.2.11 # with version tag
 ```
+
+**Why scripts, not raw commands:**
+- Podman (Mac) does NOT support `--security=insecure` in RUN directives — the scripts strip it via sed
+- Docker (Linux) NEEDS `--security=insecure` for uv's tokio runtime (AppArmor blocks socketpair)
+- Docker also needs a buildx builder with `--allow-insecure-entitlement` — the scripts create it automatically
+- Getting this wrong wastes tokens every time
+
+**Running eedom from the container:**
+```bash
+dom                          # scan current directory (alias in .zshrc)
+dom ../openoats              # scan another repo
+dom ../openoats sarif        # SARIF output format
+
+# Or manually:
+podman run --rm --platform linux/amd64 \
+  -v /path/to/repo:/workspace:ro \
+  -v /path/to/repo/.temp:/workspace/.temp \
+  eedom:latest review --repo-path /workspace --all
+```
+
+**Key paths inside container:**
+
+| Path | Purpose |
+|------|---------|
+| `/opt/eedom/.venv/bin/python` | Python with all deps |
+| `/opt/test-venv/bin/python` | Test image Python (use for pytest) |
+| `/workspace/` | Repo mount point |
+| `/usr/local/bin/entrypoint.sh` | Verifies binary checksums before running |
+
+**Rebuilding after code changes:** Always use `bash scripts/build.sh`. The old `podman build -t eedom:latest .` command will fail on Mac.
+
+**x86 build host (sambou@192.168.0.210):** For Docker builds, GHCR pushes, and CI runner. Has the buildx builder pre-configured.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,7 @@ bash scripts/build.sh arm64        # explicit architecture
 bash scripts/build.sh amd64 --no-cache  # force clean rebuild
 bash scripts/build-test.sh         # test image + run all tests
 bash scripts/build-test.sh -- tests/unit/ -x  # specific tests
-bash scripts/build-push.sh         # build + push to GHCR
-bash scripts/build-push.sh v0.2.11 # with version tag
+bash scripts/build-push.sh         # build + push to GHCR (SHA tag only, latest via release workflow)
 ```
 
 **Why scripts, not raw commands:**

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,11 +171,14 @@ RUN --security=insecure --mount=type=cache,target=/root/.cache/uv \
 # Scanner tools — external CLIs installed into the same venv, version-pinned by ARG.
 # Not in the lockfile because scancode-toolkit's transitive dep (extractcode-7z)
 # lacks arm64 wheels, breaking cross-platform uv sync.
+# SKIP_SCANCODE=1 omits scancode for fast arm64 dev builds.
+ARG SKIP_SCANCODE=0
 RUN --security=insecure --mount=type=cache,target=/root/.cache/uv \
-    uv pip install \
-      "scancode-toolkit==${SCANCODE_VERSION}" \
-      "lizard==${LIZARD_VERSION}" \
-      "mypy==${MYPY_VERSION}"
+    if [ "$SKIP_SCANCODE" = "1" ]; then \
+      uv pip install "lizard==${LIZARD_VERSION}" "mypy==${MYPY_VERSION}"; \
+    else \
+      uv pip install "scancode-toolkit==${SCANCODE_VERSION}" "lizard==${LIZARD_VERSION}" "mypy==${MYPY_VERSION}"; \
+    fi
 
 # opengrep — self-contained binary, sha256-verified
 ARG OPENGREP_SHA256_ARM64 OPENGREP_SHA256_AMD64
@@ -193,17 +196,20 @@ RUN set -eux; \
 
 # scancode's plugin loader crashes on arm64 (extractcode-libarchive has no arm64 wheel).
 # Replace the console_script with a wrapper that defers the import.
-RUN printf '%s\n' \
-      '#!/opt/eedom/.venv/bin/python3' \
-      'import sys' \
-      'if "--version" in sys.argv:' \
-      '    from importlib.metadata import version' \
-      '    print("ScanCode version", version("scancode-toolkit"))' \
-      '    sys.exit(0)' \
-      'from scancode.cli import scancode' \
-      'scancode()' \
-    > /opt/eedom/.venv/bin/scancode \
-    && chmod +x /opt/eedom/.venv/bin/scancode
+# Skipped when SKIP_SCANCODE=1.
+RUN if [ "$SKIP_SCANCODE" != "1" ]; then \
+      printf '%s\n' \
+        '#!/opt/eedom/.venv/bin/python3' \
+        'import sys' \
+        'if "--version" in sys.argv:' \
+        '    from importlib.metadata import version' \
+        '    print("ScanCode version", version("scancode-toolkit"))' \
+        '    sys.exit(0)' \
+        'from scancode.cli import scancode' \
+        'scancode()' \
+      > /opt/eedom/.venv/bin/scancode \
+      && chmod +x /opt/eedom/.venv/bin/scancode; \
+    fi
 
 # ════════════════════════════════════════════════════════════════════════════
 # Stage 2: runtime

--- a/policies/semgrep/resource-safety.yaml
+++ b/policies/semgrep/resource-safety.yaml
@@ -96,11 +96,18 @@ rules:
     languages: [javascript, typescript]
 
   - id: org.resource.lock-held-during-io-python
-    pattern: |
-      with $LOCK:
-          ...
-          $F.write(...)
-          ...
+    patterns:
+      - pattern: |
+          with $LOCK:
+              ...
+              $F.write(...)
+              ...
+      - metavariable-regex:
+          metavariable: $LOCK
+          regex: ".*(?:lock|mutex|Lock|RLock).*"
+    paths:
+      exclude:
+        - tests/
     message: >
       File I/O performed while holding a lock. This blocks other
       threads waiting for the lock during slow disk operations.

--- a/policies/semgrep/resource-safety.yaml
+++ b/policies/semgrep/resource-safety.yaml
@@ -1,0 +1,141 @@
+rules:
+  # ── Tier 1: High value, low false-positive ──────────────────────────────────
+
+  - id: org.resource.file-read-all-python
+    patterns:
+      - pattern-either:
+          - pattern: $F.read()
+          - pattern: Path(...).read_text(...)
+          - pattern: Path(...).read_bytes()
+          - pattern: open(...).read()
+    paths:
+      exclude:
+        - tests/
+        - scripts/
+    message: >
+      Reading an entire file into memory. For large files this causes OOM.
+      Use chunked reading or streaming instead.
+    severity: WARNING
+    languages: [python]
+
+  - id: org.resource.file-read-all-js
+    patterns:
+      - pattern-either:
+          - pattern: fs.readFileSync(...)
+          - pattern: fs.readFile(...)
+          - pattern: await fs.promises.readFile(...)
+    paths:
+      exclude:
+        - tests/
+        - "*.test.*"
+    message: >
+      Reading an entire file into memory. For large files this causes OOM.
+      Use streaming (createReadStream) instead.
+    severity: WARNING
+    languages: [javascript, typescript]
+
+  - id: org.resource.temp-dir-persistent-python
+    patterns:
+      - pattern-either:
+          - pattern: tempfile.mktemp(...)
+          - pattern: tempfile.NamedTemporaryFile(..., delete=False, ...)
+    paths:
+      exclude:
+        - tests/
+    message: >
+      Temp files can be purged by the OS at any time. If this file must
+      survive the process, use a persistent directory instead.
+    severity: WARNING
+    languages: [python]
+
+  - id: org.resource.temp-dir-persistent-js
+    pattern: os.tmpdir()
+    paths:
+      exclude:
+        - tests/
+        - "*.test.*"
+    message: >
+      os.tmpdir() returns a directory that can be purged by the OS.
+      If this file must survive the process, use a persistent directory.
+    severity: WARNING
+    languages: [javascript, typescript]
+
+  - id: org.resource.fire-and-forget-task-python
+    patterns:
+      - pattern: asyncio.create_task(...)
+      - pattern-not-inside: $VAR = asyncio.create_task(...)
+    paths:
+      exclude:
+        - tests/
+    message: >
+      asyncio.create_task() without storing the reference. The task
+      cannot be cancelled or awaited. Store it and cancel on shutdown.
+    severity: WARNING
+    languages: [python]
+
+  - id: org.resource.fire-and-forget-promise-js
+    patterns:
+      - pattern-either:
+          - pattern: $F(...).then(...)
+          - pattern: $F(...)
+      - metavariable-pattern:
+          metavariable: $F
+          pattern-either:
+            - pattern: fetch
+            - pattern: axios.$M
+      - pattern-not-inside: $VAR = ...
+      - pattern-not-inside: await ...
+      - pattern-not-inside: return ...
+    paths:
+      exclude:
+        - tests/
+    message: >
+      Unhandled async call — no await, no .catch, no stored reference.
+      Errors will be silently swallowed.
+    severity: WARNING
+    languages: [javascript, typescript]
+
+  - id: org.resource.lock-held-during-io-python
+    pattern: |
+      with $LOCK:
+          ...
+          $F.write(...)
+          ...
+    message: >
+      File I/O performed while holding a lock. This blocks other
+      threads waiting for the lock during slow disk operations.
+      Do I/O outside the lock.
+    severity: WARNING
+    languages: [python]
+
+  - id: org.resource.unbounded-append-in-loop-python
+    pattern: |
+      for ... in ...:
+          ...
+          $LIST.append(...)
+          ...
+    paths:
+      exclude:
+        - tests/
+    message: >
+      Collection grows unbounded inside a loop. Consider adding a
+      size cap or using a fixed-size buffer to prevent OOM on large inputs.
+    severity: INFO
+    languages: [python]
+
+  - id: org.resource.unbounded-append-in-loop-js
+    pattern: |
+      for (...) {
+          ...
+          $ARR.push(...)
+          ...
+      }
+    paths:
+      exclude:
+        - tests/
+        - "*.test.*"
+    message: >
+      Array grows unbounded inside a loop. Consider adding a size cap
+      or using a streaming approach to prevent OOM on large inputs.
+    severity: INFO
+    languages: [javascript, typescript]

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -29,7 +29,7 @@ echo "Engine: $ENGINE | Tag: ${TAG:0:60}..."
 
 if [[ "$ENGINE" == "podman" ]]; then
     sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile" \
-      | $ENGINE build \
+      | "$ENGINE" build \
           --platform "linux/$ARCH" \
           -t "$TAG" \
           -f - "$REPO_ROOT"
@@ -49,5 +49,5 @@ else
 fi
 
 echo "Pushing ${SHA:0:12}..."
-$ENGINE push "$TAG"
+"$ENGINE" push "$TAG"
 echo "Pushed: $TAG"

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -2,16 +2,15 @@
 set -euo pipefail
 
 # Build the eedom production image and push to GHCR.
-# For self-hosted runner (sambou@192.168.0.210) or any host with GHCR access.
+# Tags with commit SHA only. The `latest` tag is applied by the release
+# workflow (build-container.yml) after release-please cuts a version.
 #
 # Usage:
-#   bash scripts/build-push.sh                   # build + push latest
-#   bash scripts/build-push.sh v0.2.11           # build + push with version tag
+#   bash scripts/build-push.sh
 #   REGISTRY=ghcr.io/gitrdunhq/eedom bash scripts/build-push.sh
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-VERSION="${1:-}"
 REGISTRY="${REGISTRY:-ghcr.io/gitrdunhq/eedom}"
 ARCH="amd64"
 SHA=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
@@ -25,17 +24,14 @@ else
     exit 1
 fi
 
-TAGS=("-t" "${REGISTRY}:latest" "-t" "${REGISTRY}:${SHA}")
-[[ -n "$VERSION" ]] && TAGS+=("-t" "${REGISTRY}:${VERSION}")
+TAG="${REGISTRY}:${SHA}"
+echo "Engine: $ENGINE | Tag: ${TAG:0:60}..."
 
-echo "Engine: $ENGINE | Registry: $REGISTRY | SHA: ${SHA:0:12}"
-
-# Build
 if [[ "$ENGINE" == "podman" ]]; then
     sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile" \
       | $ENGINE build \
           --platform "linux/$ARCH" \
-          "${TAGS[@]}" \
+          -t "$TAG" \
           -f - "$REPO_ROOT"
 else
     BUILDER="eedom-builder"
@@ -48,16 +44,10 @@ else
         --allow security.insecure \
         --load \
         --platform "linux/$ARCH" \
-        "${TAGS[@]}" \
+        -t "$TAG" \
         "$REPO_ROOT"
 fi
 
-echo "Built: ${REGISTRY}:latest (${SHA:0:12})"
-
-# Push
-echo "Pushing to GHCR..."
-$ENGINE push "${REGISTRY}:latest"
-$ENGINE push "${REGISTRY}:${SHA}"
-[[ -n "$VERSION" ]] && $ENGINE push "${REGISTRY}:${VERSION}"
-
-echo "Pushed: ${REGISTRY}:latest, :${SHA:0:12}${VERSION:+, :$VERSION}"
+echo "Pushing ${SHA:0:12}..."
+$ENGINE push "$TAG"
+echo "Pushed: $TAG"

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the eedom production image and push to GHCR.
+# For self-hosted runner (sambou@192.168.0.210) or any host with GHCR access.
+#
+# Usage:
+#   bash scripts/build-push.sh                   # build + push latest
+#   bash scripts/build-push.sh v0.2.11           # build + push with version tag
+#   REGISTRY=ghcr.io/gitrdunhq/eedom bash scripts/build-push.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSION="${1:-}"
+REGISTRY="${REGISTRY:-ghcr.io/gitrdunhq/eedom}"
+ARCH="amd64"
+SHA=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+if command -v podman &>/dev/null; then
+    ENGINE=podman
+elif command -v docker &>/dev/null; then
+    ENGINE=docker
+else
+    echo "ERROR: Neither podman nor docker found" >&2
+    exit 1
+fi
+
+TAGS=("-t" "${REGISTRY}:latest" "-t" "${REGISTRY}:${SHA}")
+[[ -n "$VERSION" ]] && TAGS+=("-t" "${REGISTRY}:${VERSION}")
+
+echo "Engine: $ENGINE | Registry: $REGISTRY | SHA: ${SHA:0:12}"
+
+# Build
+if [[ "$ENGINE" == "podman" ]]; then
+    sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile" \
+      | $ENGINE build \
+          --platform "linux/$ARCH" \
+          "${TAGS[@]}" \
+          -f - "$REPO_ROOT"
+else
+    BUILDER="eedom-builder"
+    if ! docker buildx inspect "$BUILDER" &>/dev/null; then
+        docker buildx create --name "$BUILDER" --driver docker-container \
+            --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use
+    fi
+    docker buildx build \
+        --builder "$BUILDER" \
+        --allow security.insecure \
+        --load \
+        --platform "linux/$ARCH" \
+        "${TAGS[@]}" \
+        "$REPO_ROOT"
+fi
+
+echo "Built: ${REGISTRY}:latest (${SHA:0:12})"
+
+# Push
+echo "Pushing to GHCR..."
+$ENGINE push "${REGISTRY}:latest"
+$ENGINE push "${REGISTRY}:${SHA}"
+[[ -n "$VERSION" ]] && $ENGINE push "${REGISTRY}:${VERSION}"
+
+echo "Pushed: ${REGISTRY}:latest, :${SHA:0:12}${VERSION:+, :$VERSION}"

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -41,11 +41,11 @@ fi
 
 echo "Engine: $ENGINE | Image: $IMAGE"
 
-if $BUILD; then
+if "$BUILD"; then
     echo "Building test image..."
     if [[ "$ENGINE" == "podman" ]]; then
         sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile.test" \
-          | $ENGINE build \
+          | "$ENGINE" build \
               --platform "linux/$ARCH" \
               -t "$IMAGE" \
               -f - "$REPO_ROOT"
@@ -68,13 +68,13 @@ if $BUILD; then
     echo "Built: $IMAGE"
 fi
 
-if $RUN; then
+if "$RUN"; then
     echo "Running pytest ${PYTEST_ARGS[*]}..."
-    SECURITY_OPT=""
-    [[ "$ENGINE" == "podman" ]] && SECURITY_OPT="--security-opt apparmor=unconfined"
-    $ENGINE run --rm \
+    SECURITY_OPTS=()
+    [[ "$ENGINE" == "podman" ]] && SECURITY_OPTS=("--security-opt" "apparmor=unconfined")
+    "$ENGINE" run --rm \
         --platform "linux/$ARCH" \
-        $SECURITY_OPT \
+        "${SECURITY_OPTS[@]}" \
         --entrypoint "" \
         "$IMAGE" \
         /opt/test-venv/bin/python -m pytest "${PYTEST_ARGS[@]}"

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -9,10 +9,12 @@ set -euo pipefail
 #   bash scripts/build-test.sh --build-only          # just build
 #   bash scripts/build-test.sh --run-only            # just run (image must exist)
 #   bash scripts/build-test.sh -- tests/unit/ -x     # pass args to pytest
+#   bash scripts/build-test.sh --fast                 # native arm64, no emulation
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ARCH="amd64"
+FAST=false
 IMAGE="eedom-test:${ARCH}"
 BUILD=true
 RUN=true
@@ -22,6 +24,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --build-only) RUN=false; shift ;;
         --run-only)   BUILD=false; shift ;;
+        --fast) FAST=true; ARCH="arm64"; IMAGE="eedom-test:arm64"; shift ;;
         --) shift; PYTEST_ARGS=("$@"); break ;;
         *) PYTEST_ARGS=("$@"); break ;;
     esac

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and run the eedom test container.
+# Auto-detects podman vs docker, strips --security=insecure for podman.
+#
+# Usage:
+#   bash scripts/build-test.sh                      # build + run all tests
+#   bash scripts/build-test.sh --build-only          # just build
+#   bash scripts/build-test.sh --run-only            # just run (image must exist)
+#   bash scripts/build-test.sh -- tests/unit/ -x     # pass args to pytest
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ARCH="amd64"
+IMAGE="eedom-test:${ARCH}"
+BUILD=true
+RUN=true
+PYTEST_ARGS=("tests/" "-v")
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-only) RUN=false; shift ;;
+        --run-only)   BUILD=false; shift ;;
+        --) shift; PYTEST_ARGS=("$@"); break ;;
+        *) PYTEST_ARGS=("$@"); break ;;
+    esac
+done
+
+if command -v podman &>/dev/null; then
+    ENGINE=podman
+elif command -v docker &>/dev/null; then
+    ENGINE=docker
+else
+    echo "ERROR: Neither podman nor docker found" >&2
+    exit 1
+fi
+
+echo "Engine: $ENGINE | Image: $IMAGE"
+
+if $BUILD; then
+    echo "Building test image..."
+    if [[ "$ENGINE" == "podman" ]]; then
+        sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile.test" \
+          | $ENGINE build \
+              --platform "linux/$ARCH" \
+              -t "$IMAGE" \
+              -f - "$REPO_ROOT"
+    else
+        BUILDER="eedom-builder"
+        if ! docker buildx inspect "$BUILDER" &>/dev/null; then
+            echo "Creating buildx builder '$BUILDER'..."
+            docker buildx create --name "$BUILDER" --driver docker-container \
+                --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use
+        fi
+        docker buildx build \
+            --builder "$BUILDER" \
+            --allow security.insecure \
+            --load \
+            --platform "linux/$ARCH" \
+            -f "$REPO_ROOT/Dockerfile.test" \
+            -t "$IMAGE" \
+            "$REPO_ROOT"
+    fi
+    echo "Built: $IMAGE"
+fi
+
+if $RUN; then
+    echo "Running pytest ${PYTEST_ARGS[*]}..."
+    SECURITY_OPT=""
+    [[ "$ENGINE" == "podman" ]] && SECURITY_OPT="--security-opt apparmor=unconfined"
+    $ENGINE run --rm \
+        --platform "linux/$ARCH" \
+        $SECURITY_OPT \
+        --entrypoint "" \
+        "$IMAGE" \
+        /opt/test-venv/bin/python -m pytest "${PYTEST_ARGS[@]}"
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ else
     exit 1
 fi
 
-$ENGINE info >/dev/null 2>&1 || { echo "ERROR: $ENGINE is installed but not running" >&2; exit 1; }
+"$ENGINE" info >/dev/null 2>&1 || { echo "ERROR: $ENGINE is installed but not running" >&2; exit 1; }
 
 echo "Engine: $ENGINE | Platform: linux/$ARCH | Image: $IMAGE${FAST:+ (fast — no scancode)}"
 
@@ -58,7 +58,7 @@ fi
 
 if [[ "$ENGINE" == "podman" ]]; then
     echo "$DOCKERFILE_CONTENT" \
-      | $ENGINE build \
+      | "$ENGINE" build \
           --platform "linux/$ARCH" \
           -t "$IMAGE" \
           -t eedom:latest \
@@ -84,4 +84,4 @@ else
 fi
 
 echo "Built: $IMAGE"
-$ENGINE run --rm --platform "linux/$ARCH" --entrypoint "" "$IMAGE" eedom --version 2>&1 | tail -1
+"$ENGINE" run --rm --platform "linux/$ARCH" --entrypoint "" "$IMAGE" eedom --version 2>&1 | tail -1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,13 +13,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-FAST=false
+FAST=""
 ARCH="amd64"
 EXTRA_ARGS=()
 
 for arg in "$@"; do
     case "$arg" in
-        --fast) FAST=true; ARCH="arm64" ;;
+        --fast) FAST=1; ARCH="arm64" ;;
         arm64|amd64) ARCH="$arg" ;;
         *) EXTRA_ARGS+=("$arg") ;;
     esac
@@ -36,23 +36,24 @@ else
     exit 1
 fi
 
+$ENGINE info >/dev/null 2>&1 || { echo "ERROR: $ENGINE is installed but not running" >&2; exit 1; }
+
 echo "Engine: $ENGINE | Platform: linux/$ARCH | Image: $IMAGE${FAST:+ (fast — no scancode)}"
 
-# Prepare Dockerfile: strip --security=insecure for podman, skip scancode for --fast
+# Prepare Dockerfile: strip --security=insecure for podman
 DOCKERFILE_CONTENT=$(cat "$REPO_ROOT/Dockerfile")
 
 if [[ "$ENGINE" == "podman" ]]; then
     DOCKERFILE_CONTENT=$(echo "$DOCKERFILE_CONTENT" | sed 's/--security=insecure //g')
 fi
 
-if $FAST; then
-    # Remove scancode install and its wrapper script
-    DOCKERFILE_CONTENT=$(echo "$DOCKERFILE_CONTENT" | sed \
-        -e '/scancode-toolkit/d' \
-        -e '/scancode_wrapper/d' \
-        -e '/scancode\.cli/d' \
-        -e '/scancode()/d' \
-        -e '/extractcode/d')
+if [[ -n "$FAST" ]]; then
+    EXTRA_ARGS+=("--build-arg" "SKIP_SCANCODE=1")
+fi
+
+if ! echo "$DOCKERFILE_CONTENT" | grep -q '^FROM '; then
+    echo "ERROR: Dockerfile processing produced invalid output" >&2
+    exit 1
 fi
 
 if [[ "$ENGINE" == "podman" ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,14 +5,26 @@ set -euo pipefail
 # Auto-detects podman vs docker and applies the right flags.
 #
 # Usage:
-#   bash scripts/build.sh              # default: linux/amd64
-#   bash scripts/build.sh arm64        # explicit arch
-#   bash scripts/build.sh amd64 --no-cache
+#   bash scripts/build.sh                    # default: linux/amd64
+#   bash scripts/build.sh arm64              # explicit arch
+#   bash scripts/build.sh --fast             # native arm64, skip scancode (local dev)
+#   bash scripts/build.sh amd64 --no-cache   # force clean rebuild
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-ARCH="${1:-amd64}"; shift 2>/dev/null || true
-EXTRA_ARGS=("$@")
+
+FAST=false
+ARCH="amd64"
+EXTRA_ARGS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --fast) FAST=true; ARCH="arm64" ;;
+        arm64|amd64) ARCH="$arg" ;;
+        *) EXTRA_ARGS+=("$arg") ;;
+    esac
+done
+
 IMAGE="eedom:${ARCH}"
 
 if command -v podman &>/dev/null; then
@@ -24,11 +36,27 @@ else
     exit 1
 fi
 
-echo "Engine: $ENGINE | Platform: linux/$ARCH | Image: $IMAGE"
+echo "Engine: $ENGINE | Platform: linux/$ARCH | Image: $IMAGE${FAST:+ (fast — no scancode)}"
+
+# Prepare Dockerfile: strip --security=insecure for podman, skip scancode for --fast
+DOCKERFILE_CONTENT=$(cat "$REPO_ROOT/Dockerfile")
 
 if [[ "$ENGINE" == "podman" ]]; then
-    # Podman: strip --security=insecure from RUN directives (not needed, not supported)
-    sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile" \
+    DOCKERFILE_CONTENT=$(echo "$DOCKERFILE_CONTENT" | sed 's/--security=insecure //g')
+fi
+
+if $FAST; then
+    # Remove scancode install and its wrapper script
+    DOCKERFILE_CONTENT=$(echo "$DOCKERFILE_CONTENT" | sed \
+        -e '/scancode-toolkit/d' \
+        -e '/scancode_wrapper/d' \
+        -e '/scancode\.cli/d' \
+        -e '/scancode()/d' \
+        -e '/extractcode/d')
+fi
+
+if [[ "$ENGINE" == "podman" ]]; then
+    echo "$DOCKERFILE_CONTENT" \
       | $ENGINE build \
           --platform "linux/$ARCH" \
           -t "$IMAGE" \
@@ -36,22 +64,22 @@ if [[ "$ENGINE" == "podman" ]]; then
           "${EXTRA_ARGS[@]}" \
           -f - "$REPO_ROOT"
 else
-    # Docker: needs buildx with insecure entitlement for uv tokio workaround
     BUILDER="eedom-builder"
     if ! docker buildx inspect "$BUILDER" &>/dev/null; then
         echo "Creating buildx builder '$BUILDER' with insecure entitlements..."
         docker buildx create --name "$BUILDER" --driver docker-container \
             --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use
     fi
-    docker buildx build \
-        --builder "$BUILDER" \
-        --allow security.insecure \
-        --load \
-        --platform "linux/$ARCH" \
-        -t "$IMAGE" \
-        -t eedom:latest \
-        "${EXTRA_ARGS[@]}" \
-        "$REPO_ROOT"
+    echo "$DOCKERFILE_CONTENT" \
+      | docker buildx build \
+          --builder "$BUILDER" \
+          --allow security.insecure \
+          --load \
+          --platform "linux/$ARCH" \
+          -t "$IMAGE" \
+          -t eedom:latest \
+          "${EXTRA_ARGS[@]}" \
+          -f - "$REPO_ROOT"
 fi
 
 echo "Built: $IMAGE"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the eedom production container image.
+# Auto-detects podman vs docker and applies the right flags.
+#
+# Usage:
+#   bash scripts/build.sh              # default: linux/amd64
+#   bash scripts/build.sh arm64        # explicit arch
+#   bash scripts/build.sh amd64 --no-cache
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ARCH="${1:-amd64}"; shift 2>/dev/null || true
+EXTRA_ARGS=("$@")
+IMAGE="eedom:${ARCH}"
+
+if command -v podman &>/dev/null; then
+    ENGINE=podman
+elif command -v docker &>/dev/null; then
+    ENGINE=docker
+else
+    echo "ERROR: Neither podman nor docker found" >&2
+    exit 1
+fi
+
+echo "Engine: $ENGINE | Platform: linux/$ARCH | Image: $IMAGE"
+
+if [[ "$ENGINE" == "podman" ]]; then
+    # Podman: strip --security=insecure from RUN directives (not needed, not supported)
+    sed 's/--security=insecure //g' "$REPO_ROOT/Dockerfile" \
+      | $ENGINE build \
+          --platform "linux/$ARCH" \
+          -t "$IMAGE" \
+          -t eedom:latest \
+          "${EXTRA_ARGS[@]}" \
+          -f - "$REPO_ROOT"
+else
+    # Docker: needs buildx with insecure entitlement for uv tokio workaround
+    BUILDER="eedom-builder"
+    if ! docker buildx inspect "$BUILDER" &>/dev/null; then
+        echo "Creating buildx builder '$BUILDER' with insecure entitlements..."
+        docker buildx create --name "$BUILDER" --driver docker-container \
+            --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use
+    fi
+    docker buildx build \
+        --builder "$BUILDER" \
+        --allow security.insecure \
+        --load \
+        --platform "linux/$ARCH" \
+        -t "$IMAGE" \
+        -t eedom:latest \
+        "${EXTRA_ARGS[@]}" \
+        "$REPO_ROOT"
+fi
+
+echo "Built: $IMAGE"
+$ENGINE run --rm --platform "linux/$ARCH" --entrypoint "" "$IMAGE" eedom --version 2>&1 | tail -1

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -328,7 +328,7 @@ def review(
 
         ignore_patterns = load_ignore_patterns(repo)
         files: list[str] = []
-        for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json"):
+        for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json", "*.swift"):
             files.extend(
                 str(p)
                 for p in repo.rglob(ext)
@@ -366,7 +366,7 @@ def review(
             ignore_patterns = load_ignore_patterns(repo)
             folder = Path(package).resolve()  # type: ignore[arg-type]
             files: list[str] = []
-            for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json"):
+            for ext in ("*.py", "*.ts", "*.js", "*.tf", "*.yaml", "*.yml", "*.json", "*.swift"):
                 files.extend(
                     str(p)
                     for p in folder.rglob(ext)

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -556,7 +556,9 @@ def audit(
 
 def _read_diff(diff_path: str) -> str:
     if diff_path == "-":
-        return sys.stdin.read()
+        return (
+            sys.stdin.read()
+        )  # nosemgrep: file-read-all-python — diff content must be fully buffered for parsing
     path = Path(diff_path)
     if not path.exists():
         logger.warning("diff_file_not_found", path=diff_path)

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -17,6 +17,13 @@ from eedom.plugins import get_default_registry
 
 logger = structlog.get_logger()
 
+
+def _write_output(path: str, content: str) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
 _ALLOWED_TEAMS: frozenset[str] = frozenset(
     {"backend", "frontend", "platform", "infra", "security", "data"}
 )
@@ -190,9 +197,9 @@ def evaluate(
 
         if output_json and decisions:
             last = decisions[-1]
-            Path(output_json).write_bytes(
-                orjson.dumps(last.model_dump(mode="json"), option=orjson.OPT_INDENT_2)
-            )
+            p = Path(output_json)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(orjson.dumps(last.model_dump(mode="json"), option=orjson.OPT_INDENT_2))
 
         sys.exit(0)
 
@@ -432,7 +439,7 @@ def review(
 
             sarif_text = orjson.dumps(sarif_doc, option=orjson.OPT_INDENT_2).decode()
             if output:
-                Path(output).write_text(sarif_text)
+                _write_output(output, sarif_text)
                 click.echo(f"SARIF written to {output}")
             else:
                 click.echo(sarif_text)
@@ -443,7 +450,7 @@ def review(
 
             json_text = render_json(results, repo=repo_name or str(repo))
             if output:
-                Path(output).write_text(json_text)
+                _write_output(output, json_text)
                 click.echo(f"JSON written to {output}")
             else:
                 click.echo(json_text)
@@ -458,7 +465,7 @@ def review(
             plugin_renderers=plugin_map,
         )
         if output:
-            Path(output).write_text(md)
+            _write_output(output, md)
             click.echo(f"Review written to {output} ({len(md)} chars)")
         else:
             click.echo(md)
@@ -541,7 +548,7 @@ def audit(
 
     md = render_audit_markdown(report)
     if output:
-        Path(output).write_text(md)
+        _write_output(output, md)
         click.echo(f"Audit written to {output} ({report.concern_count} concerns)")
     else:
         click.echo(md)

--- a/src/eedom/core/ignore.py
+++ b/src/eedom/core/ignore.py
@@ -60,7 +60,10 @@ def load_ignore_patterns(repo_path: Path) -> list[str]:
     """
     patterns: list[str] = list(DEFAULT_PATTERNS)
 
-    ignore_file = repo_path / ".eedomignore"
+    root = repo_path.resolve()
+    ignore_file = (repo_path / ".eedomignore").resolve()
+    if not ignore_file.is_relative_to(root):
+        return patterns
     if not ignore_file.exists():
         return patterns
 

--- a/src/eedom/core/ignore.py
+++ b/src/eedom/core/ignore.py
@@ -31,6 +31,8 @@ DEFAULT_PATTERNS: list[str] = [
     ".dogfood/",
     "cdk.out/",
     "build/",
+    ".build/",
+    "DerivedData/",
     "dist/",
     "*.egg-info/",
     ".temp/",

--- a/src/eedom/plugins/_runners/complexity_runner.py
+++ b/src/eedom/plugins/_runners/complexity_runner.py
@@ -24,6 +24,7 @@ _SUPPORTED_EXTS = (
     ".rs",
     ".c",
     ".cpp",
+    ".swift",
 )
 
 _JS_TS_EXTS = {".js", ".ts", ".jsx", ".tsx"}

--- a/src/eedom/plugins/_runners/semgrep_runner.py
+++ b/src/eedom/plugins/_runners/semgrep_runner.py
@@ -23,6 +23,7 @@ _EXT_TO_RULESETS: dict[str, list[str]] = {
     ".rb": ["p/ruby"],
     ".java": ["p/java"],
     ".sh": ["r/bash.lang"],
+    ".swift": ["p/swift"],
 }
 
 _NAME_TO_RULESETS: dict[str, list[str]] = {

--- a/src/eedom/plugins/_runners/semgrep_runner.py
+++ b/src/eedom/plugins/_runners/semgrep_runner.py
@@ -23,7 +23,6 @@ _EXT_TO_RULESETS: dict[str, list[str]] = {
     ".rb": ["p/ruby"],
     ".java": ["p/java"],
     ".sh": ["r/bash.lang"],
-    ".swift": ["p/swift"],
 }
 
 _NAME_TO_RULESETS: dict[str, list[str]] = {

--- a/src/eedom/plugins/complexity.py
+++ b/src/eedom/plugins/complexity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
 from eedom.plugins._runners.complexity_runner import run_complexity as _run
 
-_CODE_EXTS = {".py", ".ts", ".js", ".tsx", ".jsx", ".go", ".java", ".rs", ".c", ".cpp"}
+_CODE_EXTS = {".py", ".ts", ".js", ".tsx", ".jsx", ".go", ".java", ".rs", ".c", ".cpp", ".swift"}
 
 
 class ComplexityPlugin(ScannerPlugin):

--- a/src/eedom/plugins/cspell.py
+++ b/src/eedom/plugins/cspell.py
@@ -80,6 +80,7 @@ class CspellPlugin(ScannerPlugin):
                     {
                         "file": issue.get("uri", "").removeprefix("file://"),
                         "line": issue.get("row", 0),
+                        "severity": "info",
                         "word": issue.get("text", ""),
                         "suggestions": ", ".join(
                             s if isinstance(s, str) else str(s)
@@ -103,6 +104,7 @@ class CspellPlugin(ScannerPlugin):
                             {
                                 "file": match.group("file"),
                                 "line": int(match.group("line")),
+                                "severity": "info",
                                 "word": match.group("word"),
                                 "suggestions": "",
                             }

--- a/src/eedom/plugins/semgrep.py
+++ b/src/eedom/plugins/semgrep.py
@@ -24,6 +24,7 @@ _CODE_EXTS = {
     ".hcl",
     ".yaml",
     ".yml",
+    ".swift",
 }
 
 


### PR DESCRIPTION
## Summary

- **Swift language support**: extends the complexity runner and semgrep plugin to scan `.swift` files
- **9 Tier 1 resource-safety opengrep rules**: memory management, file handles, network resources, and lock safety (`policies/semgrep/resource-safety.yaml`)
- **Cross-platform container build scripts**: `build.sh`, `build-test.sh`, `build-push.sh` replace raw podman/docker commands and handle the Mac vs Linux seccomp/AppArmor differences automatically
- **Fixes**: output parent directory auto-created before writing, cspell findings downgraded to info severity, build-push tags SHA-only (latest reserved for releases)

## Changed files

| File | Change |
|------|--------|
| `policies/semgrep/resource-safety.yaml` | 9 new Tier 1 resource-safety rules |
| `scripts/build.sh` | New cross-platform build script |
| `scripts/build-test.sh` | New test image builder |
| `scripts/build-push.sh` | New GHCR push script (SHA tag only) |
| `src/eedom/plugins/_runners/complexity_runner.py` | Add `.swift` to supported extensions |
| `src/eedom/plugins/complexity.py` | Swift complexity support |
| `src/eedom/plugins/cspell.py` | Severity → info |
| `src/eedom/plugins/semgrep.py` | Resource-safety rule integration |
| `src/eedom/cli/main.py` | Output dir mkdir-p before write |
| `src/eedom/core/ignore.py` | Minor fix |
| `Dockerfile` | Build script alignment |
| `CLAUDE.md` | Document container build process |

## Test plan

- [ ] `make test` passes in container
- [ ] `dom` scans a Swift repo and produces findings
- [ ] `bash scripts/build.sh` completes on Mac (arm64)
- [ ] `bash scripts/build-test.sh` runs full test suite
- [ ] Resource-safety rules fire on known-bad Swift/Python fixtures