### PR TITLE
feat: detect-then-enrich — language-agnostic CPD + cross-cutting finding enrichment (ADR-006)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -25,6 +25,7 @@ Eagle Eyed Dom — fully deterministic dependency, security, and code review for
 | OPA Rego policy rules | 6 (4 deny, 2 warn) |
 | NL query templates | 12 |
 | Copilot agent tools | 6 |
+| Finding enrichers | 2 (enclosing-symbol, code-graph) |
 | CLI commands | 6 |
 | Output formats | 4 |
 | Supported ecosystems (SBOM) | 18 |
@@ -274,6 +275,7 @@ File: `core/nl_query.py`. Keyword-matched SQL queries against the code graph. No
 | Capability | File | Description |
 |------------|------|-------------|
 | Parallel scanning | `core/orchestrator.py` | ThreadPoolExecutor with combined wall-clock timeout. |
+| Detect-then-enrich | `core/enrich.py`, `core/enrichment.py` | Post-detection pass (ADR-006): every plugin finding is decorated with deterministic context in `metadata['enrichment']` — enclosing symbol (`detectors` enricher) + code-graph blast radius (`plugins` enricher). Sequential, fail-open, time-bounded (`enrichment_timeout`); verdict-independent. Pluggable via the `ENRICHERS` registry. |
 | Cross-scanner dedup | `core/normalizer.py` | Highest severity wins per (advisory_id, category, package, version). |
 | Evidence chain | `core/seal.py` | Blockchain-style SHA-256 seals. manifest hash + previous seal → seal hash. `verify_seal()` detects tampering. |
 | Parquet audit log | `data/parquet_writer.py` | Append-only per-run audit trail. |

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -252,7 +252,7 @@ File: `core/nl_query.py`. Keyword-matched SQL queries against the code graph. No
 | Format | Where | Description |
 |--------|-------|-------------|
 | Markdown PR comment | `templates/comment.md.j2` | Verdict badge, health score (0-100), maintainability grade, per-plugin summary table, detailed sections. 65536 char max with truncation. |
-| SARIF v2.1.0 | `core/sarif.py` | GitHub Security tab integration. Severity-to-level mapping. Configurable max findings cap. |
+| SARIF v2.1.0 | `core/sarif.py` | GitHub Security tab integration. Severity-to-level mapping. Configurable max findings cap. Detect-then-enrich packets surface in each result's `properties.enrichment` (parity with the JSON report). |
 | Inline PR review | `core/pr_review.py` | SARIF → GitHub PR review. Hunk-aware line placement. REQUEST_CHANGES on reject, COMMENT on approve_with_constraints. Outside-diff findings in collapsed summary. |
 | JSON decision | CLI `--output-json` | Machine-readable decision with all findings, policy evaluation, and evidence. |
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -25,7 +25,7 @@ Eagle Eyed Dom — fully deterministic dependency, security, and code review for
 | OPA Rego policy rules | 6 (4 deny, 2 warn) |
 | NL query templates | 12 |
 | Copilot agent tools | 6 |
-| Finding enrichers | 2 (enclosing-symbol, code-graph) |
+| Finding enrichers | 3 (enclosing-symbol, code-graph, semgrep opt-in) |
 | CLI commands | 6 |
 | Output formats | 4 |
 | Supported ecosystems (SBOM) | 18 |
@@ -275,7 +275,7 @@ File: `core/nl_query.py`. Keyword-matched SQL queries against the code graph. No
 | Capability | File | Description |
 |------------|------|-------------|
 | Parallel scanning | `core/orchestrator.py` | ThreadPoolExecutor with combined wall-clock timeout. |
-| Detect-then-enrich | `core/enrich.py`, `core/enrichment.py` | Post-detection pass (ADR-006): every plugin finding is decorated with deterministic context in `metadata['enrichment']` — enclosing symbol (`detectors` enricher) + code-graph blast radius (`plugins` enricher). Sequential, fail-open, time-bounded (`enrichment_timeout`); verdict-independent. Pluggable via the `ENRICHERS` registry. |
+| Detect-then-enrich | `core/enrich.py`, `core/enrichment.py` | Post-detection pass (ADR-006): every plugin finding is decorated with deterministic context in `metadata['enrichment']` — enclosing symbol (`detectors` enricher), code-graph blast radius (`plugins` enricher), and opt-in nearby semgrep matches (`plugins` enricher). Sequential, fail-open, time-bounded (`enrichment_timeout`); verdict-independent. Pluggable via the `ENRICHERS` registry; also wired into the GATEKEEPER agent's `scan_code`. |
 | Cross-scanner dedup | `core/normalizer.py` | Highest severity wins per (advisory_id, category, package, version). |
 | Evidence chain | `core/seal.py` | Blockchain-style SHA-256 seals. manifest hash + previous seal → seal hash. `verify_seal()` detects tampering. |
 | Parquet audit log | `data/parquet_writer.py` | Append-only per-run audit trail. |

--- a/docs/adr/006-detect-then-enrich.md
+++ b/docs/adr/006-detect-then-enrich.md
@@ -1,0 +1,64 @@
+# ADR-006: Detect-then-Enrich — Deterministic Finding Enrichment
+
+## Status
+
+Accepted
+
+## Context
+
+eedom plugins **detect** findings (a vuln, a clone, a code smell) but emit them with thin context — a
+file, a line, a message. A downstream consumer (the GATEKEEPER agent, a human reviewer, or datum-ax)
+then has to *re-derive* the context it needs to act: what function is this in, who calls it, what's the
+blast radius, is there a related rule match, where should a duplicated block be consolidated. That
+re-derivation is expensive and, when an LLM does it, non-deterministic and token-hungry.
+
+eedom already owns the deterministic tools to answer those questions — the `CodeGraph`
+(`plugins/_runners/graph_builder.py`: symbols, edges, `blast_radius`), semgrep
+(`_runners/semgrep_runner.py`), and AST helpers (`detectors/ast_utils.py`). They were just never
+applied *to findings*.
+
+## Decision
+
+**Every finding is enriched after detection.** Detection and enrichment are two phases:
+
+1. **Detect** (unchanged): a plugin produces findings.
+2. **Enrich** (new): a deterministic pass attaches context to each finding — enclosing symbol, code-graph
+   blast radius, related semgrep matches, and any other available deterministic signal — stored under
+   `PluginFinding.metadata["enrichment"]` (additive; flows through `to_dict()` → JSON report and to the
+   agent). The output is a **pre-computed packet** so a downstream LLM/human reasons with minimal effort.
+
+**Enrichment is a shared service, not per-plugin code.** "Every plugin provides enrichment services"
+means every finding *is enriched* by a shared layer — an `EnricherPort` + core-owned `ENRICHERS`
+registry (mirroring the post-#404 ports pattern), with reusable adapters (`EnclosingSymbolEnricher`,
+`CodeGraphEnricher`, `SemgrepEnricher`) that reuse eedom's own tools. Plugins do **not** each
+re-implement CodeGraph/semgrep wiring — that would re-introduce the duplication the consolidation work
+is removing. A plugin may declare `enrichment` scope tags so the right enrichers apply, and may ship a
+bespoke enricher when it has special knowledge (the `cpd` plugin is the exemplar: clone groups enriched
+with enclosing symbol + blast radius + a suggested consolidation home).
+
+**Hard invariants (the gate stays a gate):**
+- Enrichment is **deterministic** (pure functions of repo content; same input → same enrichment).
+- Enrichment is **zero-LLM** and **never affects the verdict** — it only adds `metadata`. The decision
+  path remains reproducible (ADR-006 does not touch policy/OPA).
+- Enrichment is **fail-open and time-bounded**: an enricher error or timeout must never drop a finding,
+  change a verdict, or block the build. On failure the finding passes through unchanged.
+
+## Consequences
+
+- Findings carry actionable context by construction; the agent/human/datum-ax consume a deterministic
+  packet instead of re-deriving it (cheaper, reproducible — the "deterministic data → the LLM can tell
+  the story" principle).
+- New core seam: `EnricherPort` (`core/ports.py`), `ENRICHERS` registry (`core/registries.py`),
+  `ApplicationContext.enrichers` + `get_enrichers` accessor, one enrichment pass in `core/pipeline.py`
+  after `normalize_findings` and before policy. Adapters live in the tier of the tool they use
+  (`CodeGraphEnricher` in `plugins`, `EnclosingSymbolEnricher` in `detectors`) and self-register into
+  the core-owned registry, triggered by `composition.load_adapters` — same shape as every other port.
+- New deterministic query `CodeGraph.symbol_at(file, line)` (enclosing symbol for a location) — the one
+  missing graph primitive enrichment needs.
+- Cost: one cached `CodeGraph` build per run (already the `blast_radius.py` pattern); per-finding
+  enrichment is sub-10ms for graph/AST. Subprocess enrichers (semgrep) are opt-in / budgeted via the
+  canonical `ToolRunnerPort` timeouts.
+- Property-test targets (DPS-12): **Determinism** (same input → same enrichment), **Boundedness**
+  (within the enrichment timeout), **Availability/fail-open** (an enricher failure never drops a finding
+  or changes the verdict).
+</content>

--- a/scripts/dup-scan.sh
+++ b/scripts/dup-scan.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# dup-scan.sh — blended deterministic duplication / dead-code dogfood harness.
+#
+# Runs the consolidation toolchain over eedom's own source and writes a report
+# per tool under .temp/dup-scan/. Every tool is best-effort: a missing binary is
+# reported and skipped, never fatal — so the harness is a repeatable signal, not
+# a gate. Pairs with the detect-then-enrich CPD plugin (ADR-006): CPD is the
+# in-product, language-agnostic clone detector; this is the broader dev-time sweep.
+#
+# Tools (install hints printed when absent):
+#   - PMD CPD     (pmd)            N-way token clones, language-agnostic
+#   - jscpd       (npx jscpd)      cross-language copy/paste %
+#   - pylint      (R0801)          structural duplicate-code groups (Python)
+#   - vulture     (uv tool)        dead/unused code
+#   - grimp       (import graph)   cross-tier import edges (architecture drift)
+#
+# Usage:
+#   bash scripts/dup-scan.sh                 # scan src/ (default)
+#   bash scripts/dup-scan.sh src/eedom/core  # scan a subtree
+#   MIN_TOKENS=80 bash scripts/dup-scan.sh   # tune CPD/jscpd sensitivity
+set -uo pipefail
+
+TARGET="${1:-src/eedom}"
+MIN_TOKENS="${MIN_TOKENS:-50}"
+OUT_DIR="${OUT_DIR:-.temp/dup-scan}"
+mkdir -p "${OUT_DIR}"
+
+echo "==> dup-scan: target=${TARGET} min_tokens=${MIN_TOKENS} out=${OUT_DIR}"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+section() { printf '\n----- %s -----\n' "$1"; }
+
+# 1. PMD CPD — the same engine eedom's cpd plugin uses; N-way token clones.
+section "PMD CPD (token clones)"
+if have pmd; then
+    pmd cpd --minimum-tokens "${MIN_TOKENS}" --dir "${TARGET}" --language python \
+        --format text 2>/dev/null | tee "${OUT_DIR}/pmd-cpd.txt" | tail -n 5 || true
+    echo "    full report: ${OUT_DIR}/pmd-cpd.txt"
+else
+    echo "    SKIP: pmd not installed (brew install pmd / https://pmd.github.io)"
+fi
+
+# 2. jscpd — cross-language copy/paste percentage.
+section "jscpd (copy/paste %)"
+if have npx; then
+    npx --yes jscpd "${TARGET}" --min-tokens "${MIN_TOKENS}" --reporters console \
+        --output "${OUT_DIR}/jscpd" 2>/dev/null | tee "${OUT_DIR}/jscpd.txt" | tail -n 15 || true
+    echo "    full report: ${OUT_DIR}/jscpd.txt (html under ${OUT_DIR}/jscpd)"
+else
+    echo "    SKIP: npx not available (install Node.js)"
+fi
+
+# 3. pylint R0801 — structural duplicate-code groups (Python only).
+section "pylint duplicate-code (R0801)"
+if have uv; then
+    uv run --with pylint pylint --disable=all --enable=duplicate-code \
+        "${TARGET}" 2>/dev/null | tee "${OUT_DIR}/pylint-r0801.txt" | grep -A2 "R0801" | head -n 30 || true
+    echo "    full report: ${OUT_DIR}/pylint-r0801.txt"
+else
+    echo "    SKIP: uv not installed"
+fi
+
+# 4. vulture — dead/unused code (a duplication-adjacent smell: copies left behind).
+section "vulture (dead code)"
+if have uv; then
+    uv run --with vulture vulture "${TARGET}" --min-confidence 80 \
+        2>/dev/null | tee "${OUT_DIR}/vulture.txt" | head -n 20 || true
+    echo "    full report: ${OUT_DIR}/vulture.txt"
+else
+    echo "    SKIP: uv not installed"
+fi
+
+# 5. grimp — import graph (surface cross-tier edges / drift toward duplication).
+section "grimp (import graph summary)"
+if have uv; then
+    uv run --with grimp python - "$TARGET" <<'PY' 2>/dev/null | tee "${OUT_DIR}/grimp.txt" || true
+import sys, grimp
+try:
+    graph = grimp.build_graph("eedom")
+    mods = sorted(graph.modules)
+    print(f"modules: {len(mods)}")
+    # Count importers of each top-level tier to spot consolidation opportunities.
+    tiers = ("eedom.core", "eedom.plugins", "eedom.detectors", "eedom.data", "eedom.adapters")
+    for t in tiers:
+        members = [m for m in mods if m == t or m.startswith(t + ".")]
+        importers = set()
+        for m in members:
+            importers |= graph.find_modules_that_directly_import(m)
+        print(f"{t}: {len(members)} modules, {len(importers)} external importers")
+except Exception as e:  # noqa: BLE001
+    print(f"grimp error: {e}")
+PY
+    echo "    full report: ${OUT_DIR}/grimp.txt"
+else
+    echo "    SKIP: uv not installed"
+fi
+
+echo
+echo "==> dup-scan complete. Reports in ${OUT_DIR}/"

--- a/src/eedom/agent/tools.py
+++ b/src/eedom/agent/tools.py
@@ -96,6 +96,30 @@ def _serialize_decision(decision: ReviewDecision) -> dict:
     }
 
 
+def _enrich_agent_findings(findings: list[dict], repo_path: str) -> list[dict]:
+    """Run the default detect-then-enrich pass over agent findings (ADR-006).
+
+    Surfaces deterministic context (enclosing symbol, code-graph blast radius) in each
+    finding's ``metadata['enrichment']`` so GATEKEEPER reasons with minimal effort.
+    Fail-open: any wiring/enrichment error returns the findings unchanged.
+    """
+    if not findings:
+        return findings
+    try:
+        from eedom.composition.bootstrap import build_default_enrichers
+        from eedom.core.enrich import enrich_findings
+        from eedom.core.enrichment import EnrichmentContext
+
+        enrichers = build_default_enrichers()
+        if not enrichers:
+            return findings
+        ctx = EnrichmentContext(repo_path=repo_path)
+        return enrich_findings(findings, enrichers, ctx)
+    except Exception:
+        logger.exception("scan_code.enrich_failed")
+        return findings
+
+
 @tool(
     name="evaluate_change",
     description=(
@@ -386,12 +410,15 @@ def scan_code(
             "message": f.get("message", ""),
             "severity": f.get("severity", "WARNING"),
             "file": f.get("file", ""),
+            "line": f.get("start_line", 0),  # enrichers key on "line"
             "start_line": f.get("start_line", 0),
             "end_line": f.get("end_line", 0),
             "category": f.get("category", "unknown"),
         }
         for f in result.findings
     ]
+
+    findings = _enrich_agent_findings(findings, repo_path)
 
     return {
         "status": "ok",

--- a/src/eedom/composition/bootstrap.py
+++ b/src/eedom/composition/bootstrap.py
@@ -242,6 +242,23 @@ _SCANNER_REGISTRY_KEYS = {
 }
 
 
+def build_enrichers(settings: EedomSettings) -> list:
+    """Build the enabled finding enrichers from the ENRICHERS registry (ADR-006).
+
+    Detect-then-enrich: these run as a sequential post-detection pass (see
+    ``core.enrich.enrich_findings``) attaching deterministic context to each
+    finding. Unknown keys are skipped so config can name enrichers a given build
+    doesn't ship. The factories do no I/O — enrichers build tool state lazily.
+    """
+    from eedom.core.registries import ENRICHERS
+
+    enrichers: list = []
+    for name in settings.enabled_enrichers:
+        if name in ENRICHERS:
+            enrichers.append(ENRICHERS.create(name))
+    return enrichers
+
+
 def build_scanners(settings: EedomSettings) -> list:
     """Build the enabled scanners from the SCANNERS registry.
 
@@ -349,8 +366,10 @@ def load_adapters() -> None:
     import eedom.core.sarif  # noqa: F401
     import eedom.data.db  # noqa: F401
     import eedom.data.pypi  # noqa: F401
+    import eedom.detectors.enrichers.enclosing_symbol  # noqa: F401
     import eedom.plugins._runners.graph_builder  # noqa: F401
     import eedom.plugins._runners.semgrep_runner  # noqa: F401
+    import eedom.plugins.enrichers.code_graph  # noqa: F401
 
 
 def bootstrap(settings: EedomSettings) -> ApplicationContext:
@@ -394,4 +413,5 @@ def bootstrap(settings: EedomSettings) -> ApplicationContext:
         package_metadata=package_client,
         decision_repository=build_decision_repository(settings),
         audit_log_appender=build_audit_log_appender(),
+        enrichers=build_enrichers(settings),
     )

--- a/src/eedom/composition/bootstrap.py
+++ b/src/eedom/composition/bootstrap.py
@@ -259,6 +259,21 @@ def build_enrichers(settings: EedomSettings) -> list:
     return enrichers
 
 
+def build_default_enrichers() -> list:
+    """Build the on-by-default enrichers without a full settings object (ADR-006).
+
+    For standalone presentation paths (the GATEKEEPER agent's ``scan_code``) that run
+    a single plugin outside the wired ``ApplicationContext`` but still want findings
+    enriched. Triggers ``load_adapters`` so the registry is populated, then resolves
+    the ``DEFAULT_ENRICHERS`` keys (semgrep stays opt-in).
+    """
+    from eedom.core.config import DEFAULT_ENRICHERS
+    from eedom.core.registries import ENRICHERS
+
+    load_adapters()
+    return [ENRICHERS.create(k) for k in DEFAULT_ENRICHERS if k in ENRICHERS]
+
+
 def build_scanners(settings: EedomSettings) -> list:
     """Build the enabled scanners from the SCANNERS registry.
 
@@ -370,6 +385,7 @@ def load_adapters() -> None:
     import eedom.plugins._runners.graph_builder  # noqa: F401
     import eedom.plugins._runners.semgrep_runner  # noqa: F401
     import eedom.plugins.enrichers.code_graph  # noqa: F401
+    import eedom.plugins.enrichers.semgrep  # noqa: F401
 
 
 def bootstrap(settings: EedomSettings) -> ApplicationContext:

--- a/src/eedom/core/accessors.py
+++ b/src/eedom/core/accessors.py
@@ -39,8 +39,13 @@ def get_scanners(context: ApplicationContext) -> list[ScannerPort]:
 
 
 def get_enrichers(context: ApplicationContext) -> list[EnricherPort]:
-    """Return the injected finding enrichers. An empty list is valid (no enrichment)."""
-    return context.enrichers
+    """Return the injected finding enrichers. An empty list is valid (no enrichment).
+
+    Tolerant of contexts that predate the ``enrichers`` field (or minimal duck-typed
+    doubles): enrichment is an optional, fail-open collaborator, so its absence means
+    "no enrichment", never an error.
+    """
+    return getattr(context, "enrichers", []) or []
 
 
 def get_evidence_writer(context: ApplicationContext) -> EvidenceWriterPort:

--- a/src/eedom/core/accessors.py
+++ b/src/eedom/core/accessors.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from eedom.core.context import ApplicationContext
     from eedom.core.ports import (
         DecisionRepositoryPort,
+        EnricherPort,
         EvidenceWriterPort,
         PackageMetadataPort,
         ScannerPort,
@@ -35,6 +36,11 @@ def _require(value, name: str):
 def get_scanners(context: ApplicationContext) -> list[ScannerPort]:
     """Return the injected scanners. An empty list is valid (none enabled)."""
     return context.scanners
+
+
+def get_enrichers(context: ApplicationContext) -> list[EnricherPort]:
+    """Return the injected finding enrichers. An empty list is valid (no enrichment)."""
+    return context.enrichers
 
 
 def get_evidence_writer(context: ApplicationContext) -> EvidenceWriterPort:

--- a/src/eedom/core/config.py
+++ b/src/eedom/core/config.py
@@ -15,6 +15,11 @@ from eedom.core.models import OperatingMode
 
 _SCANNERS_DEFAULT = ["syft", "osv-scanner", "trivy", "scancode"]
 
+# On-by-default finding enrichers (ADR-006). Single source of truth shared by the
+# EedomSettings default and the settings-free build_default_enrichers() helper.
+# Semgrep enrichment is opt-in (subprocess cost), so it is deliberately absent here.
+DEFAULT_ENRICHERS = ("enclosing_symbol", "code_graph")
+
 
 class _CommaSeparatedEnvSource(EnvSettingsSource):
     """Custom env source that splits comma-separated strings for list fields.
@@ -88,7 +93,7 @@ class EedomSettings(BaseSettings):
     # Detect-then-enrich (ADR-006): which finding enrichers run after detection.
     # On-by-default enrichers are cheap+deterministic; semgrep is opt-in (per-file
     # subprocess cost). The whole pass is fail-open and bounded by enrichment_timeout.
-    enabled_enrichers: list[str] = Field(default=["enclosing_symbol", "code_graph"])
+    enabled_enrichers: list[str] = Field(default=list(DEFAULT_ENRICHERS))
     enrichment_timeout: int = 30
 
     # LLM task-fit advisory settings

--- a/src/eedom/core/config.py
+++ b/src/eedom/core/config.py
@@ -85,6 +85,12 @@ class EedomSettings(BaseSettings):
     # Enabled scanners (comma-separated in env, e.g. "syft,trivy,osv-scanner")
     enabled_scanners: list[str] = Field(default=_SCANNERS_DEFAULT)
 
+    # Detect-then-enrich (ADR-006): which finding enrichers run after detection.
+    # On-by-default enrichers are cheap+deterministic; semgrep is opt-in (per-file
+    # subprocess cost). The whole pass is fail-open and bounded by enrichment_timeout.
+    enabled_enrichers: list[str] = Field(default=["enclosing_symbol", "code_graph"])
+    enrichment_timeout: int = 30
+
     # LLM task-fit advisory settings
     llm_enabled: bool = False
     llm_endpoint: str | None = None

--- a/src/eedom/core/context.py
+++ b/src/eedom/core/context.py
@@ -18,6 +18,7 @@ from eedom.core.ports import (
     AuditSinkPort,
     DecisionRepositoryPort,
     DecisionStorePort,
+    EnricherPort,
     EvidenceStorePort,
     EvidenceWriterPort,
     PackageIndexPort,
@@ -54,3 +55,4 @@ class ApplicationContext:
     package_metadata: PackageMetadataPort | None = None
     decision_repository: DecisionRepositoryPort | None = None
     audit_log_appender: Callable[[Path, list, str], object] | None = None
+    enrichers: list[EnricherPort] = field(default_factory=list)

--- a/src/eedom/core/enrich.py
+++ b/src/eedom/core/enrich.py
@@ -1,0 +1,48 @@
+"""The detect-then-enrich pass (ADR-006).
+
+A sequential post-aggregation pass: after detection, each finding is run through the
+applicable enrichers, which attach deterministic context to ``metadata['enrichment']``.
+Sequential (not in the plugin ThreadPool) so shared tool state — e.g. the CodeGraph —
+is built once and read without locks. The pass is **fail-open** (an enricher raising
+never drops a finding) and **time-bounded** (an ``enrichment_timeout`` budget), so the
+verdict never depends on enrichment.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from eedom.core.enrichment import EnrichmentContext
+    from eedom.core.plugin import PluginFinding
+    from eedom.core.ports import EnricherPort
+
+logger = structlog.get_logger(__name__)
+
+
+def enrich_findings(
+    findings: list[PluginFinding],
+    enrichers: list[EnricherPort],
+    ctx: EnrichmentContext,
+) -> list[PluginFinding]:
+    """Return *findings* with enrichment applied. Pure post-detection; verdict-independent."""
+    if not findings or not enrichers:
+        return findings
+    deadline = time.monotonic() + ctx.enrichment_timeout
+    enriched: list[PluginFinding] = []
+    for finding in findings:
+        current = finding
+        for enricher in enrichers:
+            if time.monotonic() > deadline:
+                logger.warning("enrich.budget_exhausted", enricher=getattr(enricher, "name", "?"))
+                break
+            try:
+                if enricher.applies_to(current):
+                    current = enricher.enrich(current, ctx)
+            except Exception:  # fail-open: enrichment must never drop a finding or break the gate
+                logger.exception("enrich.failed", enricher=getattr(enricher, "name", "?"))
+        enriched.append(current)
+    return enriched

--- a/src/eedom/core/enrichment.py
+++ b/src/eedom/core/enrichment.py
@@ -1,0 +1,88 @@
+"""Enrichment value object + the canonical enclosing-symbol resolver (ADR-006).
+# tested-by: tests/unit/test_enrichment.py
+
+Detect-then-enrich: after a plugin detects a finding, eedom attaches deterministic
+context (enclosing symbol, code-graph blast radius, related matches) so a downstream
+consumer reasons with minimal effort. This module owns the cross-tier-safe pieces —
+the ``Enrichment`` value object, the ``EnrichmentContext``, and the single
+``enclosing_symbol`` resolver that both the cpd runner (``plugins``) and the
+``EnclosingSymbolEnricher`` (``detectors``) reuse (one source of truth).
+
+Everything here is pure (stdlib ``ast``/``re``) and deterministic; enrichers built on
+top must stay zero-LLM, fail-open, and time-bounded (the gate never depends on them).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+
+from eedom._base import Contract
+
+# Best-effort "what declares a symbol" matcher for non-Python languages: keyword + name.
+_SYMBOL_RE = re.compile(
+    r"^\s*(?:export\s+|public\s+|private\s+|protected\s+|static\s+|final\s+|async\s+|pub\s+)*"
+    r"(def|function|func|fn|class|interface|struct|impl|trait|enum|object|module|sub|method)\b"
+    r"[\s:<]*([A-Za-z_][A-Za-z0-9_]*)"
+)
+_CLASS_LIKE = {"class", "interface", "struct", "enum", "trait", "object"}
+
+
+def _python_symbol(source: str, line: int) -> tuple[str, str]:
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return ("", "")
+    best_name, best_kind, best_line = "", "", -1
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            kind = "function"
+        elif isinstance(node, ast.ClassDef):
+            kind = "class"
+        else:
+            continue
+        end = getattr(node, "end_lineno", None) or node.lineno
+        if node.lineno <= line <= end and node.lineno > best_line:
+            best_name, best_kind, best_line = node.name, kind, node.lineno
+    return (best_name, best_kind)
+
+
+def _generic_symbol(lines: list[str], line: int) -> tuple[str, str]:
+    for i in range(min(line, len(lines)) - 1, -1, -1):
+        match = _SYMBOL_RE.match(lines[i])
+        if match:
+            keyword = match.group(1)
+            kind = "class" if keyword in _CLASS_LIKE else "function"
+            return (match.group(2), kind)
+    return ("", "")
+
+
+def enclosing_symbol(text: str, line: int, *, is_python: bool) -> tuple[str, str]:
+    """Return ``(name, kind)`` of the innermost symbol enclosing *line* (best-effort).
+
+    Python uses the AST and is authoritative (an empty result means module-level, not
+    "scan upward"); other languages use a nearest-preceding-declaration heuristic.
+    """
+    if is_python:
+        return _python_symbol(text, line)
+    return _generic_symbol(text.splitlines(), line)
+
+
+class Enrichment(Contract):
+    """Deterministic context attached to a finding (serialized into ``metadata['enrichment']``)."""
+
+    enclosing_symbol: str = ""
+    enclosing_kind: str = ""
+    blast_radius: tuple[dict, ...] = ()
+    related: tuple[dict, ...] = ()
+    suggested_home: str = ""
+    sources: tuple[str, ...] = ()
+
+
+@dataclass
+class EnrichmentContext:
+    """Inputs the enrichment pass hands to each enricher (core types only)."""
+
+    repo_path: str
+    enrichment_timeout: float = 30.0

--- a/src/eedom/core/enrichment.py
+++ b/src/eedom/core/enrichment.py
@@ -86,3 +86,26 @@ class EnrichmentContext:
 
     repo_path: str
     enrichment_timeout: float = 30.0
+
+
+def merge_enrichment(finding, *, source: str, **fields):
+    """Merge enrichment *fields* into ``finding.metadata['enrichment']`` (accumulating sources).
+
+    The single helper every enricher uses to attach context, so the merge semantics live in
+    one place. Handles both representations a finding takes in eedom: a frozen ``PluginFinding``
+    (returned via ``model_copy``) and a raw ``dict`` (semgrep/blast-radius style, returned as a
+    new dict). The ``enrichment`` envelope is always a plain dict (JSON-safe).
+    """
+    is_dict = isinstance(finding, dict)
+    existing = finding.get("metadata") if is_dict else getattr(finding, "metadata", {})
+    metadata = dict(existing or {})
+    enrichment = dict(metadata.get("enrichment") or {})
+    sources = list(enrichment.get("sources", []))
+    if source not in sources:
+        sources.append(source)
+    enrichment.update(fields)
+    enrichment["sources"] = sources
+    metadata["enrichment"] = enrichment
+    if is_dict:
+        return {**finding, "metadata": metadata}
+    return finding.model_copy(update={"metadata": metadata})

--- a/src/eedom/core/ports.py
+++ b/src/eedom/core/ports.py
@@ -12,7 +12,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from eedom.core.enrichment import EnrichmentContext
     from eedom.core.models import PolicyEvaluation, ReviewDecision, ScanResult
+    from eedom.core.plugin import PluginFinding
 
 
 @runtime_checkable
@@ -189,3 +191,20 @@ class AuditSinkPort(Protocol):
     def seal(self, artifact_refs: list[str]) -> str: ...
 
     def append_audit_log(self, entry: dict) -> None: ...
+
+
+@runtime_checkable
+class EnricherPort(Protocol):
+    """Contract for a deterministic finding enricher (detect-then-enrich, ADR-006).
+
+    ``enrich`` attaches context to a finding's ``metadata['enrichment']`` and returns a
+    new finding. It must be deterministic, zero-LLM, fail-open (never raise; on error
+    return the finding unchanged), and time-bounded — the verdict never depends on it.
+    """
+
+    @property
+    def name(self) -> str: ...
+
+    def applies_to(self, finding: PluginFinding) -> bool: ...
+
+    def enrich(self, finding: PluginFinding, ctx: EnrichmentContext) -> PluginFinding: ...

--- a/src/eedom/core/registries.py
+++ b/src/eedom/core/registries.py
@@ -19,6 +19,7 @@ from eedom.core.policy_port import PolicyEnginePort
 from eedom.core.ports import (
     CodeGraphCheckPort,
     DecisionStorePort,
+    EnricherPort,
     EvidenceStorePort,
     FileSourcePort,
     PackageMetadataPort,
@@ -29,6 +30,7 @@ from eedom.core.ports import (
 )
 from eedom.registry import Registry
 
+ENRICHERS: Registry[EnricherPort] = Registry("enricher")
 POLICY_ENGINES: Registry[PolicyEnginePort] = Registry("policy_engine")
 RENDERERS: Registry[ReportRendererPort] = Registry("renderer")
 RULE_RUNNERS: Registry[SemgrepRunnerPort] = Registry("rule_runner")
@@ -46,6 +48,7 @@ REPO_SNAPSHOTS: Registry[RepoSnapshotPort] = Registry("repo_snapshot")
 __all__ = [
     "CODEGRAPH_CHECKS",
     "DECISION_STORES",
+    "ENRICHERS",
     "EVIDENCE_STORES",
     "FILE_SOURCES",
     "PACKAGE_INDEXES",

--- a/src/eedom/core/sarif.py
+++ b/src/eedom/core/sarif.py
@@ -79,6 +79,17 @@ def _make_locations(finding: dict, repo_path: str | None) -> list[dict]:
     ]
 
 
+def _enrichment(finding: dict) -> dict | None:
+    """Return the detect-then-enrich packet (ADR-006) for *finding*, or None.
+
+    Surfaced verbatim into the SARIF result's property bag so enrichment reaches
+    SARIF consumers at parity with the JSON report.
+    """
+    metadata = finding.get("metadata") or {}
+    enrichment = metadata.get("enrichment")
+    return enrichment or None
+
+
 def _plugin_to_run(
     result: PluginResult,
     repo_path: str | None,
@@ -101,6 +112,9 @@ def _plugin_to_run(
         locations = _make_locations(finding, repo_path)
         if locations:
             sarif_result["locations"] = locations
+        enrichment = _enrichment(finding)
+        if enrichment:
+            sarif_result["properties"] = {"enrichment": enrichment}
         sarif_results.append(sarif_result)
 
     if result.error:

--- a/src/eedom/core/use_cases.py
+++ b/src/eedom/core/use_cases.py
@@ -69,6 +69,34 @@ def _derive_verdict(results: list) -> str:
     return verdict
 
 
+def _enrich_results(context: ApplicationContext, results: list, repo_path: Path) -> list:
+    """Run the detect-then-enrich pass over every plugin's findings (ADR-006).
+
+    A post-detection, verdict-independent pass: each finding is decorated with
+    deterministic context (enclosing symbol, code-graph blast radius) in its
+    ``metadata['enrichment']``. Fail-open and time-bounded — enrichment can never
+    change a verdict or drop a finding, so this runs *after* detection and before
+    scoring. A no-op when no enrichers are wired.
+    """
+    from eedom.core.accessors import get_enrichers
+    from eedom.core.enrich import enrich_findings
+    from eedom.core.enrichment import EnrichmentContext
+
+    enrichers = get_enrichers(context)
+    if not enrichers:
+        return results
+    ctx = EnrichmentContext(repo_path=str(repo_path))
+    enriched: list = []
+    for result in results:
+        findings = getattr(result, "findings", None)
+        if findings:
+            new = enrich_findings(list(findings), enrichers, ctx)
+            enriched.append(dataclasses.replace(result, findings=new))
+        else:
+            enriched.append(result)
+    return enriched
+
+
 def review_repository(
     context: ApplicationContext,
     files: list,
@@ -96,6 +124,8 @@ def review_repository(
         enabled_names=options.enabled,
         repo_files=repo_files,
     )
+
+    plugin_results = _enrich_results(context, plugin_results, repo_path)
 
     verdict = _derive_verdict(plugin_results)
     security_score = calculate_severity_score(plugin_results)

--- a/src/eedom/detectors/enrichers/__init__.py
+++ b/src/eedom/detectors/enrichers/__init__.py
@@ -1,0 +1,10 @@
+"""Detectors-tier finding enrichers (detect-then-enrich, ADR-006).
+
+Cheap, stdlib-only enrichers that live in the ``detectors`` tier because they
+build on ``detectors.ast_utils`` / the core ``enclosing_symbol`` resolver. They
+self-register into the core-owned ``ENRICHERS`` registry on import; the
+composition tier triggers that import via ``load_adapters`` (see
+``eedom.composition.bootstrap``).
+"""
+
+from __future__ import annotations

--- a/src/eedom/detectors/enrichers/enclosing_symbol.py
+++ b/src/eedom/detectors/enrichers/enclosing_symbol.py
@@ -1,0 +1,55 @@
+"""EnclosingSymbolEnricher — maps a finding location to its function/class (ADR-006).
+# tested-by: tests/unit/detectors/test_enclosing_symbol_enricher.py
+
+The cheapest enricher: for any finding that carries a ``file`` + ``line``, read the
+source and attach the innermost enclosing symbol via the canonical
+``core.enrichment.enclosing_symbol`` resolver (one source of truth, shared with the
+cpd runner). Pure stdlib, no subprocess, sub-millisecond — deterministic, zero-LLM,
+and fail-open by construction (an unreadable file yields no enrichment, never an error).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from eedom.core.enrichment import enclosing_symbol, merge_enrichment
+from eedom.core.plugin import finding_get
+from eedom.core.registries import ENRICHERS
+
+if TYPE_CHECKING:
+    from eedom.core.enrichment import EnrichmentContext
+    from eedom.core.plugin import PluginFinding
+
+
+@ENRICHERS.register("enclosing_symbol")
+class EnclosingSymbolEnricher:
+    """Attach the innermost function/class enclosing a finding's ``file``:``line``."""
+
+    name = "enclosing_symbol"
+
+    def applies_to(self, finding: PluginFinding) -> bool:
+        """Applies to any finding anchored to a concrete file location."""
+        file = finding_get(finding, "file")
+        line = finding_get(finding, "line")
+        return bool(file) and isinstance(line, int) and line > 0
+
+    def enrich(self, finding: PluginFinding, ctx: EnrichmentContext) -> PluginFinding:
+        file = finding_get(finding, "file")
+        line = finding_get(finding, "line")
+        abs_path = Path(file)
+        if not abs_path.is_absolute():
+            abs_path = Path(ctx.repo_path) / file
+        try:
+            text = abs_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return finding  # fail-open: no source, no enrichment
+        name, kind = enclosing_symbol(text, line, is_python=str(file).endswith(".py"))
+        if not name:
+            return finding
+        return merge_enrichment(
+            finding,
+            source=self.name,
+            enclosing_symbol=name,
+            enclosing_kind=kind,
+        )

--- a/src/eedom/plugins/_runners/cpd_runner.py
+++ b/src/eedom/plugins/_runners/cpd_runner.py
@@ -1,10 +1,27 @@
-"""PMD CPD subprocess runner.
+"""PMD CPD subprocess runner (detect) + deterministic enrichment (ADR-006).
 # tested-by: tests/unit/test_cpd_runner.py
+
+Detect: PMD CPD across every language PMD 7 supports, with a jscpd fallback for
+the rest (and when PMD is unavailable) — so duplication detection is as
+language-agnostic as the available tools allow, and scans the *actual* changed
+files recursively via a file-list (not a non-recursive top-level dir).
+
+Enrich (ADR-006): each clone group is annotated deterministically — the enclosing
+symbol per location, the N-way ``occurrences`` count, and a ``suggested_home`` for
+consolidation — so a downstream consumer knows *where a shared base belongs*
+without re-deriving it. Every step is fail-open: a missing tool or parse error
+yields fewer findings, never an exception.
 """
 
 from __future__ import annotations
 
+import ast
+import contextlib
+import json
+import os
+import re
 import subprocess
+import tempfile
 import xml.etree.ElementTree as ET  # noqa: N817
 from pathlib import Path
 
@@ -12,22 +29,52 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
-_CPD_LANGUAGES: dict[str, str] = {
+# Extension -> PMD 7 CPD language id. Anything not here is routed to the jscpd fallback.
+_PMD_LANGUAGES: dict[str, str] = {
+    ".py": "python",
+    ".java": "java",
     ".ts": "typescript",
     ".tsx": "typescript",
     ".js": "ecmascript",
     ".jsx": "ecmascript",
-    ".py": "python",
+    ".mjs": "ecmascript",
+    ".cjs": "ecmascript",
     ".go": "go",
     ".rb": "ruby",
-    ".java": "java",
     ".kt": "kotlin",
+    ".kts": "kotlin",
     ".swift": "swift",
     ".rs": "rust",
-    ".css": "css",
+    ".c": "cpp",
+    ".h": "cpp",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".cs": "cs",
+    ".php": "php",
+    ".scala": "scala",
+    ".sc": "scala",
+    ".dart": "dart",
+    ".lua": "lua",
+    ".groovy": "groovy",
+    ".pl": "perl",
+    ".pm": "perl",
     ".html": "html",
+    ".htm": "html",
     ".xml": "xml",
+    ".json": "json",
+    ".jsp": "jsp",
+    ".jl": "julia",
+    ".feature": "gherkin",
 }
+
+# Best-effort "what declares a symbol" matcher for non-Python enclosing-symbol detection.
+_SYMBOL_RE = re.compile(
+    r"^\s*(?:export\s+|public\s+|private\s+|protected\s+|static\s+|final\s+|async\s+|pub\s+)*"
+    r"(?:def|function|func|fn|class|interface|struct|impl|trait|enum|object|module|sub|method)\b"
+    r"[\s:<]*([A-Za-z_][A-Za-z0-9_]*)"
+)
 
 
 def _parse_cpd_xml(xml_text: str, lang: str) -> list[dict]:
@@ -77,6 +124,162 @@ def _extract_xml_payload(raw_output: str) -> str:
     return raw_output[idx:]
 
 
+# --- enrichment (ADR-006): deterministic, fail-open -----------------------------------------------
+
+
+def _enclosing_symbol_python(source: str, start_line: int) -> str:
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return ""
+    best_name, best_line = "", -1
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            end = getattr(node, "end_lineno", None) or node.lineno
+            if node.lineno <= start_line <= end and node.lineno > best_line:
+                best_name, best_line = node.name, node.lineno
+    return best_name
+
+
+def _enclosing_symbol_generic(lines: list[str], start_line: int) -> str:
+    for i in range(min(start_line, len(lines)) - 1, -1, -1):
+        match = _SYMBOL_RE.match(lines[i])
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _enclosing_symbol(abs_path: str, start_line: int) -> str:
+    """Innermost function/class enclosing the location (best-effort, language-agnostic)."""
+    try:
+        text = Path(abs_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    if abs_path.endswith(".py"):
+        # AST is authoritative for Python: an empty result means module-level, not "scan upward".
+        return _enclosing_symbol_python(text, start_line)
+    return _enclosing_symbol_generic(text.splitlines(), start_line)
+
+
+def _rel(path: str, repo_path: str) -> str:
+    try:
+        return os.path.relpath(path, repo_path)
+    except ValueError:
+        return path
+
+
+def _suggested_home(locations: list[dict], repo_path: str) -> str:
+    files = sorted({loc["file"] for loc in locations})
+    if len(files) == 1:
+        return f"extract a local helper in {_rel(files[0], repo_path)}"
+    try:
+        common = os.path.commonpath(files)
+    except ValueError:
+        common = repo_path
+    return f"extract a shared module under {_rel(common, repo_path)}/"
+
+
+def _enrich_clones(dupes: list[dict], repo_path: str) -> list[dict]:
+    """Annotate each clone group with enclosing symbols, occurrences, and a consolidation home."""
+    for dup in dupes:
+        dup["occurrences"] = len(dup.get("locations", []))
+        for loc in dup.get("locations", []):
+            loc["symbol"] = _enclosing_symbol(loc.get("file", ""), loc.get("start_line", 0))
+        dup["suggested_home"] = _suggested_home(dup.get("locations", []), repo_path)
+    # Rank by impact: a large block copied many times is the highest-value consolidation.
+    dupes.sort(key=lambda d: d.get("tokens", 0) * max(d.get("occurrences", 1), 1), reverse=True)
+    return dupes
+
+
+# --- detection ------------------------------------------------------------------------------------
+
+
+def _run_pmd_lang(files: list[str], lang: str, min_tokens: int, timeout: int) -> str:
+    """Run PMD CPD for one language over an explicit file-list. Returns XML payload ('' on none)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as fh:
+        fh.write("\n".join(files))
+        list_path = fh.name
+    try:
+        result = subprocess.run(
+            [
+                "pmd",
+                "cpd",
+                "--minimum-tokens",
+                str(min_tokens),
+                "--language",
+                lang,
+                "--format",
+                "xml",
+                "--file-list",
+                list_path,
+                "--no-fail-on-violation",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(list_path)
+    payload = _extract_xml_payload(result.stdout or "")
+    return payload or _extract_xml_payload(result.stderr or "")
+
+
+def _jscpd_available() -> bool:
+    from shutil import which
+
+    return which("npx") is not None or which("jscpd") is not None
+
+
+def _run_jscpd(files: list[str], min_tokens: int, timeout: int) -> list[dict]:
+    """Fallback detector for languages PMD can't handle (or when PMD is absent). Fail-open."""
+    if not files or not _jscpd_available():
+        return []
+    with tempfile.TemporaryDirectory() as out:
+        cmd = [
+            "npx",
+            "--yes",
+            "jscpd",
+            *files,
+            "--min-tokens",
+            str(min_tokens),
+            "--reporters",
+            "json",
+            "--output",
+            out,
+            "--silent",
+        ]
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+            report = Path(out) / "jscpd-report.json"
+            if not report.exists():
+                return []
+            data = json.loads(report.read_text(encoding="utf-8"))
+        except (subprocess.TimeoutExpired, OSError, ValueError):
+            return []
+    dupes: list[dict] = []
+    for d in data.get("duplicates", []):
+        locs = []
+        for key in ("firstFile", "secondFile"):
+            fobj = d.get(key) or {}
+            start = fobj.get("start") or (fobj.get("startLoc") or {}).get("line") or 0
+            end = fobj.get("end") or (fobj.get("endLoc") or {}).get("line") or 0
+            if fobj.get("name"):
+                locs.append({"file": fobj["name"], "start_line": int(start), "end_line": int(end)})
+        if len(locs) >= 2:
+            dupes.append(
+                {
+                    "tokens": int(d.get("tokens", 0) or d.get("lines", 0)),
+                    "lines": int(d.get("lines", 0)),
+                    "language": str(d.get("format", "")),
+                    "locations": locs,
+                    "fragment": (d.get("fragment") or "")[:200],
+                }
+            )
+    return dupes
+
+
 def run_cpd(
     changed_files: list[str],
     repo_path: str,
@@ -86,52 +289,31 @@ def run_cpd(
     if not changed_files:
         return {"duplicates": [], "files_scanned": 0}
 
-    by_lang: dict[str, list[str]] = {}
+    repo = Path(repo_path)
+    abs_files: list[str] = []
     for f in changed_files:
-        lang = _CPD_LANGUAGES.get(Path(f).suffix)
+        p = Path(f)
+        abs_files.append(str(p if p.is_absolute() else repo / f))
+
+    by_lang: dict[str, list[str]] = {}
+    jscpd_files: list[str] = []
+    for f in abs_files:
+        lang = _PMD_LANGUAGES.get(Path(f).suffix.lower())
         if lang:
             by_lang.setdefault(lang, []).append(f)
-
-    if not by_lang:
-        return {"duplicates": [], "files_scanned": 0}
+        else:
+            jscpd_files.append(f)
 
     all_dupes: list[dict] = []
-    total_scanned = 0
+    scanned = 0
+    pmd_missing = False
 
     for lang, files in by_lang.items():
-        cmd = [
-            "pmd",
-            "cpd",
-            "--minimum-tokens",
-            str(min_tokens),
-            "--language",
-            lang,
-            "--format",
-            "xml",
-            "--dir",
-            repo_path,
-            "--non-recursive",
-        ]
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=False,
-            )
-            xml_text = _extract_xml_payload(result.stdout or "")
-            if not xml_text:
-                xml_text = _extract_xml_payload(result.stderr or "")
-            if xml_text:
-                all_dupes.extend(_parse_cpd_xml(xml_text, lang))
-            total_scanned += len(files)
+            xml_text = _run_pmd_lang(files, lang, min_tokens, timeout)
         except FileNotFoundError:
-            from eedom.core.errors import ErrorCode, error_msg
-
-            msg = error_msg(ErrorCode.NOT_INSTALLED, "pmd")
-            logger.warning("cpd.not_installed", error=msg)
-            return {"duplicates": [], "files_scanned": 0, "error": msg}
+            pmd_missing = True
+            break
         except subprocess.TimeoutExpired:
             from eedom.core.errors import ErrorCode, error_msg
 
@@ -139,15 +321,32 @@ def run_cpd(
             logger.warning("cpd.timeout", error=msg)
             return {"duplicates": [], "files_scanned": 0, "error": msg}
         except Exception:
-            from eedom.core.errors import ErrorCode, error_msg
+            logger.exception("cpd.pmd_failed", language=lang)
+            continue
+        if xml_text:
+            all_dupes.extend(_parse_cpd_xml(xml_text, lang))
+        scanned += len(files)
 
-            msg = error_msg(ErrorCode.BINARY_CRASHED, "pmd", exit_code=-1)
-            logger.exception("cpd.failed")
-            return {"duplicates": [], "files_scanned": 0, "error": msg}
+    # jscpd handles non-PMD languages always, and every language if PMD is unavailable.
+    fallback = list(jscpd_files)
+    if pmd_missing:
+        for files in by_lang.values():
+            fallback.extend(files)
+    if fallback:
+        fb = _run_jscpd(fallback, min_tokens, timeout)
+        all_dupes.extend(fb)
+        scanned += len(fallback)
 
-    all_dupes.sort(key=lambda d: d["tokens"], reverse=True)
+    if pmd_missing and not _jscpd_available():
+        from eedom.core.errors import ErrorCode, error_msg
+
+        msg = error_msg(ErrorCode.NOT_INSTALLED, "pmd")
+        logger.warning("cpd.not_installed", error=msg)
+        return {"duplicates": [], "files_scanned": 0, "error": msg}
+
+    _enrich_clones(all_dupes, repo_path)
     return {
         "duplicates": all_dupes,
-        "files_scanned": total_scanned,
+        "files_scanned": scanned,
         "duplicate_count": len(all_dupes),
     }

--- a/src/eedom/plugins/_runners/cpd_runner.py
+++ b/src/eedom/plugins/_runners/cpd_runner.py
@@ -15,17 +15,17 @@ yields fewer findings, never an exception.
 
 from __future__ import annotations
 
-import ast
 import contextlib
 import json
 import os
-import re
 import subprocess
 import tempfile
 import xml.etree.ElementTree as ET  # noqa: N817
 from pathlib import Path
 
 import structlog
+
+from eedom.core.enrichment import enclosing_symbol as _enclosing_symbol_core
 
 logger = structlog.get_logger(__name__)
 
@@ -68,14 +68,6 @@ _PMD_LANGUAGES: dict[str, str] = {
     ".jl": "julia",
     ".feature": "gherkin",
 }
-
-# Best-effort "what declares a symbol" matcher for non-Python enclosing-symbol detection.
-_SYMBOL_RE = re.compile(
-    r"^\s*(?:export\s+|public\s+|private\s+|protected\s+|static\s+|final\s+|async\s+|pub\s+)*"
-    r"(?:def|function|func|fn|class|interface|struct|impl|trait|enum|object|module|sub|method)\b"
-    r"[\s:<]*([A-Za-z_][A-Za-z0-9_]*)"
-)
-
 
 def _parse_cpd_xml(xml_text: str, lang: str) -> list[dict]:
     """Parse PMD CPD XML output into a list of duplication dicts."""
@@ -127,38 +119,14 @@ def _extract_xml_payload(raw_output: str) -> str:
 # --- enrichment (ADR-006): deterministic, fail-open -----------------------------------------------
 
 
-def _enclosing_symbol_python(source: str, start_line: int) -> str:
-    try:
-        tree = ast.parse(source)
-    except (SyntaxError, ValueError):
-        return ""
-    best_name, best_line = "", -1
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            end = getattr(node, "end_lineno", None) or node.lineno
-            if node.lineno <= start_line <= end and node.lineno > best_line:
-                best_name, best_line = node.name, node.lineno
-    return best_name
-
-
-def _enclosing_symbol_generic(lines: list[str], start_line: int) -> str:
-    for i in range(min(start_line, len(lines)) - 1, -1, -1):
-        match = _SYMBOL_RE.match(lines[i])
-        if match:
-            return match.group(1)
-    return ""
-
-
 def _enclosing_symbol(abs_path: str, start_line: int) -> str:
-    """Innermost function/class enclosing the location (best-effort, language-agnostic)."""
+    """Innermost function/class enclosing the location (delegates to the core resolver, SoT)."""
     try:
         text = Path(abs_path).read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
-    if abs_path.endswith(".py"):
-        # AST is authoritative for Python: an empty result means module-level, not "scan upward".
-        return _enclosing_symbol_python(text, start_line)
-    return _enclosing_symbol_generic(text.splitlines(), start_line)
+    name, _kind = _enclosing_symbol_core(text, start_line, is_python=abs_path.endswith(".py"))
+    return name
 
 
 def _rel(path: str, repo_path: str) -> str:

--- a/src/eedom/plugins/_runners/cpd_runner.py
+++ b/src/eedom/plugins/_runners/cpd_runner.py
@@ -69,6 +69,7 @@ _PMD_LANGUAGES: dict[str, str] = {
     ".feature": "gherkin",
 }
 
+
 def _parse_cpd_xml(xml_text: str, lang: str) -> list[dict]:
     """Parse PMD CPD XML output into a list of duplication dicts."""
     dupes: list[dict] = []

--- a/src/eedom/plugins/_runners/graph_builder.py
+++ b/src/eedom/plugins/_runners/graph_builder.py
@@ -326,6 +326,22 @@ class CodeGraph:
         """
         return self.run_checks([str(file_path)])
 
+    def symbol_at(self, file_path: str | Path, line: int) -> dict | None:
+        """Return the innermost symbol enclosing *file_path*:*line*, or None.
+
+        Deterministic: among symbols whose ``[line, end_line]`` span contains
+        *line*, the innermost (largest start line) wins. The enrichment layer
+        (ADR-006) uses this to map a finding location to its function/class.
+        """
+        key = self._storage_key(file_path)
+        row = self.conn.execute(
+            "SELECT name, kind, file, line, end_line FROM symbols "
+            "WHERE file = ? AND line <= ? AND COALESCE(end_line, line) >= ? "
+            "ORDER BY line DESC LIMIT 1",
+            (key, line, line),
+        ).fetchone()
+        return dict(row) if row else None
+
     def blast_radius(self, symbol_name: str, max_depth: int = 3) -> list[dict]:
         results: list[dict] = []
         visited: set[int] = set()

--- a/src/eedom/plugins/cpd.py
+++ b/src/eedom/plugins/cpd.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from eedom.core.plugin import PluginCategory, PluginResult, ScannerPlugin
+from eedom.core.plugin import (
+    PluginCategory,
+    PluginResult,
+    ScannerPlugin,
+    result_with_dict_findings,
+)
 from eedom.plugins._runners.cpd_runner import run_cpd as _run
 
 _CODE_EXTS = {
@@ -65,14 +70,21 @@ class CpdPlugin(ScannerPlugin):
     def render(self, result: PluginResult, template_dir: Path | None = None) -> str:
         if result.error:
             return f"**cpd**: {result.error}"
+        result = result_with_dict_findings(result)
         if not result.findings:
             return ""
         lines = ["<details open>"]
         lines.append(f"<summary>📋 <b>Duplicated Code ({len(result.findings)})</b></summary>\n")
         for d in result.findings[:10]:
-            lines.append(f"**{d['lines']} lines, {d['tokens']} tokens** ({d['language']})")
+            occ = d.get("occurrences", len(d.get("locations", [])))
+            lines.append(
+                f"**{d['lines']} lines, {d['tokens']} tokens, copied {occ}×** ({d['language']})"
+            )
+            if d.get("suggested_home"):
+                lines.append(f"↳ _{d['suggested_home']}_")
             for loc in d["locations"]:
-                lines.append(f"- `{loc['file']}:{loc['start_line']}-{loc['end_line']}`")
+                sym = f" — `{loc['symbol']}`" if loc.get("symbol") else ""
+                lines.append(f"- `{loc['file']}:{loc['start_line']}-{loc['end_line']}`{sym}")
             if d.get("fragment"):
                 lines.append(f"```\n{d['fragment'][:150]}\n```")
             lines.append("")

--- a/src/eedom/plugins/enrichers/__init__.py
+++ b/src/eedom/plugins/enrichers/__init__.py
@@ -1,0 +1,10 @@
+"""Plugins-tier finding enrichers (detect-then-enrich, ADR-006).
+
+Enrichers that build on heavier ``plugins`` machinery — the SQLite ``CodeGraph``
+(blast radius) and, later, targeted semgrep — live here because the arch-guard
+forbids ``detectors`` from importing ``plugins`` internals. They self-register into
+the core-owned ``ENRICHERS`` registry on import; the composition tier triggers that
+import via ``load_adapters`` (see ``eedom.composition.bootstrap``).
+"""
+
+from __future__ import annotations

--- a/src/eedom/plugins/enrichers/code_graph.py
+++ b/src/eedom/plugins/enrichers/code_graph.py
@@ -1,0 +1,97 @@
+"""CodeGraphEnricher — attaches blast radius + enclosing symbol from the code graph (ADR-006).
+# tested-by: tests/unit/plugins/test_code_graph_enricher.py
+
+For a code finding (``.py``/``.ts``/``.js`` family), resolve the enclosing symbol via the
+SQLite ``CodeGraph`` and walk its upstream callers (``blast_radius``) so a consumer sees
+"who breaks if this changes" without re-deriving it. The graph is the same one the
+``blast-radius`` plugin builds; this enricher builds it **once per run** and caches it on
+the instance (the enrichment pass is sequential, so no locking is needed).
+
+Deterministic, zero-LLM, fail-open: any error (missing graph, unindexed file) yields the
+finding unchanged. The graph build is the one cost — already paid by the blast-radius
+plugin — and the whole pass is time-bounded by ``EnrichmentContext.enrichment_timeout``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+from eedom.core.enrichment import merge_enrichment
+from eedom.core.plugin import finding_get
+from eedom.core.registries import ENRICHERS
+from eedom.plugins._runners.graph_builder import CodeGraph, resolve_graph_db_path
+
+if TYPE_CHECKING:
+    from eedom.core.enrichment import EnrichmentContext
+    from eedom.core.plugin import PluginFinding
+
+logger = structlog.get_logger(__name__)
+
+_CODE_EXTS = {".py", ".ts", ".tsx", ".js", ".jsx"}
+_MAX_CALLERS = 25  # cap the attached blast radius so enrichment stays bounded
+
+
+@ENRICHERS.register("code_graph")
+class CodeGraphEnricher:
+    """Attach enclosing symbol + upstream blast radius from the SQLite code graph."""
+
+    name = "code_graph"
+
+    def __init__(self) -> None:
+        self._graph: CodeGraph | None = None
+        self._graph_repo: str | None = None
+
+    def applies_to(self, finding: PluginFinding) -> bool:
+        file = finding_get(finding, "file")
+        line = finding_get(finding, "line")
+        return (
+            bool(file)
+            and Path(str(file)).suffix in _CODE_EXTS
+            and isinstance(line, int)
+            and line > 0
+        )
+
+    def _resolve_graph(self, repo_path: str) -> CodeGraph | None:
+        """Build (once) or reuse the cached code graph for *repo_path* (fail-open)."""
+        if self._graph is not None and self._graph_repo == repo_path:
+            return self._graph
+        try:
+            db_path = str(resolve_graph_db_path(repo_path))
+            graph = CodeGraph(db_path=db_path, repo_root=Path(repo_path))
+            if graph.stats()["symbols"] == 0:
+                graph.index_directory(Path(repo_path))
+            self._graph = graph
+            self._graph_repo = repo_path
+        except Exception:
+            logger.exception("enrich.code_graph.build_failed", repo=repo_path)
+            return None
+        return self._graph
+
+    def enrich(self, finding: PluginFinding, ctx: EnrichmentContext) -> PluginFinding:
+        graph = self._resolve_graph(ctx.repo_path)
+        if graph is None:
+            return finding
+        file = str(finding_get(finding, "file"))
+        line = int(finding_get(finding, "line"))
+        rel = file
+        abs_path = Path(file)
+        if abs_path.is_absolute():
+            try:
+                rel = str(abs_path.resolve().relative_to(Path(ctx.repo_path).resolve()))
+            except ValueError:
+                return finding  # outside the repo — nothing the graph can say
+        symbol = graph.symbol_at(rel, line)
+        if not symbol or not symbol.get("name"):
+            return finding
+        callers = graph.blast_radius(symbol["name"])[:_MAX_CALLERS]
+        return merge_enrichment(
+            finding,
+            source=self.name,
+            enclosing_symbol=symbol["name"],
+            enclosing_kind=symbol.get("kind", ""),
+            blast_radius=callers,
+            blast_radius_count=len(callers),
+        )

--- a/src/eedom/plugins/enrichers/semgrep.py
+++ b/src/eedom/plugins/enrichers/semgrep.py
@@ -1,0 +1,99 @@
+"""SemgrepEnricher — attaches nearby static-analysis rule matches (detect-then-enrich, ADR-006).
+# tested-by: tests/unit/plugins/test_semgrep_enricher.py
+
+Opt-in (off by default — each scanned file is a subprocess, ~100-200ms): when enabled it
+runs opengrep over a finding's single file and attaches the rule matches *near* the finding
+location as ``metadata['enrichment']['related']``, so a consumer sees "what else the static
+analyzer flagged right here" without a second tool invocation. Results are cached per file
+within a run, deterministic given the same rules+file, and fail-open: any error (tool missing,
+timeout, parse failure) yields the finding unchanged. Reuses the canonical opengrep runner so
+ruleset selection / exclusion semantics stay in one place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+from eedom.core.enrichment import merge_enrichment
+from eedom.core.plugin import finding_get
+from eedom.core.registries import ENRICHERS
+from eedom.plugins._runners.semgrep_runner import (
+    _EXT_TO_RULESETS,
+    _NAME_TO_RULESETS,
+    run_semgrep,
+)
+
+if TYPE_CHECKING:
+    from eedom.core.enrichment import EnrichmentContext
+    from eedom.core.plugin import PluginFinding
+
+logger = structlog.get_logger(__name__)
+
+_LINE_WINDOW = 25  # a match within this many lines of the finding counts as "related"
+_MAX_RELATED = 10  # cap the attached matches so enrichment stays bounded
+_DEFAULT_TIMEOUT = 15  # per-file opengrep budget (seconds)
+
+
+def _supported(file: str) -> bool:
+    return Path(file).suffix in _EXT_TO_RULESETS or Path(file).name in _NAME_TO_RULESETS
+
+
+@ENRICHERS.register("semgrep")
+class SemgrepEnricher:
+    """Attach opengrep rule matches near a finding's location (opt-in, budgeted)."""
+
+    name = "semgrep"
+
+    def __init__(self, timeout: int = _DEFAULT_TIMEOUT) -> None:
+        self._timeout = timeout
+        self._cache: dict[tuple[str, str], list[dict]] = {}  # (repo, file) -> results
+
+    def applies_to(self, finding: PluginFinding) -> bool:
+        file = finding_get(finding, "file")
+        line = finding_get(finding, "line")
+        return bool(file) and _supported(str(file)) and isinstance(line, int) and line > 0
+
+    def _matches_for(self, repo_path: str, rel_file: str) -> list[dict]:
+        """Run (once, cached) opengrep over a single file; fail-open to []."""
+        key = (repo_path, rel_file)
+        if key in self._cache:
+            return self._cache[key]
+        try:
+            data = run_semgrep([rel_file], repo_path, timeout=self._timeout)
+            results = data.get("results") or []
+        except Exception:
+            logger.exception("enrich.semgrep.run_failed", file=rel_file)
+            results = []
+        self._cache[key] = results
+        return results
+
+    def enrich(self, finding: PluginFinding, ctx: EnrichmentContext) -> PluginFinding:
+        file = str(finding_get(finding, "file"))
+        line = int(finding_get(finding, "line"))
+        rel = file
+        abs_path = Path(file)
+        if abs_path.is_absolute():
+            try:
+                rel = str(abs_path.resolve().relative_to(Path(ctx.repo_path).resolve()))
+            except ValueError:
+                return finding
+        related: list[dict] = []
+        for r in self._matches_for(ctx.repo_path, rel):
+            start = (r.get("start") or {}).get("line", 0)
+            if abs(start - line) > _LINE_WINDOW:
+                continue
+            related.append(
+                {
+                    "check_id": r.get("check_id", ""),
+                    "line": start,
+                    "message": ((r.get("extra") or {}).get("message") or "").strip(),
+                    "severity": (r.get("extra") or {}).get("severity", ""),
+                }
+            )
+        related.sort(key=lambda m: (m["line"], m["check_id"]))
+        if not related:
+            return finding
+        return merge_enrichment(finding, source=self.name, related=related[:_MAX_RELATED])

--- a/tests/unit/detectors/test_enclosing_symbol_enricher.py
+++ b/tests/unit/detectors/test_enclosing_symbol_enricher.py
@@ -1,0 +1,65 @@
+"""EnclosingSymbolEnricher (detect-then-enrich, ADR-006).
+# tested-by: tests/unit/detectors/test_enclosing_symbol_enricher.py
+
+DPS-12 domains: Determinism (same file+finding -> same enrichment), Availability
+(fail-open: unreadable source never drops the finding), Integrity (enrichment only
+adds metadata; severity/message untouched).
+"""
+
+from __future__ import annotations
+
+from eedom.core.enrichment import EnrichmentContext
+from eedom.core.plugin import PluginFinding
+from eedom.detectors.enrichers.enclosing_symbol import EnclosingSymbolEnricher
+
+_SRC = (
+    "def alpha():\n    x = 1\n    return x\n\nclass Beta:\n    def gamma(self):\n        return 2\n"
+)
+
+
+def _finding(**kw) -> PluginFinding:
+    base = {"id": "x", "severity": "info", "message": "m", "file": "a.py", "line": 2}
+    base.update(kw)
+    return PluginFinding(**base)
+
+
+def test_applies_only_to_located_findings() -> None:
+    e = EnclosingSymbolEnricher()
+    assert e.applies_to(_finding(file="a.py", line=2)) is True
+    assert e.applies_to(_finding(file="", line=2)) is False
+    assert e.applies_to(_finding(file="a.py", line=0)) is False
+
+
+def test_attaches_innermost_symbol(tmp_path) -> None:
+    (tmp_path / "a.py").write_text(_SRC)
+    e = EnclosingSymbolEnricher()
+    ctx = EnrichmentContext(repo_path=str(tmp_path))
+    out = e.enrich(_finding(file="a.py", line=7), ctx)
+    enr = out.metadata["enrichment"]
+    assert enr["enclosing_symbol"] == "gamma"
+    assert enr["enclosing_kind"] == "function"
+    assert "enclosing_symbol" in enr["sources"]
+
+
+def test_is_deterministic(tmp_path) -> None:
+    (tmp_path / "a.py").write_text(_SRC)
+    e = EnclosingSymbolEnricher()
+    ctx = EnrichmentContext(repo_path=str(tmp_path))
+    f = _finding(file="a.py", line=2)
+    assert e.enrich(f, ctx).to_dict() == e.enrich(f, ctx).to_dict()  # Determinism
+
+
+def test_missing_file_is_fail_open(tmp_path) -> None:
+    e = EnclosingSymbolEnricher()
+    ctx = EnrichmentContext(repo_path=str(tmp_path))
+    f = _finding(file="nope.py", line=2)
+    assert e.enrich(f, ctx) == f  # Availability: finding survives unchanged
+
+
+def test_enriches_dict_findings(tmp_path) -> None:
+    (tmp_path / "a.py").write_text(_SRC)
+    e = EnclosingSymbolEnricher()
+    ctx = EnrichmentContext(repo_path=str(tmp_path))
+    out = e.enrich({"file": "a.py", "line": 2, "severity": "info"}, ctx)
+    assert out["metadata"]["enrichment"]["enclosing_symbol"] == "alpha"
+    assert out["severity"] == "info"  # Integrity: original fields preserved

--- a/tests/unit/plugins/test_code_graph_enricher.py
+++ b/tests/unit/plugins/test_code_graph_enricher.py
@@ -1,0 +1,58 @@
+"""CodeGraphEnricher (detect-then-enrich, ADR-006).
+# tested-by: tests/unit/plugins/test_code_graph_enricher.py
+
+DPS-12 domains: Determinism (same repo+finding -> same enrichment), Availability
+(fail-open: an unbuildable/empty graph never drops the finding), Boundedness (the
+attached blast radius is capped).
+"""
+
+from __future__ import annotations
+
+from eedom.core.enrichment import EnrichmentContext
+from eedom.core.plugin import PluginFinding
+from eedom.plugins.enrichers.code_graph import CodeGraphEnricher
+
+_SRC = "def helper():\n    return 1\n\n\ndef caller():\n    return helper()\n"
+
+
+def _finding(**kw) -> PluginFinding:
+    base = {"id": "x", "severity": "info", "message": "m", "file": "a.py", "line": 2}
+    base.update(kw)
+    return PluginFinding(**base)
+
+
+def _repo(tmp_path, monkeypatch):
+    (tmp_path / "a.py").write_text(_SRC)
+    monkeypatch.setenv("EEDOM_GRAPH_DB", str(tmp_path / "graph.db"))
+    return EnrichmentContext(repo_path=str(tmp_path))
+
+
+def test_applies_only_to_code_findings() -> None:
+    e = CodeGraphEnricher()
+    assert e.applies_to(_finding(file="a.py", line=2)) is True
+    assert e.applies_to(_finding(file="README.md", line=2)) is False
+    assert e.applies_to(_finding(file="a.py", line=0)) is False
+
+
+def test_attaches_symbol_and_blast_radius(tmp_path, monkeypatch) -> None:
+    ctx = _repo(tmp_path, monkeypatch)
+    out = CodeGraphEnricher().enrich(_finding(file="a.py", line=2), ctx)
+    enr = out.metadata["enrichment"]
+    assert enr["enclosing_symbol"] == "helper"
+    assert "blast_radius" in enr and "blast_radius_count" in enr
+    assert any(c.get("name") == "caller" for c in enr["blast_radius"])  # upstream caller found
+    assert "code_graph" in enr["sources"]
+
+
+def test_is_deterministic(tmp_path, monkeypatch) -> None:
+    ctx = _repo(tmp_path, monkeypatch)
+    e = CodeGraphEnricher()
+    f = _finding(file="a.py", line=2)
+    assert e.enrich(f, ctx).to_dict() == e.enrich(f, ctx).to_dict()  # Determinism (cached graph)
+
+
+def test_unindexable_repo_is_fail_open(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("EEDOM_GRAPH_DB", str(tmp_path / "graph.db"))
+    ctx = EnrichmentContext(repo_path=str(tmp_path))  # empty repo, no symbols
+    f = _finding(file="a.py", line=2)
+    assert CodeGraphEnricher().enrich(f, ctx) == f  # Availability: survives unchanged

--- a/tests/unit/plugins/test_semgrep_enricher.py
+++ b/tests/unit/plugins/test_semgrep_enricher.py
@@ -1,0 +1,80 @@
+"""SemgrepEnricher (detect-then-enrich, ADR-006).
+# tested-by: tests/unit/plugins/test_semgrep_enricher.py
+
+DPS-12 domains: Determinism (same matches -> same enrichment), Availability
+(fail-open: a crashing/absent tool never drops the finding), Boundedness (related
+matches are line-windowed and capped), Isolation (per-file results cached once).
+"""
+
+from __future__ import annotations
+
+import eedom.plugins.enrichers.semgrep as mod
+from eedom.core.enrichment import EnrichmentContext
+from eedom.core.plugin import PluginFinding
+from eedom.plugins.enrichers.semgrep import SemgrepEnricher
+
+
+def _finding(**kw) -> PluginFinding:
+    base = {"id": "x", "severity": "info", "message": "m", "file": "a.py", "line": 20}
+    base.update(kw)
+    return PluginFinding(**base)
+
+
+def _match(line: int, check_id: str = "rule", sev: str = "WARNING") -> dict:
+    return {
+        "check_id": check_id,
+        "start": {"line": line},
+        "extra": {"message": f"msg {line}", "severity": sev},
+    }
+
+
+def test_applies_only_to_supported_located_files() -> None:
+    e = SemgrepEnricher()
+    assert e.applies_to(_finding(file="a.py", line=20)) is True
+    assert e.applies_to(_finding(file="notes.md", line=20)) is False
+    assert e.applies_to(_finding(file="a.py", line=0)) is False
+
+
+def test_attaches_nearby_matches_and_windows_out_far_ones(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "run_semgrep", lambda *a, **k: {"results": [_match(22), _match(200)]})
+    out = SemgrepEnricher().enrich(_finding(line=20), EnrichmentContext(repo_path="."))
+    related = out.metadata["enrichment"]["related"]
+    assert [m["line"] for m in related] == [22]  # 200 is outside the ±25 window
+    assert "semgrep" in out.metadata["enrichment"]["sources"]
+
+
+def test_no_nearby_matches_leaves_finding_unchanged(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "run_semgrep", lambda *a, **k: {"results": [_match(999)]})
+    f = _finding(line=20)
+    assert SemgrepEnricher().enrich(f, EnrichmentContext(repo_path=".")) == f
+
+
+def test_tool_crash_is_fail_open(monkeypatch) -> None:
+    def boom(*a, **k):
+        raise RuntimeError("opengrep exploded")
+
+    monkeypatch.setattr(mod, "run_semgrep", boom)
+    f = _finding(line=20)
+    assert SemgrepEnricher().enrich(f, EnrichmentContext(repo_path=".")) == f  # Availability
+
+
+def test_caps_related_matches(monkeypatch) -> None:
+    many = {"results": [_match(20 + i, check_id=f"r{i}") for i in range(20)]}
+    monkeypatch.setattr(mod, "run_semgrep", lambda *a, **k: many)
+    out = SemgrepEnricher().enrich(_finding(line=20), EnrichmentContext(repo_path="."))
+    assert len(out.metadata["enrichment"]["related"]) == mod._MAX_RELATED  # Boundedness
+
+
+def test_results_cached_per_file(monkeypatch) -> None:
+    calls = {"n": 0}
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return {"results": [_match(20)]}
+
+    monkeypatch.setattr(mod, "run_semgrep", counting)
+    e = SemgrepEnricher()
+    ctx = EnrichmentContext(repo_path=".")
+    e.enrich(_finding(line=20), ctx)
+    e.enrich(_finding(line=21), ctx)
+    assert calls["n"] == 1  # Isolation: one subprocess per file, reused across findings

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -557,12 +557,12 @@ class TestGenerateBaseSbom:
         checkout_calls = [cmd for cmd in cmds if "checkout" in cmd]
         worktree_calls = [cmd for cmd in cmds if "worktree" in cmd]
 
-        assert len(checkout_calls) == 0, (
-            f"Must not use git checkout (race condition): {checkout_calls}"
-        )
-        assert len(worktree_calls) >= 2, (
-            f"Expected worktree add+remove calls, found: {worktree_calls}"
-        )
+        assert (
+            len(checkout_calls) == 0
+        ), f"Must not use git checkout (race condition): {checkout_calls}"
+        assert (
+            len(worktree_calls) >= 2
+        ), f"Expected worktree add+remove calls, found: {worktree_calls}"
 
     def test_worktree_cleaned_up_on_syft_failure(self):
         """The worktree must be removed via 'worktree remove' even if run_syft raises."""
@@ -594,9 +594,9 @@ class TestGenerateBaseSbom:
         calls = mock_run.call_args_list
         cmds = [c.args[0] for c in calls if c.args and isinstance(c.args[0], list)]
         remove_calls = [cmd for cmd in cmds if "worktree" in cmd and "remove" in cmd]
-        assert len(remove_calls) >= 1, (
-            f"Worktree must be removed on failure, subprocess calls were: {cmds}"
-        )
+        assert (
+            len(remove_calls) >= 1
+        ), f"Worktree must be removed on failure, subprocess calls were: {cmds}"
 
 
 class TestRunSyftPathValidation:
@@ -974,9 +974,9 @@ class TestBuildDepSummaryPathTraversal:
         # After fix: must return {} without reading sensitive/package.json.
         # Before fix: reads it and includes "sentinel-evil-pkg" in direct.
         evil = [d for d in result.get("direct", []) if d["name"] == "sentinel-evil-pkg"]
-        assert evil == [], (
-            f"Path traversal allowed reading 'sentinel-evil-pkg' from outside repo: {result}"
-        )
+        assert (
+            evil == []
+        ), f"Path traversal allowed reading 'sentinel-evil-pkg' from outside repo: {result}"
 
     def test_sbom_absolute_path_names_are_sanitized_in_shared(self, tmp_path):
         """SBOM component names that look like filesystem paths must not appear verbatim
@@ -1009,7 +1009,7 @@ class TestBuildDepSummaryPathTraversal:
 
         # After fix: shared names must not start with "/" or contain "..".
         for item in result.get("shared", []):
-            assert not item["name"].startswith("/"), (
-                f"Absolute path leaked into shared: {item['name']!r}"
-            )
+            assert not item["name"].startswith(
+                "/"
+            ), f"Absolute path leaked into shared: {item['name']!r}"
             assert ".." not in item["name"], f"Traversal sequence in shared name: {item['name']!r}"

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -385,6 +385,47 @@ class TestScanCode:
         assert result["status"] == "error"
         assert "not_installed" in result["error"]
 
+    def test_attaches_enrichment_when_source_available(self, tmp_path, monkeypatch):
+        """scan_code findings carry detect-then-enrich context (ADR-006)."""
+        from unittest.mock import MagicMock
+
+        from eedom.agent.tools import scan_code
+        from eedom.core.plugin import PluginResult
+
+        (tmp_path / "app.py").write_text("def handler():\n    eval(x)\n    return 1\n")
+        monkeypatch.setenv("EEDOM_GRAPH_DB", str(tmp_path / "graph.db"))
+
+        mock_result = PluginResult(
+            plugin_name="semgrep",
+            findings=[
+                {
+                    "rule_id": "python.security.eval-injection",
+                    "file": "app.py",
+                    "start_line": 2,
+                    "end_line": 2,
+                    "severity": "ERROR",
+                    "message": "Detected eval() usage",
+                }
+            ],
+        )
+        mock_plugin = MagicMock()
+        mock_plugin.run.return_value = mock_result
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = mock_plugin
+
+        with patch(
+            "eedom.agent.tools.get_default_registry",
+            return_value=mock_registry,
+        ):
+            result = scan_code(
+                diff_text="diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1 +2 @@\n+eval(x)",
+                repo_path=str(tmp_path),
+            )
+        assert result["status"] == "ok"
+        enrichment = result["findings"][0]["metadata"]["enrichment"]
+        assert enrichment["enclosing_symbol"] == "handler"
+        assert "enclosing_symbol" in enrichment["sources"]
+
     def test_only_scans_changed_files(self):
         from eedom.agent.tool_helpers import (
             extract_changed_files as _extract_changed_files,
@@ -516,12 +557,12 @@ class TestGenerateBaseSbom:
         checkout_calls = [cmd for cmd in cmds if "checkout" in cmd]
         worktree_calls = [cmd for cmd in cmds if "worktree" in cmd]
 
-        assert (
-            len(checkout_calls) == 0
-        ), f"Must not use git checkout (race condition): {checkout_calls}"
-        assert (
-            len(worktree_calls) >= 2
-        ), f"Expected worktree add+remove calls, found: {worktree_calls}"
+        assert len(checkout_calls) == 0, (
+            f"Must not use git checkout (race condition): {checkout_calls}"
+        )
+        assert len(worktree_calls) >= 2, (
+            f"Expected worktree add+remove calls, found: {worktree_calls}"
+        )
 
     def test_worktree_cleaned_up_on_syft_failure(self):
         """The worktree must be removed via 'worktree remove' even if run_syft raises."""
@@ -553,9 +594,9 @@ class TestGenerateBaseSbom:
         calls = mock_run.call_args_list
         cmds = [c.args[0] for c in calls if c.args and isinstance(c.args[0], list)]
         remove_calls = [cmd for cmd in cmds if "worktree" in cmd and "remove" in cmd]
-        assert (
-            len(remove_calls) >= 1
-        ), f"Worktree must be removed on failure, subprocess calls were: {cmds}"
+        assert len(remove_calls) >= 1, (
+            f"Worktree must be removed on failure, subprocess calls were: {cmds}"
+        )
 
 
 class TestRunSyftPathValidation:
@@ -641,8 +682,7 @@ class TestExtractChangedFilesEdgeCases:
         from eedom.agent.tool_helpers import extract_changed_files
 
         diff = (
-            "diff --git a/image.png b/image.png\n"
-            "Binary files a/image.png and b/image.png differ\n"
+            "diff --git a/image.png b/image.png\nBinary files a/image.png and b/image.png differ\n"
         )
         result = extract_changed_files(diff)
         assert result == ["image.png"]
@@ -708,13 +748,7 @@ class TestRegistryRouting:
 
         get_agent_settings.cache_clear()
 
-    _DIFF_PY = (
-        "diff --git a/app.py b/app.py\n"
-        "--- a/app.py\n"
-        "+++ b/app.py\n"
-        "@@ -1 +1 @@\n"
-        "+x = 1\n"
-    )
+    _DIFF_PY = "diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n+x = 1\n"
     _DIFF_YAML = (
         "diff --git a/deploy.yaml b/deploy.yaml\n"
         "--- a/deploy.yaml\n"
@@ -940,9 +974,9 @@ class TestBuildDepSummaryPathTraversal:
         # After fix: must return {} without reading sensitive/package.json.
         # Before fix: reads it and includes "sentinel-evil-pkg" in direct.
         evil = [d for d in result.get("direct", []) if d["name"] == "sentinel-evil-pkg"]
-        assert (
-            evil == []
-        ), f"Path traversal allowed reading 'sentinel-evil-pkg' from outside repo: {result}"
+        assert evil == [], (
+            f"Path traversal allowed reading 'sentinel-evil-pkg' from outside repo: {result}"
+        )
 
     def test_sbom_absolute_path_names_are_sanitized_in_shared(self, tmp_path):
         """SBOM component names that look like filesystem paths must not appear verbatim
@@ -975,7 +1009,7 @@ class TestBuildDepSummaryPathTraversal:
 
         # After fix: shared names must not start with "/" or contain "..".
         for item in result.get("shared", []):
-            assert not item["name"].startswith(
-                "/"
-            ), f"Absolute path leaked into shared: {item['name']!r}"
+            assert not item["name"].startswith("/"), (
+                f"Absolute path leaked into shared: {item['name']!r}"
+            )
             assert ".." not in item["name"], f"Traversal sequence in shared name: {item['name']!r}"

--- a/tests/unit/test_cpd_runner.py
+++ b/tests/unit/test_cpd_runner.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from eedom.plugins._runners.cpd_runner import _parse_cpd_xml, run_cpd
+from eedom.plugins._runners.cpd_runner import (
+    _enclosing_symbol,
+    _enrich_clones,
+    _parse_cpd_xml,
+    run_cpd,
+)
 
 
 def test_parse_cpd_xml_handles_pmd_7_namespace() -> None:
@@ -63,3 +68,56 @@ def test_run_cpd_parses_xml_with_stdout_preamble(mock_run) -> None:
 
     assert result["duplicate_count"] == 1
     assert result["duplicates"][0]["tokens"] == 80
+
+
+def test_enclosing_symbol_python_picks_innermost(tmp_path) -> None:
+    f = tmp_path / "m.py"
+    f.write_text(
+        "def alpha():\n"
+        "    x = 1\n"
+        "    return x\n"
+        "\n"
+        "class Beta:\n"
+        "    def gamma(self):\n"
+        "        return 2\n"
+    )
+    assert _enclosing_symbol(str(f), 2) == "alpha"
+    assert _enclosing_symbol(str(f), 7) == "gamma"  # innermost (method) wins over the class
+    assert _enclosing_symbol(str(f), 99) == ""  # out of range, fail-open
+
+
+def test_enrich_clones_adds_occurrences_symbol_and_home(tmp_path) -> None:
+    a = tmp_path / "a.py"
+    a.write_text("def foo():\n    return 1\n")
+    b = tmp_path / "b.py"
+    b.write_text("def bar():\n    return 1\n")
+    dupes = [
+        {  # cross-file, lower impact
+            "tokens": 50,
+            "lines": 2,
+            "language": "python",
+            "locations": [
+                {"file": str(a), "start_line": 1, "end_line": 2},
+                {"file": str(b), "start_line": 1, "end_line": 2},
+            ],
+        },
+        {  # same-file, higher impact (tokens x occurrences)
+            "tokens": 90,
+            "lines": 2,
+            "language": "python",
+            "locations": [
+                {"file": str(a), "start_line": 1, "end_line": 2},
+                {"file": str(a), "start_line": 1, "end_line": 2},
+            ],
+        },
+    ]
+
+    out = _enrich_clones(dupes, str(tmp_path))
+
+    assert out[0]["tokens"] == 90  # ranked by tokens x occurrences
+    assert out[0]["occurrences"] == 2
+    assert "local helper" in out[0]["suggested_home"]  # same file
+    cross = next(d for d in out if d["tokens"] == 50)
+    assert "shared module" in cross["suggested_home"]  # cross file
+    assert cross["locations"][0]["symbol"] == "foo"
+    assert cross["locations"][1]["symbol"] == "bar"

--- a/tests/unit/test_enricher_registry.py
+++ b/tests/unit/test_enricher_registry.py
@@ -16,7 +16,7 @@ from eedom.core.registries import ENRICHERS
 
 load_adapters()
 
-_EXPECTED = {"enclosing_symbol", "code_graph"}
+_EXPECTED = {"enclosing_symbol", "code_graph", "semgrep"}
 
 
 def test_expected_enrichers_registered() -> None:

--- a/tests/unit/test_enricher_registry.py
+++ b/tests/unit/test_enricher_registry.py
@@ -1,0 +1,35 @@
+"""Conformance tests for the ENRICHERS registry (detect-then-enrich, ADR-006).
+# tested-by: tests/unit/test_enricher_registry.py
+
+Mirrors ``test_port_registries``: the composition tier's ``load_adapters`` triggers
+the cross-tier self-registration, then every registered enricher must resolve to an
+``EnricherPort``-satisfying instance and unknown keys must raise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from eedom.composition.bootstrap import load_adapters
+from eedom.core.ports import EnricherPort
+from eedom.core.registries import ENRICHERS
+
+load_adapters()
+
+_EXPECTED = {"enclosing_symbol", "code_graph"}
+
+
+def test_expected_enrichers_registered() -> None:
+    assert set(ENRICHERS.keys()) >= _EXPECTED
+
+
+@pytest.mark.parametrize("key", sorted(_EXPECTED))
+def test_enricher_satisfies_port(key: str) -> None:
+    instance = ENRICHERS.create(key)
+    assert isinstance(instance, EnricherPort)
+    assert instance.name == key
+
+
+def test_unknown_enricher_raises() -> None:
+    with pytest.raises(KeyError):
+        ENRICHERS.create("does-not-exist")

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -12,7 +12,9 @@ from eedom.core.enrich import enrich_findings
 from eedom.core.enrichment import Enrichment, EnrichmentContext, enclosing_symbol
 from eedom.core.plugin import PluginFinding
 
-_PY = "def alpha():\n    x = 1\n    return x\n\nclass Beta:\n    def gamma(self):\n        return 2\n"
+_PY = (
+    "def alpha():\n    x = 1\n    return x\n\nclass Beta:\n    def gamma(self):\n        return 2\n"
+)
 
 
 def test_enclosing_symbol_python_is_innermost_and_authoritative() -> None:

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,0 +1,86 @@
+"""Detect-then-enrich core seam (ADR-006).
+# tested-by: tests/unit/test_enrichment.py
+
+DPS-12 domains exercised: Determinism (same input -> same enrichment), Availability
+(fail-open: an enricher raising never drops a finding), Boundedness (the pass respects
+the enrichment budget).
+"""
+
+from __future__ import annotations
+
+from eedom.core.enrich import enrich_findings
+from eedom.core.enrichment import Enrichment, EnrichmentContext, enclosing_symbol
+from eedom.core.plugin import PluginFinding
+
+_PY = "def alpha():\n    x = 1\n    return x\n\nclass Beta:\n    def gamma(self):\n        return 2\n"
+
+
+def test_enclosing_symbol_python_is_innermost_and_authoritative() -> None:
+    assert enclosing_symbol(_PY, 2, is_python=True) == ("alpha", "function")
+    assert enclosing_symbol(_PY, 7, is_python=True) == ("gamma", "function")
+    assert enclosing_symbol(_PY, 5, is_python=True) == ("Beta", "class")
+    assert enclosing_symbol(_PY, 99, is_python=True) == ("", "")  # module-level, not "scan upward"
+
+
+def test_enclosing_symbol_generic_languages() -> None:
+    assert enclosing_symbol("func helper() {\n  return 1\n}\n", 2, is_python=False) == (
+        "helper",
+        "function",
+    )
+    assert enclosing_symbol("class Foo:\n  pass\n", 2, is_python=False) == ("Foo", "class")
+
+
+def test_enrichment_model_defaults_serialize() -> None:
+    e = Enrichment(enclosing_symbol="scan", enclosing_kind="function", sources=("x",))
+    dumped = e.model_dump()
+    assert dumped["enclosing_symbol"] == "scan" and dumped["sources"] == ("x",)
+
+
+def _finding(**kw) -> PluginFinding:
+    base = {"id": "x", "severity": "info", "message": "m", "file": "a.py", "line": 1}
+    base.update(kw)
+    return PluginFinding(**base)
+
+
+class _Tagger:
+    name = "tagger"
+
+    def applies_to(self, finding: PluginFinding) -> bool:
+        return True
+
+    def enrich(self, finding: PluginFinding, ctx: EnrichmentContext) -> PluginFinding:
+        md = dict(finding.metadata)
+        md["enrichment"] = {"sources": ["tagger"]}
+        return finding.model_copy(update={"metadata": md})
+
+
+class _Boom:
+    name = "boom"
+
+    def applies_to(self, finding: PluginFinding) -> bool:
+        return True
+
+    def enrich(self, finding: PluginFinding, ctx: EnrichmentContext) -> PluginFinding:
+        raise RuntimeError("enricher exploded")
+
+
+def test_enrich_applies_and_is_deterministic() -> None:
+    ctx = EnrichmentContext(repo_path=".")
+    f = _finding()
+    out1 = enrich_findings([f], [_Tagger()], ctx)
+    out2 = enrich_findings([f], [_Tagger()], ctx)
+    assert out1[0].metadata["enrichment"]["sources"] == ["tagger"]
+    assert out1[0].to_dict() == out2[0].to_dict()  # Determinism
+
+
+def test_enrich_is_fail_open() -> None:
+    ctx = EnrichmentContext(repo_path=".")
+    f = _finding()
+    out = enrich_findings([f], [_Boom()], ctx)
+    assert out[0] == f  # Availability: finding survives an exploding enricher, unchanged
+
+
+def test_enrich_respects_budget() -> None:
+    ctx = EnrichmentContext(repo_path=".", enrichment_timeout=-1.0)  # deadline already passed
+    out = enrich_findings([_finding()], [_Tagger()], ctx)
+    assert "enrichment" not in out[0].metadata  # Boundedness: nothing runs past budget

--- a/tests/unit/test_sarif.py
+++ b/tests/unit/test_sarif.py
@@ -93,6 +93,49 @@ class TestSinglePluginWithFindings:
         assert loc["region"]["startLine"] == 42
 
 
+class TestEnrichmentProperties:
+    """Detect-then-enrich packets (ADR-006) surface in the SARIF property bag."""
+
+    def _result_with_enrichment(self) -> PluginResult:
+        return PluginResult(
+            plugin_name="semgrep",
+            findings=[
+                {
+                    "rule_id": "python.eval",
+                    "file": "src/app.py",
+                    "start_line": 10,
+                    "severity": "ERROR",
+                    "message": "eval is dangerous",
+                    "metadata": {
+                        "enrichment": {
+                            "enclosing_symbol": "handler",
+                            "enclosing_kind": "function",
+                            "sources": ["enclosing_symbol", "code_graph"],
+                        }
+                    },
+                }
+            ],
+        )
+
+    def test_enrichment_in_properties(self) -> None:
+        out = to_sarif([self._result_with_enrichment()])
+        result = out["runs"][0]["results"][0]
+        assert result["properties"]["enrichment"]["enclosing_symbol"] == "handler"
+        assert "code_graph" in result["properties"]["enrichment"]["sources"]
+
+    def test_no_properties_key_without_enrichment(self) -> None:
+        plain = PluginResult(
+            plugin_name="semgrep",
+            findings=[{"rule_id": "r", "file": "a.py", "start_line": 1, "severity": "INFO"}],
+        )
+        out = to_sarif([plain])
+        assert "properties" not in out["runs"][0]["results"][0]
+
+    def test_sarif_with_enrichment_is_json_serialisable(self) -> None:
+        out = to_sarif([self._result_with_enrichment()])
+        assert json.loads(json.dumps(out))  # round-trips cleanly
+
+
 class TestSeverityMapping:
     """Severity fields are mapped correctly to SARIF levels."""
 


### PR DESCRIPTION
## Summary

Introduces the **detect-then-enrich** pattern (ADR-006): after a plugin detects a finding, eedom deterministically attaches context (enclosing symbol, code-graph blast radius, nearby static-analysis matches) into `metadata['enrichment']` so any downstream consumer — JSON report, SARIF, the GATEKEEPER agent — reasons with minimal effort. Zero-LLM, fail-open, time-bounded, and **verdict-independent** (enrichment only adds metadata; the gate never depends on it).

Also enhances the `cpd` plugin into a language-agnostic, N-way clone detector that is the first exemplar of the pattern.

## What's included

**CPD enhancement** (`991c115`)
- Recursive `--file-list` fix (PMD was silently ignoring files), PMD-7 all-languages map + jscpd fallback, N-way `occurrences`, ranked by tokens × occurrences.
- Per-clone enrichment: enclosing symbol + `suggested_home`.

**Core enrichment seam** (`3a92e2d`)
- `EnricherPort` protocol, core-owned `ENRICHERS` registry, `Enrichment` value object + `EnrichmentContext`, the canonical `enclosing_symbol` resolver (single source of truth, shared by cpd + the enrichers), and the sequential `enrich_findings` pass (fail-open, budgeted).

**Cross-cutting enrichers + wiring** (`b01fd38`)
- `EnclosingSymbolEnricher` (detectors tier) and `CodeGraphEnricher` (plugins tier), self-registering into `ENRICHERS`.
- Wired through `composition.bootstrap` + `review_repository` so **every plugin's findings are enriched**; auto-surfaced in the JSON report.

**Dup-scan harness** (`8a0892e`)
- `scripts/dup-scan.sh` — blended PMD CPD + jscpd + pylint R0801 + vulture + grimp deterministic dogfood sweep.

**Opt-in semgrep enricher + agent enrichment** (`cae42d4`)
- `SemgrepEnricher` (opt-in, per-file budgeted, cached) attaching nearby rule matches.
- GATEKEEPER `scan_code` now enriches its findings via a settings-free default builder.

**SARIF parity** (`3bbc5db`)
- Enrichment surfaces in each SARIF result's `properties.enrichment`, at parity with the JSON report.

## Architecture notes
- Tier boundaries respected (enforced arch-guard passes): the port/model/registry/pass live in `core`; each enricher adapter lives in the tier of the tool it uses (CodeGraph → `plugins`, ast resolver → `detectors`) and self-registers, triggered by `composition.load_adapters`.
- New `CodeGraph.symbol_at(file, line)` deterministic query maps a location to its enclosing symbol.
- All enrichment is deterministic, zero-LLM, fail-open, and time-bounded (`enrichment_timeout`).

## Testing
- Full unit suite green on host (2295 passed, 11 skipped). New tests follow DPS-12 domains: Determinism, Availability/fail-open, Boundedness, Integrity, Isolation.
- `ruff check` + `black --check` clean.
- `docs/CAPABILITIES.md` updated (enricher count, SARIF note, detect-then-enrich row).

> Note: the GATEKEEPER `scan_code` enrichment test is gated on `eedom[copilot]` (`agent_framework`) and runs in CI/container; its underlying logic was smoke-tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat

---
_Generated by [Claude Code](https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat)_