### PR TITLE
fix: blast-radius purge on disk existence + copilot lockfile bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ parquet = [
     "pyarrow==24.0.0",
 ]
 copilot = [
-    "agent-framework-github-copilot==1.0.0b260424",
+    "agent-framework-github-copilot==1.0.0rc1",
     "starlette==1.0.0",
     "uvicorn==0.46.0",
 ]

--- a/src/eedom/plugins/_runners/graph_builder.py
+++ b/src/eedom/plugins/_runners/graph_builder.py
@@ -483,12 +483,20 @@ class CodeGraph:
         self.conn.commit()
 
     def purge_deleted_files(self, existing_files: list[str]) -> int:
-        """Remove symbols/edges/metadata for files no longer on disk."""
-        existing = set(existing_files)
+        """Remove symbols/edges/metadata for files no longer on disk.
+
+        Keys on actual disk existence, NOT membership in existing_files.
+        A tracked file absent from the argument list but still present on
+        disk must survive — per-file incremental callers
+        (rebuild_incremental([one_file])) pass only the changed file, and
+        list-membership purging destroyed every other tracked file's
+        symbols (gitrdunhq/eedom#385). existing_files is retained for
+        API compatibility but no longer consulted.
+        """
         tracked = self.conn.execute("SELECT path FROM file_metadata").fetchall()
         purged = 0
         for row in tracked:
-            if row["path"] not in existing:
+            if not Path(row["path"]).exists():
                 self.conn.execute(
                     "DELETE FROM edges"
                     " WHERE source_id IN (SELECT id FROM symbols WHERE file = ?)"

--- a/tests/unit/test_graph_builder.py
+++ b/tests/unit/test_graph_builder.py
@@ -281,8 +281,43 @@ class TestPurgeDeletedFiles:
         g = CodeGraph(db_path=db_file)
         g.rebuild_incremental([str(file_a), str(file_b)])
 
+        file_b.unlink()
         count = g.purge_deleted_files([str(file_a)])
         assert count == 1
+
+    def test_single_file_rebuild_preserves_other_tracked_files(self, tmp_path):
+        """rebuild_incremental([one_file]) must NOT purge other tracked files
+        that still exist on disk.
+
+        Regression for the per-write incremental pattern (datum agent-loop):
+        write A -> rebuild_incremental([A]); write B -> rebuild_incremental([B]).
+        The second call passed only B, and purge_deleted_files treated 'not in
+        the argument list' as 'deleted from disk', destroying A's symbols.
+        Purge must key on actual disk existence, not list membership.
+        """
+        db_file = str(tmp_path / "graph.sqlite")
+        file_a = tmp_path / "a.py"
+        file_b = tmp_path / "b.py"
+        file_a.write_text(SAMPLE_A)
+        file_b.write_text(SAMPLE_B)
+
+        g = CodeGraph(db_path=db_file)
+        # Per-write pattern: each file rebuilt in its own call
+        g.rebuild_incremental([str(file_a)])
+        g.rebuild_incremental([str(file_b)])
+
+        names = {
+            r["name"]
+            for r in g.conn.execute("SELECT name FROM symbols WHERE kind = 'function'").fetchall()
+        }
+        assert "alpha" in names, "file_a still exists on disk — its symbols must survive"
+        assert "gamma" in names
+
+        # And the metadata row for file_a must survive too
+        row = g.conn.execute(
+            "SELECT path FROM file_metadata WHERE path = ?", (str(file_a),)
+        ).fetchone()
+        assert row is not None, "file_a metadata must not be purged while it exists on disk"
 
     def test_purge_with_all_files_present_returns_zero(self, tmp_path):
         """purge_deleted_files with all files still present returns 0."""

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agent-framework-core"
-version = "1.2.0"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -12,22 +12,22 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/57/d83aff2a267ba7d0f48065eb6b15f73346fa0f96c766e31646625b678347/agent_framework_core-1.2.0.tar.gz", hash = "sha256:c5ddcef69246baca90a517bb1d440a0f36bbc4fb9894bb2b05b8b43162597c0c", size = 306773, upload-time = "2026-04-24T10:56:59.545Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e0/63ca0c0271679fdbd79f14010b8e14c8deee84b66e28371c8fd917cd2f40/agent_framework_core-1.8.1.tar.gz", hash = "sha256:d4c694603961cbe4df1f08c6a277a1617df489cd86a333d03763f2bf2a5f86bd", size = 425777, upload-time = "2026-06-09T22:31:21.526Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/1f/0c7fcb2ed4432be3c1386b83f4d6e16797c09e5cb4e68aad008d8eca127f/agent_framework_core-1.2.0-py3-none-any.whl", hash = "sha256:e22d824d57ecd7d5a4ca33bc4f86d523c7558453a17b94f48c14c6a67b5c48ff", size = 345536, upload-time = "2026-04-24T10:57:16.643Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c3/85866de030196efa1c053002d48b4b51fa5a93a7d6009adfa7be707f21d2/agent_framework_core-1.8.1-py3-none-any.whl", hash = "sha256:e0dcdd277b8fa7f442f7a3debaab55f5c38b59764e6eafc1a929346cfdd90715", size = 471445, upload-time = "2026-06-09T22:31:30.654Z" },
 ]
 
 [[package]]
 name = "agent-framework-github-copilot"
-version = "1.0.0b260424"
+version = "1.0.0rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-framework-core" },
     { name = "github-copilot-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/80/9e2853d3181bae4a543cc0cfebee660c094c4364ea7f6854cdae88577dd1/agent_framework_github_copilot-1.0.0b260424.tar.gz", hash = "sha256:7abc0f078cb1cf60e20e586922a6226bec2320e92d9d39db85eb6418e1ec3a4b", size = 10965, upload-time = "2026-04-24T10:57:46.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b0/7aee4d36674f65c1a854b36cf58a610f498546eb6665982d77325151f442/agent_framework_github_copilot-1.0.0rc1.tar.gz", hash = "sha256:99a62a205a5ee187cffb00912981d4afe3825b0f8f28ed2781dd12a18e633750", size = 12614, upload-time = "2026-06-04T23:55:55.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/3a/7bd4e1659cf9fa8ef62968b8e8c1a910d2f581fab968dc6bb19bb0891ec1/agent_framework_github_copilot-1.0.0b260424-py3-none-any.whl", hash = "sha256:dc8c3812f9da2ae316eb9e4cb0dcf21daca1802bcc7d1e7036de9e7a5599fc68", size = 10929, upload-time = "2026-04-24T10:56:54.303Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/64/d96626e9f44b5820393a3666bd3f60a5ec07d1f1fe2850f8435c81df327f/agent_framework_github_copilot-1.0.0rc1-py3-none-any.whl", hash = "sha256:f0355a02cb755be8ba8e110c32e9bcf4a0baea5740fe7f993df34c845ebe5702", size = 12545, upload-time = "2026-06-04T23:56:09.701Z" },
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ wheels = [
 
 [[package]]
 name = "eedom"
-version = "0.2.11"
+version = "0.2.24"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -170,7 +170,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework-github-copilot", marker = "extra == 'copilot'", specifier = "==1.0.0b260424" },
+    { name = "agent-framework-github-copilot", marker = "extra == 'copilot'", specifier = "==1.0.0rc1" },
     { name = "click", specifier = "==8.3.3" },
     { name = "eedom", extras = ["db", "parquet", "copilot", "watch"], marker = "extra == 'all'" },
     { name = "httpx", specifier = "==0.28.1" },
@@ -183,7 +183,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-settings", specifier = "==2.14.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "rich", specifier = "==13.9.4" },
+    { name = "rich", specifier = "==15.0.0" },
     { name = "starlette", marker = "extra == 'copilot'", specifier = "==1.0.0" },
     { name = "structlog", specifier = "==25.5.0" },
     { name = "uvicorn", marker = "extra == 'copilot'", specifier = "==0.46.0" },
@@ -204,19 +204,19 @@ dev = [
 
 [[package]]
 name = "github-copilot-sdk"
-version = "0.2.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/41/76a9d50d7600bf8d26c659dc113be62e4e56e00a5cbfd544e1b5b200f45c/github_copilot_sdk-0.2.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c0823150f3b73431f04caee43d1dbafac22ae7e8bd1fc83727ee8363089ee038", size = 61076141, upload-time = "2026-04-03T20:18:22.062Z" },
-    { url = "https://files.pythonhosted.org/packages/04/04/d2e8bf4587c4da270ccb9cbd5ab8a2c4b41217c2bf04a43904be8a27ae20/github_copilot_sdk-0.2.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ef7ff68eb8960515e1a2e199ac0ffb9a17cd3325266461e6edd7290e43dcf012", size = 57838464, upload-time = "2026-04-03T20:18:26.042Z" },
-    { url = "https://files.pythonhosted.org/packages/78/8b/cc8ee46724bd9fdfd6afe855a043c8403ed6884c5f3a55a9737780810396/github_copilot_sdk-0.2.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:890f7124e3b147532a1ac6c8d5f66421ea37757b2b9990d7967f3f147a2f533a", size = 63940155, upload-time = "2026-04-03T20:18:30.297Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/ee/facf04e22e42d4bdd4fe3d356f3a51180a6ea769ae2ac306d0897f9bf9d9/github_copilot_sdk-0.2.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6502be0b9ececacbda671835e5f61c7aaa906c6b8657ee252cad6cc8335cac8e", size = 62130538, upload-time = "2026-04-03T20:18:34.061Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/1c/8b105f14bf61d1d304a00ac29460cb0d4e7406ceb89907d5a7b41a72fe85/github_copilot_sdk-0.2.1-py3-none-win_amd64.whl", hash = "sha256:8275ca8e387e6b29bc5155a3c02a0eb3d035c6bc7b1896253eb0d469f2385790", size = 56547331, upload-time = "2026-04-03T20:18:37.859Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c1/0ce319d2f618e9bc89f275e60b1920f4587eb0218bba6cbb84283dc7a7f3/github_copilot_sdk-0.2.1-py3-none-win_arm64.whl", hash = "sha256:1f9b59b7c41f31be416bf20818f58e25b6adc76f6d17357653fde6fbab662606", size = 54499549, upload-time = "2026-04-03T20:18:41.77Z" },
+    { url = "https://files.pythonhosted.org/packages/89/22/d4d576becff84146501e043831bdd2ca5aee57fcfdfface4ee7db7883655/github_copilot_sdk-1.0.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d1ca7fff62b69f8c9aa24eb2d1f615195730d6b7297050e8e240aa38fbae5eba", size = 94824679, upload-time = "2026-06-10T16:54:17.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5f/f3d935b81f11930539cdf47a7e0dbd4d5ccaadba1f4daf0c64892421a81d/github_copilot_sdk-1.0.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dc4b59dfe034bec6a031b291dbe49de8a8558e42d28aee25213c680ab771d54e", size = 88837334, upload-time = "2026-06-10T16:54:23.056Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/94/225ec0258e1630a81e13b193a9258d8c4550b552b6197f903b75002abf75/github_copilot_sdk-1.0.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:bedb442ee4dd40d43870719f91a9fb6e117ca5d76bbbf1807af80cc77ff64257", size = 97255205, upload-time = "2026-06-10T16:54:29.828Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/34/72fb3936e7e8a425f1498bd6693a4e7db678e43fc3912dc5ce9cecccfe23/github_copilot_sdk-1.0.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a498fffba3d8a521eb73f31d08fef9f534e7c57ae6d0a76fa1848beebb3fb6a9", size = 94572477, upload-time = "2026-06-10T16:54:37.253Z" },
+    { url = "https://files.pythonhosted.org/packages/df/95/34aa49c08033acabbe129acf83a2d71a382bd2977ce92f5114a299508a4e/github_copilot_sdk-1.0.1-py3-none-win_amd64.whl", hash = "sha256:29d850cf5cf2b85c0513b68cba112d4a7aba0a9a447893fc7cc69136dd4e6ac1", size = 91387201, upload-time = "2026-06-10T16:54:45.164Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/900b278e519442d4a5fc9dd070b9100f6f1e6b3c6af3b8642b0b3a65d2f5/github_copilot_sdk-1.0.1-py3-none-win_arm64.whl", hash = "sha256:5f69245b1cb2fc1054e78543ee5c10464b53ebbba11e749c7a42002b02ce6b13", size = 90455774, upload-time = "2026-06-10T16:54:53.093Z" },
 ]
 
 [[package]]
@@ -870,15 +870,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "13.9.4"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refs #385, #386

- fix(blast-radius): purge keys on disk existence, not argument-list membership
- fix(deps): bump copilot extra to agent-framework-github-copilot 1.0.0rc1

Full 2204-test suite green on this branch; 50 graph_builder/blast_radius tests re-verified post-merge locally.