### PR TITLE
fix: CodeGraph DX — graph db location (#391), non-empty finding messages (#390), path normalization + per-file API (#387)

### DIFF
--- a/docs/plugins/quality.md
+++ b/docs/plugins/quality.md
@@ -29,6 +29,19 @@ Reviewing a repo never writes into the repo itself. The code graph SQLite db is 
 
 `eedom query` reads the same resolved location by default; pass `--db` to point elsewhere.
 
+### Path conventions (library API)
+
+`CodeGraph` stores `symbols.file` and `file_metadata.path` RELATIVE to the repo root. Once a repo root is known (constructor `repo_root=` or inferred by `index_directory()`), every public method — `run_checks`, `run_checks_for_file`, `needs_rebuild`, `rebuild_file`, `rebuild_incremental`, `purge_deleted_files` — accepts either repo-relative or absolute paths and normalizes at the API boundary. Absolute paths outside the repo root raise `ValueError`.
+
+For per-file queries use the convenience API:
+
+```python
+graph = CodeGraph(db_path=db, repo_root="/path/to/repo")
+findings = graph.run_checks_for_file("/path/to/repo/src/mod.py")  # or "src/mod.py"
+```
+
+Without a repo root (ad hoc `CodeGraph()`), paths are stored and matched exactly as given.
+
 ---
 
 ## complexity

--- a/docs/plugins/quality.md
+++ b/docs/plugins/quality.md
@@ -18,6 +18,17 @@ Counts how many symbols depend on a given function, surfacing the change surface
 
 Even advisory, this tells a reviewer whether a one-line change touches 2 callers or 40.
 
+### Graph database location
+
+Reviewing a repo never writes into the repo itself. The code graph SQLite db is resolved in this order:
+
+1. `EEDOM_GRAPH_DB` environment variable — explicit override.
+2. `thresholds.blast-radius.graph_db` in `.eagle-eyed-dom.yaml` — relative paths resolve against the repo root.
+3. A pre-existing legacy `<repo>/.eedom/code_graph.sqlite` keeps being used.
+4. Default: `$XDG_CACHE_HOME/eedom/graphs/<repo-hash>/code_graph.sqlite` (`~/.cache` when `XDG_CACHE_HOME` is unset).
+
+`eedom query` reads the same resolved location by default; pass `--db` to point elsewhere.
+
 ---
 
 ## complexity

--- a/src/eedom/cli/query_cmd.py
+++ b/src/eedom/cli/query_cmd.py
@@ -14,11 +14,14 @@ import click
     "--db",
     "db_path",
     type=click.Path(),
-    default=".eedom/graph.db",
-    show_default=True,
-    help="Path to the CodeGraph SQLite database.",
+    default=None,
+    help=(
+        "Path to the CodeGraph SQLite database. Defaults to the db "
+        "'eedom review' maintains for the current directory (user cache dir, "
+        "or a legacy ./.eedom/code_graph.sqlite if present)."
+    ),
 )
-def query(question: str, db_path: str) -> None:
+def query(question: str, db_path: str | None) -> None:
     """Query the code graph using natural language.
 
     Examples:
@@ -30,8 +33,13 @@ def query(question: str, db_path: str) -> None:
       eedom query "are there circular imports?"
     """
     from eedom.core.nl_query import TEMPLATES, query_code
+    from eedom.plugins._runners.graph_builder import resolve_graph_db_path
 
-    db = Path(db_path)
+    if db_path is None:
+        candidates = [resolve_graph_db_path(Path.cwd()), Path(".eedom/graph.db")]
+        db = next((c for c in candidates if c.exists()), candidates[0])
+    else:
+        db = Path(db_path)
     if not db.exists():
         click.echo(f"Database not found: {db}", err=True)
         click.echo(

--- a/src/eedom/plugins/_runners/graph_builder.py
+++ b/src/eedom/plugins/_runners/graph_builder.py
@@ -106,6 +106,39 @@ CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id);
 """
 
+
+def _finding_message(check_name: str, description: str | None, finding: dict) -> str:
+    """Build a non-empty human-readable message for a check finding.
+
+    Base text is the check's description, falling back to the check name
+    (NOT NULL in the schema), so the result is never empty (issue #390).
+    Row context — subject symbol/files and metric columns — is appended
+    deterministically when present.
+    """
+    existing = str(finding.get("message") or "").strip()
+    if existing:
+        return existing
+    base = str(description or "").strip() or check_name
+    name = finding.get("name")
+    file = finding.get("file")
+    subject = ""
+    if name and name != file:
+        subject = str(name)
+    elif finding.get("file_a") and finding.get("file_b"):
+        subject = f"{finding['file_a']} <-> {finding['file_b']}"
+    metrics = [
+        f"{key}={finding[key]}"
+        for key in ("dependents", "calls_out", "depth", "import_count", "method_count")
+        if finding.get(key) is not None
+    ]
+    msg = base
+    if subject:
+        msg = f"{base}: {subject}"
+    if metrics:
+        msg = f"{msg} ({', '.join(metrics)})"
+    return msg
+
+
 _CHECKS_YAML = Path(__file__).parent / "checks.yaml"
 
 
@@ -195,14 +228,18 @@ class CodeGraph:
             try:
                 rows = self.conn.execute(query, changed_files).fetchall()
                 for row in rows:
-                    findings.append(
-                        {
-                            "check": check["name"],
-                            "severity": check["severity"],
-                            "description": check["description"],
-                            **dict(row),
-                        }
+                    finding = {
+                        "check": check["name"],
+                        "severity": check["severity"],
+                        "description": check["description"],
+                        **dict(row),
+                    }
+                    # Issue #390: every finding carries a non-empty,
+                    # human-readable message — consumers render it directly.
+                    finding["message"] = _finding_message(
+                        check["name"], check["description"], finding
                     )
+                    findings.append(finding)
             except sqlite3.Error as exc:
                 logger.debug("graph.check_failed", check=check["name"], error=str(exc))
         return findings

--- a/src/eedom/plugins/_runners/graph_builder.py
+++ b/src/eedom/plugins/_runners/graph_builder.py
@@ -152,12 +152,67 @@ def _load_builtin_checks() -> list[dict]:
 
 
 class CodeGraph:
-    def __init__(self, db_path: str = ":memory:", fan_out_limit: int = 8) -> None:
+    """SQLite-backed code knowledge graph.
+
+    Path convention (issue #387): ``symbols.file`` and ``file_metadata.path``
+    store paths RELATIVE to the repo root. Once a repo root is known — passed
+    to the constructor or inferred by :meth:`index_directory` — every public
+    method accepts either repo-relative or absolute paths and normalizes them
+    at the boundary. Absolute paths outside the repo root raise ``ValueError``.
+
+    Without a repo root (``CodeGraph()`` ad hoc usage) paths are stored and
+    matched exactly as given — callers must then be consistent about which
+    form they use.
+    """
+
+    def __init__(
+        self,
+        db_path: str = ":memory:",
+        fan_out_limit: int = 8,
+        repo_root: str | Path | None = None,
+    ) -> None:
         self.conn = sqlite3.connect(db_path)
         self.conn.row_factory = sqlite3.Row
         self.conn.executescript(_SCHEMA)
         self._fan_out_limit = fan_out_limit
+        self.repo_root: Path | None = Path(repo_root).resolve() if repo_root else None
         self._register_builtin_checks()
+
+    # ------------------------------------------------------------------
+    # Path normalization at the API boundary (issue #387)
+    # ------------------------------------------------------------------
+
+    def _storage_key(self, file_path: str | Path) -> str:
+        """Return the stored (repo-relative) form of *file_path*.
+
+        Absolute paths are relativized against ``repo_root``; absolute paths
+        outside the root are rejected with a clear error. Relative paths are
+        assumed repo-relative and returned unchanged. Without a repo root the
+        path passes through as given (legacy behavior).
+        """
+        p = Path(file_path)
+        if not p.is_absolute():
+            return str(file_path)
+        if self.repo_root is None:
+            return str(file_path)
+        try:
+            return str(p.resolve().relative_to(self.repo_root))
+        except ValueError:
+            raise ValueError(
+                f"Path {file_path} is outside the repo root {self.repo_root}; "
+                "pass a repo-relative path or an absolute path under the root."
+            ) from None
+
+    def _disk_path(self, file_path: str | Path) -> Path:
+        """Return the on-disk path for *file_path* (for stat/read).
+
+        Relative paths resolve against ``repo_root`` when known, otherwise
+        against the current working directory (legacy behavior).
+        """
+        p = Path(file_path)
+        if p.is_absolute() or self.repo_root is None:
+            return p
+        return self.repo_root / p
 
     def _register_builtin_checks(self) -> None:
         required = {"name", "query", "severity", "description"}
@@ -193,6 +248,14 @@ class CodeGraph:
             self._index_javascript(file_path, source)
 
     def index_directory(self, root: Path) -> int:
+        """Index every code file under *root*.
+
+        Symbols are stored with paths RELATIVE to *root*. Also records *root*
+        as the graph's repo root (when not already set), enabling absolute or
+        relative paths interchangeably on subsequent API calls (issue #387).
+        """
+        if self.repo_root is None:
+            self.repo_root = Path(root).resolve()
         count = 0
         for ext in ("*.py", "*.ts", "*.js", "*.tsx", "*.jsx"):
             for path in root.rglob(ext):
@@ -217,8 +280,17 @@ class CodeGraph:
         return count
 
     def run_checks(self, changed_files: list[str]) -> list[dict]:
+        """Run all registered checks scoped to *changed_files*.
+
+        Accepts repo-relative or absolute paths; both are normalized to the
+        stored repo-relative form when the repo root is known (issue #387).
+        Each returned finding dict carries check/severity/description, a
+        non-empty human-readable ``message`` (issue #390), and the row's
+        columns (typically ``name``/``file``/``line`` plus check metrics).
+        """
         if not changed_files:
             return []
+        changed_files = [self._storage_key(f) for f in changed_files]
         placeholders = ",".join("?" for _ in changed_files)
         checks = self.conn.execute("SELECT * FROM checks").fetchall()
         findings: list[dict] = []
@@ -243,6 +315,16 @@ class CodeGraph:
             except sqlite3.Error as exc:
                 logger.debug("graph.check_failed", check=check["name"], error=str(exc))
         return findings
+
+    def run_checks_for_file(self, file_path: str | Path) -> list[dict]:
+        """Run all registered checks scoped to a single file (issue #387).
+
+        Per-file convenience wrapper around :meth:`run_checks` — accepts a
+        repo-relative or absolute path and normalizes it to the stored form,
+        so library consumers never have to reverse-engineer the storage
+        convention from SQL.
+        """
+        return self.run_checks([str(file_path)])
 
     def blast_radius(self, symbol_name: str, max_depth: int = 3) -> list[dict]:
         results: list[dict] = []
@@ -520,43 +602,57 @@ class CodeGraph:
         return "real"
 
     def needs_rebuild(self, file_path: str) -> bool:
-        """Return True if file_path is new or has changed since last rebuild."""
+        """Return True if file_path is new or has changed since last rebuild.
+
+        Accepts a repo-relative or absolute path (issue #387): metadata is
+        looked up by the stored repo-relative key, while mtime/hash are
+        checked against the resolved on-disk path.
+        """
+        key = self._storage_key(file_path)
+        disk = self._disk_path(file_path)
         row = self.conn.execute(
             "SELECT mtime, content_hash FROM file_metadata WHERE path = ?",
-            (file_path,),
+            (key,),
         ).fetchone()
         if row is None:
             return True
         try:
-            stat = Path(file_path).stat()
+            stat = disk.stat()
             if abs(stat.st_mtime - row["mtime"]) > 0.001:
                 # mtime changed — confirm via content hash
-                return _hash_file(file_path) != row["content_hash"]
+                return _hash_file(str(disk)) != row["content_hash"]
             return False
         except FileNotFoundError:
             return True
 
     def rebuild_file(self, file_path: str) -> None:
-        """Delete old symbols/edges for file_path, re-parse from disk, update metadata."""
+        """Delete old symbols/edges for file_path, re-parse from disk, update metadata.
+
+        Accepts a repo-relative or absolute path (issue #387). Symbols and
+        metadata are stored under the repo-relative key; file contents are
+        read from the resolved on-disk path.
+        """
+        key = self._storage_key(file_path)
+        disk = self._disk_path(file_path)
         # Remove edges that involve symbols from this file
         self.conn.execute(
             "DELETE FROM edges"
             " WHERE source_id IN (SELECT id FROM symbols WHERE file = ?)"
             " OR target_id IN (SELECT id FROM symbols WHERE file = ?)",
-            (file_path, file_path),
+            (key, key),
         )
-        self.conn.execute("DELETE FROM symbols WHERE file = ?", (file_path,))
+        self.conn.execute("DELETE FROM symbols WHERE file = ?", (key,))
         self.conn.commit()
 
-        content = Path(file_path).read_text()
-        self.index_file(file_path, content)
+        content = disk.read_text()
+        self.index_file(key, content)
         self.conn.commit()
 
-        stat = Path(file_path).stat()
+        stat = disk.stat()
         content_hash = hashlib.sha256(content.encode()).hexdigest()
         self.conn.execute(
             "INSERT OR REPLACE INTO file_metadata (path, mtime, content_hash) VALUES (?, ?, ?)",
-            (file_path, stat.st_mtime, content_hash),
+            (key, stat.st_mtime, content_hash),
         )
         self.conn.commit()
 
@@ -570,11 +666,14 @@ class CodeGraph:
         list-membership purging destroyed every other tracked file's
         symbols (gitrdunhq/eedom#385). existing_files is retained for
         API compatibility but no longer consulted.
+
+        Stored keys are resolved via :meth:`_disk_path` (issue #387), so the
+        existence check is correct regardless of the caller's cwd.
         """
         tracked = self.conn.execute("SELECT path FROM file_metadata").fetchall()
         purged = 0
         for row in tracked:
-            if not Path(row["path"]).exists():
+            if not self._disk_path(row["path"]).exists():
                 self.conn.execute(
                     "DELETE FROM edges"
                     " WHERE source_id IN (SELECT id FROM symbols WHERE file = ?)"
@@ -589,7 +688,12 @@ class CodeGraph:
         return purged
 
     def rebuild_incremental(self, files: list[str]) -> int:
-        """Rebuild only changed files. Returns count of files actually rebuilt."""
+        """Rebuild only changed files. Returns count of files actually rebuilt.
+
+        *files* may be repo-relative or absolute paths (issue #387); each is
+        normalized at the boundary by :meth:`needs_rebuild` /
+        :meth:`rebuild_file` / :meth:`purge_deleted_files`.
+        """
         code_suffixes = {".py", ".ts", ".js", ".tsx", ".jsx"}
         code_files = [f for f in files if Path(f).suffix in code_suffixes]
         self.purge_deleted_files(code_files)

--- a/src/eedom/plugins/_runners/graph_builder.py
+++ b/src/eedom/plugins/_runners/graph_builder.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import os
 import re
 import sqlite3
 from pathlib import Path
@@ -15,6 +16,46 @@ from pathlib import Path
 import structlog
 
 logger = structlog.get_logger(__name__)
+
+_GRAPH_DB_FILENAME = "code_graph.sqlite"
+
+
+def default_graph_db_dir(repo_path: Path | str) -> Path:
+    """Return the per-repo cache directory for the graph database.
+
+    Defaults to ``$XDG_CACHE_HOME/eedom/graphs/<repo-hash>`` (falling back to
+    ``~/.cache`` when ``XDG_CACHE_HOME`` is unset).  The hash is derived from
+    the resolved absolute repo path so each reviewed repo gets its own db.
+    """
+    cache_root = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+    digest = hashlib.sha256(str(Path(repo_path).resolve()).encode()).hexdigest()[:16]
+    return cache_root / "eedom" / "graphs" / digest
+
+
+def resolve_graph_db_path(repo_path: Path | str, configured: str | None = None) -> Path:
+    """Resolve where the code graph SQLite db for *repo_path* lives.
+
+    Resolution order:
+
+    1. ``EEDOM_GRAPH_DB`` environment variable (explicit override).
+    2. *configured* — an explicit path from repo config
+       (``thresholds.blast-radius.graph_db`` in ``.eagle-eyed-dom.yaml``);
+       relative values are resolved against *repo_path*.
+    3. A pre-existing legacy ``<repo>/.eedom/code_graph.sqlite`` (the pre-0.3
+       layout) keeps being used so existing graphs are not orphaned.
+    4. Default: :func:`default_graph_db_dir`, i.e. the user cache dir —
+       reviewing a repo never writes into the repo itself (issue #391).
+    """
+    env_override = os.environ.get("EEDOM_GRAPH_DB")
+    if env_override:
+        return Path(env_override)
+    if configured:
+        p = Path(configured)
+        return p if p.is_absolute() else Path(repo_path) / p
+    legacy = Path(repo_path) / ".eedom" / _GRAPH_DB_FILENAME
+    if legacy.exists():
+        return legacy
+    return default_graph_db_dir(repo_path) / _GRAPH_DB_FILENAME
 
 
 def _hash_file(file_path: str) -> str:

--- a/src/eedom/plugins/blast_radius.py
+++ b/src/eedom/plugins/blast_radius.py
@@ -63,20 +63,16 @@ class BlastRadiusPlugin(ScannerPlugin):
             db_dir = Path(tempfile.mkdtemp(prefix="eedom-blast-radius-"))
         db_path = str(db_dir / db_name)
 
-        graph = CodeGraph(db_path=db_path, fan_out_limit=fan_out_limit)
+        # Issue #387: CodeGraph normalizes repo-relative/absolute paths at its
+        # API boundary once repo_root is known — no manual conversion needed.
+        graph = CodeGraph(db_path=db_path, fan_out_limit=fan_out_limit, repo_root=repo_path)
 
         if graph.stats()["symbols"] == 0:
             graph.index_directory(repo_path)
         else:
-            graph.rebuild_incremental(
-                [str(repo_path / f) if not Path(f).is_absolute() else f for f in files]
-            )
+            graph.rebuild_incremental(files)
 
-        changed = [
-            str(Path(f).relative_to(repo_path)) if Path(f).is_absolute() else f
-            for f in files
-            if Path(f).suffix in _CODE_EXTS
-        ]
+        changed = [f for f in files if Path(f).suffix in _CODE_EXTS]
 
         findings = graph.run_checks(changed)
         stats = graph.stats()

--- a/src/eedom/plugins/blast_radius.py
+++ b/src/eedom/plugins/blast_radius.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import structlog
 
 from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
-from eedom.plugins._runners.graph_builder import CodeGraph
+from eedom.plugins._runners.graph_builder import CodeGraph, resolve_graph_db_path
 
 logger = structlog.get_logger(__name__)
 
@@ -37,25 +37,31 @@ class BlastRadiusPlugin(ScannerPlugin):
         return any(Path(f).suffix in _CODE_EXTS for f in files)
 
     def run(self, files: list[str], repo_path: Path) -> PluginResult:
-        db_dir = repo_path / ".eedom"
-        try:
-            db_dir.mkdir(exist_ok=True)
-            test_file = db_dir / ".write_test"
-            test_file.touch()
-            test_file.unlink()
-        except OSError:
-            logger.warning(
-                "blast-radius: repo_path not writable, using temp dir",
-                repo_path=str(repo_path),
-            )
-            db_dir = Path(tempfile.mkdtemp(prefix="eedom-blast-radius-"))
-        db_path = str(db_dir / "code_graph.sqlite")
-
         from eedom.core.repo_config import load_repo_config
 
         config = load_repo_config(repo_path)
         br_thresholds = config.thresholds.get("blast-radius", {})
         fan_out_limit = br_thresholds.get("fan_out_limit", 8)
+
+        # Issue #391: the graph db defaults to the user cache dir — reviewing
+        # a repo must not dirty it. Explicit overrides (EEDOM_GRAPH_DB env var
+        # or `thresholds.blast-radius.graph_db` in .eagle-eyed-dom.yaml) and
+        # pre-existing legacy in-repo dbs are honored by the resolver.
+        resolved_db = resolve_graph_db_path(repo_path, br_thresholds.get("graph_db"))
+        db_dir = resolved_db.parent
+        db_name = resolved_db.name
+        try:
+            db_dir.mkdir(parents=True, exist_ok=True)
+            test_file = db_dir / ".write_test"
+            test_file.touch()
+            test_file.unlink()
+        except OSError:
+            logger.warning(
+                "blast-radius: graph db dir not writable, using temp dir",
+                db_dir=str(db_dir),
+            )
+            db_dir = Path(tempfile.mkdtemp(prefix="eedom-blast-radius-"))
+        db_path = str(db_dir / db_name)
 
         graph = CodeGraph(db_path=db_path, fan_out_limit=fan_out_limit)
 

--- a/tests/unit/test_blast_radius.py
+++ b/tests/unit/test_blast_radius.py
@@ -272,6 +272,70 @@ class TestCodeGraph:
         assert len(names) >= 8
 
 
+class TestFindingMessages:
+    """Issue #390 — every blast-radius finding carries a non-empty message."""
+
+    def _graph_with_findings(self):
+        g = CodeGraph()
+        g.index_file("scanner.py", SAMPLE_PYTHON)
+        # A second module importing scanner-ish things to trigger more checks.
+        g.index_file(
+            "test_calculator.py",
+            textwrap.dedent("""\
+                def add(a, b):
+                    return a + b
+
+                def test_addition():
+                    assert add(1, 2) == 3
+
+                def test_subtraction():
+                    assert add(5, -2) == 3
+            """),
+        )
+        g.conn.commit()
+        return g
+
+    def test_run_checks_findings_all_have_nonempty_message(self):
+        g = self._graph_with_findings()
+        findings = g.run_checks(["scanner.py", "test_calculator.py"])
+        assert findings, "fixture must trigger at least one finding"
+        for f in findings:
+            assert f.get("message", "").strip(), f"empty message in finding: {f}"
+
+    def test_custom_check_with_empty_description_still_has_message(self):
+        g = self._graph_with_findings()
+        g.register_check(
+            name="every_function",
+            query="SELECT s.name, s.file, s.line FROM symbols s"
+            " WHERE s.file IN ({changed_files}) AND s.kind = 'function'",
+        )  # description defaults to "" — message must not be empty
+        findings = g.run_checks(["scanner.py"])
+        custom = [f for f in findings if f["check"] == "every_function"]
+        assert custom, "custom check must produce findings"
+        for f in custom:
+            assert f.get("message", "").strip(), f"empty message in finding: {f}"
+
+    def test_plugin_findings_normalize_to_nonempty_messages(self, tmp_path, monkeypatch):
+        """End-to-end: PluginFinding.message is never empty for blast-radius."""
+        from eedom.core.registry import _normalize_findings
+
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "test_calculator.py").write_text(
+            "def add(a, b):\n"
+            "    return a + b\n\n"
+            "def test_addition():\n"
+            "    assert add(1, 2) == 3\n"
+        )
+        result = BlastRadiusPlugin().run(["test_calculator.py"], repo)
+        assert result.error == ""
+        findings = _normalize_findings(result.findings)
+        assert findings, "fixture must trigger at least one finding (orphan test funcs)"
+        for f in findings:
+            assert f.message.strip(), f"empty message in finding: {f.to_dict()}"
+
+
 class TestGraphDbLocation:
     """Issue #391 — the graph db must not pollute the reviewed repo by default."""
 

--- a/tests/unit/test_blast_radius.py
+++ b/tests/unit/test_blast_radius.py
@@ -272,6 +272,76 @@ class TestCodeGraph:
         assert len(names) >= 8
 
 
+class TestGraphDbLocation:
+    """Issue #391 — the graph db must not pollute the reviewed repo by default."""
+
+    def _make_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "mod.py").write_text("def hello():\n    return 1\n")
+        return repo
+
+    def test_default_db_not_written_into_target_repo(self, tmp_path, monkeypatch):
+        """Default graph db lives in the XDG cache dir, not in the reviewed repo."""
+        cache = tmp_path / "cache"
+        monkeypatch.setenv("XDG_CACHE_HOME", str(cache))
+        monkeypatch.delenv("EEDOM_GRAPH_DB", raising=False)
+        repo = self._make_repo(tmp_path)
+
+        result = BlastRadiusPlugin().run(["mod.py"], repo)
+
+        assert result.error == ""
+        assert not (repo / ".eedom").exists(), "review must not dirty the target repo"
+        dbs = list((cache / "eedom").rglob("code_graph.sqlite"))
+        assert len(dbs) == 1, f"expected graph db under XDG cache, found: {dbs}"
+
+    def test_env_var_overrides_db_location(self, tmp_path, monkeypatch):
+        """EEDOM_GRAPH_DB points the graph db at an explicit path."""
+        custom = tmp_path / "custom" / "graph.sqlite"
+        monkeypatch.setenv("EEDOM_GRAPH_DB", str(custom))
+        repo = self._make_repo(tmp_path)
+
+        result = BlastRadiusPlugin().run(["mod.py"], repo)
+
+        assert result.error == ""
+        assert custom.exists()
+        assert not (repo / ".eedom").exists()
+
+    def test_config_graph_db_honored(self, tmp_path, monkeypatch):
+        """A repo config that explicitly asks for an in-repo path keeps working."""
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+        monkeypatch.delenv("EEDOM_GRAPH_DB", raising=False)
+        repo = self._make_repo(tmp_path)
+        (repo / ".eagle-eyed-dom.yaml").write_text(
+            "thresholds:\n  blast-radius:\n    graph_db: .eedom/code_graph.sqlite\n"
+        )
+
+        result = BlastRadiusPlugin().run(["mod.py"], repo)
+
+        assert result.error == ""
+        assert (repo / ".eedom" / "code_graph.sqlite").exists()
+
+    def test_legacy_in_repo_db_is_reused(self, tmp_path, monkeypatch):
+        """An existing .eedom/code_graph.sqlite (pre-#391 layout) keeps being used."""
+        cache = tmp_path / "cache"
+        monkeypatch.setenv("XDG_CACHE_HOME", str(cache))
+        monkeypatch.delenv("EEDOM_GRAPH_DB", raising=False)
+        repo = self._make_repo(tmp_path)
+        legacy = repo / ".eedom" / "code_graph.sqlite"
+        legacy.parent.mkdir()
+        g = CodeGraph(db_path=str(legacy))
+        g.conn.close()
+
+        result = BlastRadiusPlugin().run(["mod.py"], repo)
+
+        assert result.error == ""
+        # Legacy db got the symbols; no second db materialized in the cache.
+        g2 = CodeGraph(db_path=str(legacy))
+        assert g2.stats()["symbols"] > 0
+        g2.conn.close()
+        assert list((cache / "eedom").rglob("*.sqlite")) == []
+
+
 class TestBlastRadiusPluginReadOnly:
     def test_run_falls_back_to_temp_dir_on_read_only_fs(self, tmp_path):
         """blast-radius should not crash when repo_path is read-only."""

--- a/tests/unit/test_graph_builder.py
+++ b/tests/unit/test_graph_builder.py
@@ -337,6 +337,88 @@ class TestPurgeDeletedFiles:
         assert "alpha" in names
 
 
+class TestPathNormalization:
+    """Issue #387 — CodeGraph normalizes paths at the API boundary.
+
+    Convention: symbols/file_metadata store paths RELATIVE to the repo root.
+    Every public method accepts either repo-relative or absolute paths once a
+    repo root is known (constructor arg or index_directory), and absolute
+    paths outside the root are rejected loudly.
+    """
+
+    def _build(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "a.py").write_text(SAMPLE_A)
+        (repo / "b.py").write_text(SAMPLE_B)
+        g = CodeGraph(db_path=str(tmp_path / "graph.sqlite"))
+        g.index_directory(repo)
+        return repo, g
+
+    def test_run_checks_accepts_absolute_paths(self, tmp_path):
+        repo, g = self._build(tmp_path)
+        rel = g.run_checks(["a.py"])
+        absolute = g.run_checks([str(repo / "a.py")])
+        assert rel, "relative path must produce findings (orphan alpha/beta)"
+        assert absolute == rel, "absolute path must match the same stored rows"
+
+    def test_run_checks_for_file_accepts_both_forms(self, tmp_path):
+        repo, g = self._build(tmp_path)
+        rel = g.run_checks_for_file("a.py")
+        absolute = g.run_checks_for_file(str(repo / "a.py"))
+        assert rel
+        assert absolute == rel
+
+    def test_rebuild_stores_relative_paths_no_duplicate_spellings(self, tmp_path):
+        repo, g = self._build(tmp_path)
+        (repo / "a.py").write_text(SAMPLE_A_MODIFIED)
+        os.utime(repo / "a.py", (time.time() + 2, time.time() + 2))
+
+        g.rebuild_incremental([str(repo / "a.py"), str(repo / "b.py")])
+
+        files = {
+            r["file"]
+            for r in g.conn.execute("SELECT DISTINCT file FROM symbols").fetchall()
+            if r["file"].endswith(".py")
+        }
+        assert files == {"a.py", "b.py"}, f"expected only relative spellings, got: {files}"
+        # And the rebuilt content must be queryable via the relative form.
+        findings = g.run_checks(["a.py"])
+        names = {f.get("name") for f in findings}
+        assert "epsilon" in names
+
+    def test_needs_rebuild_accepts_relative_path(self, tmp_path):
+        repo, g = self._build(tmp_path)
+        g.rebuild_incremental(["a.py"])
+        assert g.needs_rebuild("a.py") is False
+        assert g.needs_rebuild(str(repo / "a.py")) is False
+
+    def test_absolute_path_outside_root_rejected_loudly(self, tmp_path):
+        repo, g = self._build(tmp_path)
+        outside = tmp_path / "elsewhere" / "x.py"
+        with pytest.raises(ValueError, match="repo root"):
+            g.run_checks([str(outside)])
+
+    def test_constructor_repo_root(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "a.py").write_text(SAMPLE_A)
+        g = CodeGraph(db_path=str(tmp_path / "g.sqlite"), repo_root=repo)
+        g.rebuild_incremental([str(repo / "a.py")])
+        row = g.conn.execute("SELECT path FROM file_metadata").fetchone()
+        assert row["path"] == "a.py", "metadata must use the repo-relative key"
+        assert g.run_checks_for_file(str(repo / "a.py"))
+
+    def test_no_repo_root_keeps_legacy_behavior(self, tmp_path):
+        """Without a known root, paths are stored exactly as given."""
+        py_file = tmp_path / "module.py"
+        py_file.write_text(SAMPLE_A)
+        g = CodeGraph()
+        g.rebuild_file(str(py_file))
+        row = g.conn.execute("SELECT path FROM file_metadata").fetchone()
+        assert row["path"] == str(py_file)
+
+
 class TestImportEdgePathTraversal:
     """_add_import_edge must reject paths that could escape the indexed directory."""
 

--- a/tests/unit/test_graph_builder.py
+++ b/tests/unit/test_graph_builder.py
@@ -437,6 +437,7 @@ class TestBlastRadiusPersistence:
         """BlastRadiusPlugin reads db_path from config and passes it to CodeGraph."""
         from eedom.plugins.blast_radius import BlastRadiusPlugin
 
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
         plugin = BlastRadiusPlugin()
         # The plugin's run() should not crash when called with a tmp repo_path
         # Create a minimal Python file so indexing succeeds


### PR DESCRIPTION
Closes #391, closes #390, closes #387.

Three fixes in the CodeGraph/blast-radius cluster, found while embedding eedom into the datum TDD pipeline:

- **#391** — `eedom review` no longer writes `.eedom/code_graph.sqlite` into the reviewed repo. Resolution order: `EEDOM_GRAPH_DB` env → `thresholds.blast-radius.graph_db` in `.eagle-eyed-dom.yaml` → pre-existing legacy path reused → `$XDG_CACHE_HOME/eedom/graphs/<repo-hash>/`. Also points `eedom query` at the same resolver (its old default never matched what review wrote).
- **#390** — every code-graph finding now carries a non-empty message (description → check-name fallback, with subject/metric context). Consumers reading `finding["message"]` no longer get blanks.
- **#387** — `CodeGraph` accepts repo-relative or absolute paths on all public methods, normalized at the boundary; out-of-root absolute paths raise `ValueError`. Adds `run_checks_for_file()`. Fixes a real duplicate-symbol-spelling bug in `rebuild_file` with absolute paths. Convention documented.

TDD throughout (14 new tests, RED confirmed per fix). Full suite: 2132 passed; 3 pre-existing `test_dockerfile.py` host-environment failures reproduce identically on the base commit.