### PR TITLE
feat(semgrep): extra_config_dirs + exclude_rules via .eagle-eyed-dom.yaml

### DIFF
--- a/src/eedom/core/repo_config.py
+++ b/src/eedom/core/repo_config.py
@@ -16,11 +16,19 @@ logger = structlog.get_logger()
 _CONFIG_FILENAME = ".eagle-eyed-dom.yaml"
 
 
+class SemgrepConfig(BaseModel):
+    """Semgrep/opengrep tuning passed to the runner."""
+
+    extra_config_dirs: list[str] = []
+    exclude_rules: list[str] = []
+
+
 class PluginConfig(BaseModel):
     """Per-plugin allow/deny filtering."""
 
     enabled: list[str] | None = None
     disabled: list[str] | None = None
+    semgrep: SemgrepConfig = SemgrepConfig()
 
 
 class TelemetryConfig(BaseModel):

--- a/src/eedom/plugins/_runners/semgrep_runner.py
+++ b/src/eedom/plugins/_runners/semgrep_runner.py
@@ -51,6 +51,19 @@ def detect_rulesets(changed_files: list[str]) -> list[str]:
     return rulesets
 
 
+def _is_excluded(check_id: str, exclude_rules: list[str]) -> bool:
+    """True when *check_id* matches an excluded rule id.
+
+    Opengrep rewrites local-rule ids with dotted path prefixes (e.g.
+    ``policies.semgrep.path-traversal``), so a bare rule id matches either
+    the full check_id or its trailing dotted segment — never a substring.
+    """
+    for rule in exclude_rules:
+        if check_id == rule or check_id.endswith(f".{rule}"):
+            return True
+    return False
+
+
 def run_semgrep(
     changed_files: list[str],
     repo_path: str,
@@ -90,7 +103,17 @@ def run_semgrep(
             check=False,
         )
         if result.stdout:
-            return json.loads(result.stdout)
+            data = json.loads(result.stdout)
+            if exclude_rules and isinstance(data.get("results"), list):
+                # Post-filter: --exclude-rule only matches exact ids, but
+                # opengrep prefixes local-rule ids with their dotted path
+                # (policies.semgrep.<rule>). Filtering here is backend-agnostic.
+                data["results"] = [
+                    r
+                    for r in data["results"]
+                    if not _is_excluded(str(r.get("check_id", "")), exclude_rules)
+                ]
+            return data
         return {
             "results": [],
             "errors": [{"message": "no output", "level": "warn"}],

--- a/src/eedom/plugins/_runners/semgrep_runner.py
+++ b/src/eedom/plugins/_runners/semgrep_runner.py
@@ -58,10 +58,7 @@ def _is_excluded(check_id: str, exclude_rules: list[str]) -> bool:
     ``policies.semgrep.path-traversal``), so a bare rule id matches either
     the full check_id or its trailing dotted segment — never a substring.
     """
-    for rule in exclude_rules:
-        if check_id == rule or check_id.endswith(f".{rule}"):
-            return True
-    return False
+    return any(check_id == rule or check_id.endswith(f".{rule}") for rule in exclude_rules)
 
 
 def run_semgrep(

--- a/src/eedom/plugins/_runners/semgrep_runner.py
+++ b/src/eedom/plugins/_runners/semgrep_runner.py
@@ -55,6 +55,8 @@ def run_semgrep(
     changed_files: list[str],
     repo_path: str,
     timeout: int = 120,
+    extra_config_dirs: list[str] | None = None,
+    exclude_rules: list[str] | None = None,
 ) -> dict:
     if not changed_files:
         return {"results": [], "errors": []}
@@ -67,8 +69,17 @@ def run_semgrep(
         config_args.extend(["--config", rs])
     if org_rules.is_dir():
         config_args.extend(["--config", str(org_rules)])
+    for extra_dir in extra_config_dirs or []:
+        if Path(extra_dir).is_dir():
+            config_args.extend(["--config", extra_dir])
+        else:
+            logger.debug("semgrep.extra_config_dir_missing", path=extra_dir)
 
-    cmd = ["opengrep", *config_args, "--json", *changed_files]
+    exclude_args: list[str] = []
+    for rule_id in exclude_rules or []:
+        exclude_args.extend(["--exclude-rule", rule_id])
+
+    cmd = ["opengrep", *config_args, *exclude_args, "--json", *changed_files]
     try:
         result = subprocess.run(
             cmd,

--- a/src/eedom/plugins/semgrep.py
+++ b/src/eedom/plugins/semgrep.py
@@ -45,8 +45,23 @@ class SemgrepPlugin(ScannerPlugin):
         return any(Path(f).suffix in _CODE_EXTS for f in files)
 
     def run(self, files: list[str], repo_path: Path) -> PluginResult:
+        from eedom.core.repo_config import RepoConfig, load_repo_config
+
+        repo_config: RepoConfig
         try:
-            data = _run(files, str(repo_path), timeout=120)
+            repo_config = load_repo_config(repo_path)
+        except (ValueError, OSError):
+            repo_config = RepoConfig()
+        sg = repo_config.plugins.semgrep
+
+        try:
+            data = _run(
+                files,
+                str(repo_path),
+                timeout=120,
+                extra_config_dirs=sg.extra_config_dirs,
+                exclude_rules=sg.exclude_rules,
+            )
         except Exception as exc:
             return PluginResult(plugin_name=self.name, error=str(exc))
 

--- a/tests/unit/test_opengrep_runner.py
+++ b/tests/unit/test_opengrep_runner.py
@@ -103,3 +103,39 @@ class TestExcludeRules:
         run_semgrep(["app.py"], "/workspace")
         cmd = mock_run.call_args[0][0]
         assert "--exclude-rule" not in cmd
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_exclude_rules_post_filter_prefixed_ids(self, mock_run):
+        """Local-rule ids get dotted path prefixes (e.g. policies.semgrep.X);
+        post-filter must drop them when the bare rule id is excluded."""
+        mock_run.return_value.stdout = (
+            '{"results": ['
+            '{"check_id": "policies.semgrep.path-traversal", "path": "a.py"},'
+            '{"check_id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true", "path": "a.py"},'
+            '{"check_id": "policies.semgrep.sql-injection", "path": "a.py"}'
+            '], "errors": []}'
+        )
+        mock_run.return_value.returncode = 0
+        data = run_semgrep(["a.py"], "/workspace", exclude_rules=["path-traversal"])
+        ids = [r["check_id"] for r in data["results"]]
+        assert "policies.semgrep.path-traversal" not in ids
+        assert "policies.semgrep.sql-injection" in ids
+        assert any("subprocess-shell-true" in i for i in ids)
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_exclude_rules_post_filter_exact_and_suffix(self, mock_run):
+        """Exclusion matches the full check_id or its trailing dotted segment,
+        never a bare substring (excluding 'traversal' must not drop path-traversal)."""
+        mock_run.return_value.stdout = (
+            '{"results": ['
+            '{"check_id": "policies.semgrep.path-traversal", "path": "a.py"},'
+            '{"check_id": "unsafe-deserialization", "path": "a.py"}'
+            '], "errors": []}'
+        )
+        mock_run.return_value.returncode = 0
+        data = run_semgrep(
+            ["a.py"], "/workspace", exclude_rules=["traversal", "unsafe-deserialization"]
+        )
+        ids = [r["check_id"] for r in data["results"]]
+        assert "policies.semgrep.path-traversal" in ids  # substring must NOT match
+        assert "unsafe-deserialization" not in ids  # exact bare id matches

--- a/tests/unit/test_opengrep_runner.py
+++ b/tests/unit/test_opengrep_runner.py
@@ -52,3 +52,54 @@ class TestRegistryAndLocalRules:
         cmd = mock_run.call_args[0][0]
         config_values = [cmd[i + 1] for i, v in enumerate(cmd) if v == "--config"]
         assert any("policies/semgrep" in v for v in config_values)
+
+
+class TestExtraConfigDirs:
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_extra_config_dirs_added(self, mock_run, tmp_path):
+        """Extra config dirs from .eagle-eyed-dom.yaml appear as --config args."""
+        mock_run.return_value.stdout = '{"results": [], "errors": []}'
+        mock_run.return_value.returncode = 0
+        extra = tmp_path / "community-rules"
+        extra.mkdir()
+        (extra / "rule.yaml").touch()
+        run_semgrep(["app.py"], "/workspace", extra_config_dirs=[str(extra)])
+        cmd = mock_run.call_args[0][0]
+        config_values = [cmd[i + 1] for i, v in enumerate(cmd) if v == "--config"]
+        assert str(extra) in config_values
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_extra_config_dir_missing_is_skipped(self, mock_run):
+        """Non-existent extra config dirs are silently skipped."""
+        mock_run.return_value.stdout = '{"results": [], "errors": []}'
+        mock_run.return_value.returncode = 0
+        run_semgrep(["app.py"], "/workspace", extra_config_dirs=["/no/such/dir"])
+        cmd = mock_run.call_args[0][0]
+        config_values = [cmd[i + 1] for i, v in enumerate(cmd) if v == "--config"]
+        assert "/no/such/dir" not in config_values
+
+
+class TestExcludeRules:
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_exclude_rules_passed_to_cli(self, mock_run):
+        """Excluded rule IDs are passed as --exclude-rule flags."""
+        mock_run.return_value.stdout = '{"results": [], "errors": []}'
+        mock_run.return_value.returncode = 0
+        run_semgrep(
+            ["app.py"],
+            "/workspace",
+            exclude_rules=["path-traversal", "unvalidated-path-construction"],
+        )
+        cmd = mock_run.call_args[0][0]
+        exclude_values = [cmd[i + 1] for i, v in enumerate(cmd) if v == "--exclude-rule"]
+        assert "path-traversal" in exclude_values
+        assert "unvalidated-path-construction" in exclude_values
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_no_exclude_rules_by_default(self, mock_run):
+        """No --exclude-rule flags when list is empty/None."""
+        mock_run.return_value.stdout = '{"results": [], "errors": []}'
+        mock_run.return_value.returncode = 0
+        run_semgrep(["app.py"], "/workspace")
+        cmd = mock_run.call_args[0][0]
+        assert "--exclude-rule" not in cmd

--- a/tests/unit/test_repo_config.py
+++ b/tests/unit/test_repo_config.py
@@ -151,3 +151,37 @@ class TestRepoConfigModel:
         )
         assert rc.plugins.disabled == ["cspell"]
         assert rc.thresholds["semgrep"] == {"level": "error"}
+
+
+class TestSemgrepConfig:
+    def test_default_semgrep_config(self) -> None:
+        """Default SemgrepConfig has empty lists."""
+        rc = RepoConfig()
+        assert rc.plugins.semgrep.extra_config_dirs == []
+        assert rc.plugins.semgrep.exclude_rules == []
+
+    def test_semgrep_config_from_yaml(self, tmp_path: Path) -> None:
+        """Semgrep tuning keys are parsed from .eagle-eyed-dom.yaml."""
+        _write_config(
+            tmp_path,
+            {
+                "plugins": {
+                    "enabled": ["semgrep"],
+                    "semgrep": {
+                        "extra_config_dirs": ["/opt/rules/community"],
+                        "exclude_rules": ["path-traversal", "magic-number"],
+                    },
+                }
+            },
+        )
+        config = load_repo_config(tmp_path)
+        assert config.plugins.semgrep.extra_config_dirs == ["/opt/rules/community"]
+        assert "path-traversal" in config.plugins.semgrep.exclude_rules
+        assert "magic-number" in config.plugins.semgrep.exclude_rules
+
+    def test_semgrep_config_absent_defaults(self, tmp_path: Path) -> None:
+        """Missing semgrep key produces empty defaults, not an error."""
+        _write_config(tmp_path, {"plugins": {"enabled": ["semgrep"]}})
+        config = load_repo_config(tmp_path)
+        assert config.plugins.semgrep.extra_config_dirs == []
+        assert config.plugins.semgrep.exclude_rules == []


### PR DESCRIPTION
Extends the semgrep/opengrep runner to accept:
- extra_config_dirs: additional local rule directories (--config)
- exclude_rules: rule IDs to skip (--exclude-rule, natively supported by opengrep)

Both read from .eagle-eyed-dom.yaml plugins.semgrep section. Non-existent extra dirs silently skipped with debug log. 37 unit tests green (8 runner + 18 repo_config + 11 merge).

Refs gitrdunhq/datum#96