### PR TITLE
fix(semgrep): repair two rules that degraded the scanner and blocked the release gate

### DIFF
--- a/policies/semgrep/org-code-smells.yaml
+++ b/policies/semgrep/org-code-smells.yaml
@@ -130,7 +130,7 @@ rules:
             ...
           }
       - pattern-not-inside: |
-          resource "aws_s3_bucket_server_side_encryption_configuration" ... {
+          resource "aws_s3_bucket_server_side_encryption_configuration" $ENC {
             ...
           }
     message: >

--- a/policies/semgrep/solid-first.yaml
+++ b/policies/semgrep/solid-first.yaml
@@ -40,15 +40,18 @@ rules:
   - id: first-test-no-assert
     patterns:
       - pattern: |
-          def test_$NAME(...):
+          def $NAME(...):
               ...
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: ^test_
       - pattern-not: |
-          def test_$NAME(...):
+          def $NAME(...):
               ...
               assert ...
               ...
       - pattern-not: |
-          def test_$NAME(...):
+          def $NAME(...):
               ...
               with pytest.raises($E):
                   ...

--- a/tests/e2e/test_semgrep_rules_parse.py
+++ b/tests/e2e/test_semgrep_rules_parse.py
@@ -1,0 +1,55 @@
+# tested-by: self (e2e)
+"""E2E: every org semgrep rule must parse (regression guard for the release gate).
+
+A single malformed rule makes opengrep abort with a parse error, which the semgrep
+plugin surfaces as a degraded-scanner error → an ``eedom-plugin-error`` SARIF result →
+counted as a *crashed* plugin by the nightly release gate (``release-candidate.yml``),
+blocking the release. This caught two such rules (the Terraform ``no-unencrypted-s3``
+``resource "..." ...`` pattern and the Python ``def test_$NAME`` prefix-metavariable);
+this test fails fast if any new rule reintroduces a parse error.
+
+Runs only in the e2e container (EEDOM_E2E=1) and only when the opengrep binary is present.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import E2E_ENABLED
+
+pytestmark = pytest.mark.skipif(not E2E_ENABLED, reason="E2E tests require EEDOM_E2E=1")
+
+_RULES_DIR = Path(__file__).resolve().parents[2] / "policies" / "semgrep"
+
+
+def test_all_org_semgrep_rules_parse(tmp_path: Path) -> None:
+    """opengrep loads every policies/semgrep rule with zero parse errors."""
+    opengrep = shutil.which("opengrep")
+    if opengrep is None:
+        pytest.skip("opengrep binary not installed")
+
+    # A trivial target across a few languages — rule *loading* is what we assert,
+    # so the file contents don't matter, only that opengrep parses the rule set.
+    (tmp_path / "s.py").write_text("x = 1\n")
+    (tmp_path / "m.tf").write_text('resource "aws_s3_bucket" "b" {}\n')
+
+    proc = subprocess.run(
+        [opengrep, "--config", str(_RULES_DIR), "--json", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    data = json.loads(proc.stdout)
+    parse_errors = [
+        e.get("message", "")
+        for e in data.get("errors", [])
+        if e.get("level") == "error"
+        and ("Parse_error" in e.get("message", "") or "Invalid pattern" in e.get("message", ""))
+    ]
+    assert not parse_errors, "semgrep rule parse errors:\n" + "\n".join(parse_errors)


### PR DESCRIPTION
## Problem

The nightly release gate (`release-candidate.yml`) runs a full `eedom review` on the repo and **fails the release if any plugin crashed** (`errors > 0 or crashed > 0`). Two org semgrep rules had invalid patterns that made opengrep abort with a parse error; the semgrep plugin surfaces that as a degraded-scanner error → an `eedom-plugin-error` SARIF result → counted as a *crashed* plugin → **every release candidate blocked**. (Also visible as `semgrep | error: scanner degraded` in normal PR reviews.)

## Fixes

- **`org.terraform.no-unencrypted-s3`** — `resource "..." ... {` is invalid HCL pattern syntax (ellipsis in the resource-label position). Switched to a `$ENC` metavariable, matching the working first pattern's `$NAME`.
- **`first-test-no-assert`** — `def test_$NAME(...)`: semgrep can't prefix a metavariable with a literal. Switched to a full `$NAME` metavariable + `metavariable-regex: ^test_`.

Both validated with **opengrep 1.20.0** (the exact CI version): the `policies/semgrep` dir now loads with **zero parse errors** (was 2).

## Regression guard

Adds `tests/e2e/test_semgrep_rules_parse.py` — loads every rule via opengrep and fails fast if any future rule reintroduces a parse error. Runs in the e2e / release jobs where opengrep is installed; skips otherwise.

## Verification
- `opengrep --config policies/semgrep` → 0 parse errors (verified locally with the CI binary).
- `tests/unit/test_solid_first_checks.py` (14) + capability-count + policy guards all green.
- No new findings on eedom's own source (no `aws_s3_bucket` Terraform outside test fixtures), so the self-review verdict is unaffected.

No rule count change (still 61). Pre-existing bug, surfaced while verifying the release pipeline after #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat

---
_Generated by [Claude Code](https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat)_