### PR TITLE
fix(dockerfile): install escomplex-cli for full JS complexity analysis

### DIFF
--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scan any repo with eedom using the local arm64 image.
+#
+# Usage:
+#   bash scripts/scan.sh /path/to/repo
+#   bash scripts/scan.sh ../my-project sarif
+#   bash scripts/scan.sh ~/repos/sam/ba-pipeline-full_1
+#
+# Args:
+#   $1  Path to the repo to scan (required)
+#   $2  Output format: markdown (default) or sarif
+set -euo pipefail
+
+TARGET="${1:-}"
+FORMAT="${2:-markdown}"
+IMAGE="${EEDOM_IMAGE:-eedom:arm64}"
+PLATFORM="${EEDOM_PLATFORM:-linux/arm64}"
+
+if [ -z "${TARGET}" ]; then
+    echo "Usage: bash scripts/scan.sh <repo-path> [markdown|sarif]" >&2
+    exit 1
+fi
+
+# Resolve to absolute path
+REPO="$(cd "${TARGET}" && pwd)"
+
+if [ ! -d "${REPO}" ]; then
+    echo "Error: '${REPO}' is not a directory" >&2
+    exit 1
+fi
+
+mkdir -p "${REPO}/.temp"
+
+echo "=== Eagle Eyed Dom ==="
+echo "Target : ${REPO}"
+echo "Format : ${FORMAT}"
+echo "Image  : ${IMAGE}"
+echo ""
+
+podman run --rm \
+    --platform "${PLATFORM}" \
+    --security-opt apparmor=unconfined \
+    -v "${REPO}:/workspace:ro" \
+    -v "${REPO}/.temp:/workspace/.temp" \
+    "${IMAGE}" review --repo-path /workspace --all \
+    ${FORMAT:+--format "${FORMAT}"}

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -29,7 +29,8 @@ if [ ! -d "${REPO}" ]; then
     exit 1
 fi
 
-mkdir -p "${REPO}/.temp"
+TRIVY_CACHE="${HOME}/.cache/eedom/trivy"
+mkdir -p "${TRIVY_CACHE}"
 
 echo "=== Eagle Eyed Dom ==="
 echo "Target : ${REPO}"
@@ -37,10 +38,18 @@ echo "Format : ${FORMAT}"
 echo "Image  : ${IMAGE}"
 echo ""
 
+# Prune any crashed containers from previous runs before starting.
+# A crashed scan leaves a leaked overlay layer that accumulates and fills the VM disk.
+podman container prune -f >/dev/null 2>&1 || true
+
 podman run --rm \
     --platform "${PLATFORM}" \
     --security-opt apparmor=unconfined \
+    --tmpfs /workspace/.temp:rw,size=512m \
     -v "${REPO}:/workspace:ro" \
-    -v "${REPO}/.temp:/workspace/.temp" \
+    -v "${TRIVY_CACHE}:/home/eedom/.cache/trivy" \
     "${IMAGE}" review --repo-path /workspace --all \
     ${FORMAT:+--format "${FORMAT}"}
+
+# Prune dangling layers after a successful run.
+podman system prune -f --volumes >/dev/null 2>&1 || true


### PR DESCRIPTION
Without escomplex-cli the complexity plugin falls back to Halstead
approximation. Adding it to npm install -g gives proper cyclomatic
complexity, Halstead metrics, and maintainability index for JS/TS.## Summary

<!-- What does this PR do? 1-3 bullet points. -->

## Changes

<!-- List the key files/modules changed and why. -->

## Test Plan

- [ ] Unit tests pass (`uv run pytest tests/ -v`)
- [ ] Lint passes (`uv run ruff check src/ tests/`)
- [ ] Format passes (`uv run black --check src/ tests/`)
- [ ] OPA policy tests pass (`opa test policies/`)

## Evidence

<!-- For dependency changes: link to evidence artifacts or paste decision summary. -->

## Checklist

- [ ] No secrets in code or comments
- [ ] Fail-open contract maintained (no new blocking failure paths)
- [ ] `# tested-by:` annotation on new source files
- [ ] ADR written for significant architectural decisions
