### PR TITLE
fix(dockerfile): install escomplex-cli for full JS complexity analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -267,7 +267,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       default-jre-headless ruby ruby-dev build-essential \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g "cspell@${CSPELL_VERSION}" "@cspell/cspell-json-reporter" "aws-cdk" --no-fund --no-audit \
+    && npm install -g "cspell@${CSPELL_VERSION}" "@cspell/cspell-json-reporter" "aws-cdk" "escomplex-cli" --no-fund --no-audit \
     && npm cache clean --force \
     && gem install cfn-nag --no-document \
     && apt-get purge -y build-essential ruby-dev curl gnupg \


### PR DESCRIPTION
Without `escomplex-cli` the complexity plugin warns `escomplex not found` and falls back to the Halstead approximation. One package added to the `npm install -g` line.