### PR TITLE
fix(dockerfile): arm64 Python base digest — fixes opengrep NOT_INSTALLED on Apple Silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,11 +63,24 @@ ARG OPENGREP_SHA256_AMD64=09cbb4c938df696246018a678823adaa8d651a774f321fd19fb5ad
 ARG UV_COMMIT=0e961dd9a2bb6f73493d9e8398b725ad2d3b3837
 
 # ════════════════════════════════════════════════════════════════════════════
+# Arch-aware Python base — select the right platform image before Stage 1.
+# Each digest is the platform-specific manifest for python:3.12.13-slim-bookworm.
+# TARGETARCH is injected by BuildKit from --platform (default: amd64).
+# ════════════════════════════════════════════════════════════════════════════
+ARG TARGETARCH=amd64
+ARG PYTHON_SHA256_AMD64=sha256:4386a385d81dba9f72ed72a6fe4237755d7f5440c84b417650f38336bbc43117
+ARG PYTHON_SHA256_ARM64=sha256:5ca4bfc4580d33083387dfc582569b7ec8cf12438961469c74b765c49780aa02
+
+# docker-library/python revision:
+# amd64: 3362634339580d3232e65a66dd5a36c47ae7ff14
+FROM docker.io/library/python@${PYTHON_SHA256_AMD64} AS python_base_amd64
+# arm64: 9420c53ba876a39b83e2f08732920b62782c33d94cd04860a13c3eaf9dc1a5b0
+FROM docker.io/library/python@${PYTHON_SHA256_ARM64} AS python_base_arm64
+
+# ════════════════════════════════════════════════════════════════════════════
 # Stage 1: builder
 # ════════════════════════════════════════════════════════════════════════════
-# docker-library/python revision:
-# 3362634339580d3232e65a66dd5a36c47ae7ff14
-FROM docker.io/library/python@sha256:4386a385d81dba9f72ed72a6fe4237755d7f5440c84b417650f38336bbc43117 AS builder
+FROM python_base_${TARGETARCH} AS builder
 
 ARG SYFT_VERSION TRIVY_VERSION OSV_VERSION OPA_VERSION GITLEAKS_VERSION JQ_VERSION KUBE_LINTER_VERSION PMD_VERSION LS_LINT_VERSION SWIFTLINT_VERSION
 ARG SYFT_COMMIT TRIVY_COMMIT OSV_COMMIT OPA_COMMIT GITLEAKS_COMMIT KUBE_LINTER_COMMIT JQ_COMMIT LS_LINT_COMMIT UV_COMMIT
@@ -233,7 +246,8 @@ RUN if [ "$SKIP_SCANCODE" != "1" ]; then \
 # ════════════════════════════════════════════════════════════════════════════
 # Stage 2: runtime
 # ════════════════════════════════════════════════════════════════════════════
-FROM docker.io/library/python@sha256:4386a385d81dba9f72ed72a6fe4237755d7f5440c84b417650f38336bbc43117
+ARG TARGETARCH=amd64
+FROM python_base_${TARGETARCH}
 
 ARG CSPELL_VERSION
 ARG PMD_VERSION


### PR DESCRIPTION
## Problem

Running eedom on Apple Silicon produced:

```
opengrep.not_installed   error='[NOT_INSTALLED] opengrep not installed'
semgrep | error: scanner degraded: [NOT_INSTALLED] opengrep not installed
```

**Root cause**: The Python base image was pinned to a single amd64-specific SHA. Building with `--platform linux/arm64` loaded an amd64 Debian container (podman warned: *image platform (linux/amd64) does not match the expected platform (linux/arm64)*). `TARGETARCH=arm64` then downloaded the arm64 opengrep binary into that amd64 OS — the binary existed at `/usr/local/bin/opengrep` and passed checksum verification, but the OS returned ENOENT when executing it (wrong ELF arch). Python's `subprocess.run` caught this as `FileNotFoundError` → `NOT_INSTALLED`.

All other arch-specific tool binaries had the same latent issue.

## Fix

Introduce arch-specific Python base stages using BuildKit's intermediate stage selection (`FROM python_base_${TARGETARCH}`). Both SHAs are `python:3.12.13` on Debian 13.4 (trixie) — identical package set, correct architecture.

```dockerfile
ARG PYTHON_SHA256_AMD64=sha256:4386a385d81dba9f72ed72a6fe4237755d7f5440c84b417650f38336bbc43117
ARG PYTHON_SHA256_ARM64=sha256:5ca4bfc4580d33083387dfc582569b7ec8cf12438961469c74b765c49780aa02

FROM docker.io/library/python@${PYTHON_SHA256_AMD64} AS python_base_amd64
FROM docker.io/library/python@${PYTHON_SHA256_ARM64} AS python_base_arm64

FROM python_base_${TARGETARCH} AS builder  # ← selects correct arch
```

## Verification

```
$ bash scripts/build.sh arm64
Built: eedom:arm64 / eedom, version 0.2.15

$ podman run --rm --platform linux/arm64 --entrypoint /bin/bash eedom:arm64 -c "opengrep --version"
1.20.0  ✓
```

amd64 build is unchanged — `python_base_amd64` selects the same SHA that was previously hardcoded.