### PR TITLE
fix(release): find open release-please PR by branch name, not unreliable outputs.pr

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,10 +31,13 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       - name: Auto-merge release PR
-        if: steps.release.outputs.pr
         run: |
-          PR_NUM=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
-          if [ "$PR_NUM" != "null" ] && [ -n "$PR_NUM" ]; then
+          PR_NUM=$(gh pr list \
+            --head "release-please--branches--main--components--eedom" \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
+          if [ -n "$PR_NUM" ]; then
             gh pr edit "$PR_NUM" --remove-label "autorelease: pending" --add-label "autorelease: tagged" || true
             gh pr merge "$PR_NUM" --auto --rebase || true
           fi


### PR DESCRIPTION
## Summary

- `outputs.pr` from release-please-action v4 is only set on the run that creates/updates the PR. On the run that *publishes* the release, it's empty — so the label flip was silently skipped.
- Fix: search for the open release-please PR by its well-known branch name on every Release workflow run, unconditionally. No more loop.

Closes #368 is still on xs-sweep. This is just the workflow fix.