### PR TITLE
fix(gate): fail closed when opengrep aborts (#396)

### DIFF
--- a/src/eedom/plugins/_runners/semgrep_runner.py
+++ b/src/eedom/plugins/_runners/semgrep_runner.py
@@ -51,6 +51,27 @@ def detect_rulesets(changed_files: list[str]) -> list[str]:
     return rulesets
 
 
+def _abort_detail(data: dict, returncode: int) -> str | None:
+    """Return failure detail when opengrep aborted the scan, else None.
+
+    Opengrep can abort the ENTIRE scan (e.g. one broken symlink in the
+    target list) while still printing valid JSON: empty ``results`` plus
+    ``level=error`` entries, exit code >= 2. Treating that as a clean scan
+    is fail-open (#396) — the caller must see a scanner error instead.
+    """
+    errors = data.get("errors") or []
+    fatal_msgs = [
+        str(e.get("message") or "unknown error")
+        for e in errors
+        if isinstance(e, dict) and e.get("level") == "error"
+    ]
+    if returncode >= 2:
+        return fatal_msgs[0] if fatal_msgs else f"exit code {returncode}"
+    if not data.get("results") and fatal_msgs:
+        return fatal_msgs[0]
+    return None
+
+
 def _is_excluded(check_id: str, exclude_rules: list[str]) -> bool:
     """True when *check_id* matches an excluded rule id.
 
@@ -101,6 +122,17 @@ def run_semgrep(
         )
         if result.stdout:
             data = json.loads(result.stdout)
+            abort_detail = _abort_detail(data, result.returncode)
+            if abort_detail is not None:
+                from eedom.core.errors import ErrorCode, error_msg
+
+                msg = error_msg(ErrorCode.SCANNER_DEGRADED, "opengrep", detail=abort_detail)
+                logger.warning(
+                    "opengrep.scan_aborted",
+                    error=msg,
+                    exit_code=result.returncode,
+                )
+                return {"results": [], "errors": [{"message": msg}], "status": "error"}
             if exclude_rules and isinstance(data.get("results"), list):
                 # Post-filter: --exclude-rule only matches exact ids, but
                 # opengrep prefixes local-rule ids with their dotted path

--- a/tests/unit/test_opengrep_runner.py
+++ b/tests/unit/test_opengrep_runner.py
@@ -79,6 +79,81 @@ class TestExtraConfigDirs:
         assert "/no/such/dir" not in config_values
 
 
+class TestFailClosedOnAbort:
+    """Issue #396 — opengrep aborting the whole scan must fail CLOSED.
+
+    When opengrep exits with code >= 2 it can still print valid JSON with
+    empty results and level=error entries (e.g. one broken symlink in the
+    target list aborts the entire scan). That must never look like a clean
+    scan to the caller.
+    """
+
+    _ABORT_STDOUT = (
+        '{"results": [], "errors": [{"code": 2, "level": "error", '
+        '"type": "SemgrepError", '
+        '"message": "File not found: .antigravitycli/dead.json"}]}'
+    )
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_abort_with_fatal_exit_code_sets_status_error(self, mock_run):
+        """returncode 2 + empty results + level=error -> status error, never clean."""
+        mock_run.return_value.stdout = self._ABORT_STDOUT
+        mock_run.return_value.returncode = 2
+        data = run_semgrep(["app.py"], "/workspace")
+        assert data.get("status") == "error"
+        assert data["results"] == []
+        assert data["errors"], "fail-closed result must carry an error entry"
+        assert "File not found" in data["errors"][0]["message"]
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_fatal_exit_code_without_error_entries_sets_status_error(self, mock_run):
+        """returncode >= 2 fails closed even when the JSON errors list is empty."""
+        mock_run.return_value.stdout = '{"results": [], "errors": []}'
+        mock_run.return_value.returncode = 2
+        data = run_semgrep(["app.py"], "/workspace")
+        assert data.get("status") == "error"
+        assert data["errors"], "fail-closed result must carry an error entry"
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_zero_results_with_fatal_errors_sets_status_error(self, mock_run):
+        """Empty results + level=error entries fail closed even if exit code is 0."""
+        mock_run.return_value.stdout = self._ABORT_STDOUT
+        mock_run.return_value.returncode = 0
+        data = run_semgrep(["app.py"], "/workspace")
+        assert data.get("status") == "error"
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_clean_scan_stays_clean(self, mock_run):
+        """No findings, no errors, exit 0 -> genuinely clean, no status injected."""
+        mock_run.return_value.stdout = '{"results": [], "errors": []}'
+        mock_run.return_value.returncode = 0
+        data = run_semgrep(["app.py"], "/workspace")
+        assert data.get("status") is None
+        assert data["results"] == []
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_warn_level_errors_with_zero_results_stay_clean(self, mock_run):
+        """Non-fatal (level=warn) errors with zero results are not an abort."""
+        mock_run.return_value.stdout = (
+            '{"results": [], "errors": [{"level": "warn", "message": "skipped file"}]}'
+        )
+        mock_run.return_value.returncode = 0
+        data = run_semgrep(["app.py"], "/workspace")
+        assert data.get("status") is None
+
+    @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
+    def test_partial_scan_with_findings_keeps_findings(self, mock_run):
+        """Per-file level=error entries alongside real findings: scan ran, keep results."""
+        mock_run.return_value.stdout = (
+            '{"results": [{"check_id": "rule-x", "path": "a.py"}], '
+            '"errors": [{"level": "error", "message": "parse error: b.py"}]}'
+        )
+        mock_run.return_value.returncode = 0
+        data = run_semgrep(["app.py"], "/workspace")
+        assert data.get("status") is None
+        assert len(data["results"]) == 1
+
+
 class TestExcludeRules:
     @patch("eedom.plugins._runners.semgrep_runner.subprocess.run")
     def test_exclude_rules_passed_to_cli(self, mock_run):


### PR DESCRIPTION
## Fail-open risk

When opengrep aborts the ENTIRE scan (e.g. one broken symlink in the target list), it exits with code >= 2 but still prints valid JSON: `{"results": [], "errors": [{"level": "error", ...}]}`. `run_semgrep` returned that dict as-is (stdout non-empty, JSON parsed fine), and `SemgrepPlugin.run()` only checks the runner-injected `status` field — never set on this path. Result: 0 findings, no error, verdict **clear**, even though zero rules ran on zero files. Observed in the wild on the datum repo: one stale broken symlink silently disabled the entire semgrep plugin (clear vs 891 raw findings after excluding the symlink).

## The fix

`run_semgrep` now detects the abort and fails CLOSED:

- `returncode >= 2`, **or**
- zero `results` with `level=error` entries in `errors`

→ returns `{"results": [], "errors": [{"message": "opengrep scanner degraded: <detail>"}], "status": "error"}` (via `ErrorCode.SCANNER_DEGRADED`) and logs `opengrep.scan_aborted`. The plugin's existing `status == "error"` path then reports `scanner degraded: ...` instead of a clean result.

Negative paths preserved (regression-tested):

- clean scan (no findings, no errors, exit 0) stays clean
- `level=warn` errors with zero results are not an abort
- partial scan (per-file parse errors alongside real findings) keeps its findings

## Tests

TDD red/green: 6 new tests in `tests/unit/test_opengrep_runner.py` (`TestFailClosedOnAbort`) — the 3 fail-closed cases fail against the old code, pass with the fix. Full unit suite in container: 2150 passed, 0 failed.

User-approved fix for #396.

Note: the deployed v0.2.8 binary is skewed from source; this fix takes effect on the next binary rebuild.

Closes #396
