### PR TITLE
fix(review): single source of truth for the verdict (header vs body can't disagree)

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -430,7 +430,11 @@ jobs:
           PID_SARIF=$!
           uv run eedom review --repo-path . --all $DIFF_FLAG --output .temp/review.md &
           PID_MD=$!
-          wait $PID_SARIF $PID_MD
+          # review.json carries the single source of truth (verdict + counts); the
+          # verdict step below reads it instead of re-deriving from SARIF.
+          uv run eedom review --repo-path . --all $DIFF_FLAG --format json --output .temp/review.json &
+          PID_JSON=$!
+          wait $PID_SARIF $PID_MD $PID_JSON
 
       - name: Upload review artifacts
         if: always()
@@ -440,6 +444,7 @@ jobs:
           path: |
             .temp/review.sarif
             .temp/review.md
+            .temp/review.json
           retention-days: 7
           if-no-files-found: ignore
 
@@ -522,70 +527,36 @@ jobs:
       - name: Compute verdict
         id: verdict
         run: |
-          python3 << 'VERDICT_SCRIPT'
-          import json, os, re
-
-          out_path = os.environ["GITHUB_OUTPUT"]
-          errors = 0
-          warnings = 0
-          crashed = 0
-          skipped = 0
-          total = 0
-
-          sarif_path = ".temp/review.sarif"
-          md_path = ".temp/review.md"
-
-          if os.path.isfile(sarif_path):
-              with open(sarif_path) as f:
-                  sarif = json.load(f)
-              runs = sarif.get("runs", [])
-              total = len(runs)
-              for r in runs:
-                  plugin_errored = False
-                  for res in r.get("results", []):
-                      if res.get("ruleId") == "eedom-plugin-error":
-                          crashed += 1
-                          plugin_errored = True
-                          break
-                  if plugin_errored:
-                      continue
-                  for res in r.get("results", []):
-                      if res.get("level") == "error":
-                          errors += 1
-                      elif res.get("level") == "warning":
-                          warnings += 1
-
-          if os.path.isfile(md_path):
-              with open(md_path) as mf:
-                  md = mf.read()
-              if crashed == 0:
-                  crashed = len(re.findall(r"BINARY_CRASHED", md))
-              skipped = len(re.findall(r"NOT_INSTALLED", md))
-              timed_out = len(re.findall(r"\[TIMEOUT\]", md))
-              warnings += timed_out
-
-          if crashed > 0:
-              verdict = "warnings"
-          elif errors > 0:
-              verdict = "blocked"
-          elif warnings > 0 or skipped > 0:
-              verdict = "warnings"
-          else:
-              verdict = "approved"
-
-          with open(out_path, "a") as out:
-              out.write(f"errors={errors}\n")
-              out.write(f"warnings={warnings}\n")
-              out.write(f"crashed={crashed}\n")
-              out.write(f"skipped={skipped}\n")
-              out.write(f"total_plugins={total}\n")
-              out.write(f"verdict={verdict}\n")
-          VERDICT_SCRIPT
+          # Single source of truth: read eedom's own verdict + counts from review.json
+          # (eedom.core.review_summary). No re-derivation from SARIF here — that second
+          # engine is exactly what made the header and the markdown badge disagree.
+          JSON=.temp/review.json
+          if [ -s "$JSON" ]; then
+            RAW=$(jq -r '.verdict // "incomplete"' "$JSON")
+            ERRORS=$(jq -r '.error_count // 0' "$JSON")
+            WARNINGS=$(jq -r '.warning_count // 0' "$JSON")
+            CRASHED=$(jq -r '.crashed_count // 0' "$JSON")
+            SKIPPED=$(jq -r '.skipped_count // 0' "$JSON")
+            TOTAL=$(jq -r '.total_plugins // 0' "$JSON")
+          else
+            RAW=incomplete; ERRORS=0; WARNINGS=0; CRASHED=0; SKIPPED=0; TOTAL=0
+          fi
+          # User-facing label/header says "approved" for the all-clear verdict.
+          VERDICT="$RAW"
+          [ "$RAW" = "clear" ] && VERDICT="approved"
+          {
+            echo "errors=$ERRORS"
+            echo "warnings=$WARNINGS"
+            echo "crashed=$CRASHED"
+            echo "skipped=$SKIPPED"
+            echo "total_plugins=$TOTAL"
+            echo "verdict=$VERDICT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set dom label
         if: github.event_name == 'pull_request' && steps.upstream.outputs.upstream_ok == 'true'
         run: |
-          for LABEL in "dom: approved" "dom: warnings" "dom: blocked"; do
+          for LABEL in "dom: approved" "dom: warnings" "dom: blocked" "dom: incomplete"; do
             gh issue edit "$PR_NUM" --remove-label "$LABEL" 2>/dev/null || true
           done
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -275,6 +275,7 @@ File: `core/nl_query.py`. Keyword-matched SQL queries against the code graph. No
 | Capability | File | Description |
 |------------|------|-------------|
 | Parallel scanning | `core/orchestrator.py` | ThreadPoolExecutor with combined wall-clock timeout. |
+| Unified verdict (SoT) | `core/review_summary.py` | One `summarize_review()` computes verdict + counts + scores; the markdown badge, JSON report, SARIF properties, and CI header/label all consume it (no divergent re-derivation). Diff-scoped gate: only PR-introduced security findings block; pre-existing dependency CVEs are advisory. |
 | Detect-then-enrich | `core/enrich.py`, `core/enrichment.py` | Post-detection pass (ADR-006): every plugin finding is decorated with deterministic context in `metadata['enrichment']` — enclosing symbol (`detectors` enricher), code-graph blast radius (`plugins` enricher), and opt-in nearby semgrep matches (`plugins` enricher). Sequential, fail-open, time-bounded (`enrichment_timeout`); verdict-independent. Pluggable via the `ENRICHERS` registry; also wired into the GATEKEEPER agent's `scan_code`. |
 | Cross-scanner dedup | `core/normalizer.py` | Highest severity wins per (advisory_id, category, package, version). |
 | Evidence chain | `core/seal.py` | Blockchain-style SHA-256 seals. manifest hash + previous seal → seal hash. `verify_seal()` detects tampering. |

--- a/docs/schema/report-v1.0.json
+++ b/docs/schema/report-v1.0.json
@@ -135,6 +135,42 @@
       "title": "Quality Score",
       "type": "number"
     },
+    "error_count": {
+      "default": 0,
+      "description": "Error-level (critical/high) findings.",
+      "title": "Error Count",
+      "type": "integer"
+    },
+    "warning_count": {
+      "default": 0,
+      "description": "Warning-level (medium) findings.",
+      "title": "Warning Count",
+      "type": "integer"
+    },
+    "note_count": {
+      "default": 0,
+      "description": "Note-level (low/info) findings.",
+      "title": "Note Count",
+      "type": "integer"
+    },
+    "crashed_count": {
+      "default": 0,
+      "description": "Plugins that crashed.",
+      "title": "Crashed Count",
+      "type": "integer"
+    },
+    "skipped_count": {
+      "default": 0,
+      "description": "Plugins skipped (e.g. not installed).",
+      "title": "Skipped Count",
+      "type": "integer"
+    },
+    "blocking_count": {
+      "default": 0,
+      "description": "Attributable error-level security findings — what drives a 'blocked' verdict.",
+      "title": "Blocking Count",
+      "type": "integer"
+    },
     "total_findings": {
       "default": 0,
       "title": "Total Findings",

--- a/src/eedom/cli/main.py
+++ b/src/eedom/cli/main.py
@@ -430,8 +430,16 @@ def review(
             enabled=enabled_names,
             scope=resolved_scope or ScanScope.REPO,
         )
-        review_result = review_repository(_ctx, files, repo, options, repo_files=repo_file_list)
+        # Scope the *blocking* decision to the change under review when a diff was
+        # supplied (the workflow passes --diff without --scope). A plain repo scan
+        # leaves changed_files=None so the gate stays repo-wide.
+        is_diff_scoped = diff is not None or resolved_scope == ScanScope.DIFF
+        changed_files = set(files) if is_diff_scoped else None
+        review_result = review_repository(
+            _ctx, files, repo, options, repo_files=repo_file_list, changed_files=changed_files
+        )
         results = review_result.results
+        summary = review_result.summary
 
         if output_format == "sarif" or pr is not None:
             import orjson
@@ -439,7 +447,10 @@ def review(
             from eedom.core.sarif import to_sarif
 
             sarif_doc = to_sarif(
-                results, repo_path=str(repo), max_findings_per_run=sarif_max_findings
+                results,
+                repo_path=str(repo),
+                max_findings_per_run=sarif_max_findings,
+                summary=summary,
             )
 
             if pr is not None:
@@ -482,7 +493,7 @@ def review(
         if output_format == "json":
             from eedom.core.json_report import render_json
 
-            json_text = render_json(results, repo=repo_name or str(repo))
+            json_text = render_json(results, repo=repo_name or str(repo), summary=summary)
             if output:
                 _write_output(output, json_text)
                 click.echo(f"JSON written to {output}")
@@ -497,6 +508,7 @@ def review(
             title=title,
             file_count=len(files),
             plugin_renderers=plugin_map,
+            verdict=summary.verdict.value if summary else None,
         )
         if output:
             _write_output(output, md)

--- a/src/eedom/core/json_report.py
+++ b/src/eedom/core/json_report.py
@@ -15,7 +15,6 @@ from datetime import UTC, datetime
 import orjson
 
 from eedom.core.plugin import PluginResult
-from eedom.core.renderer import calculate_quality_score, calculate_severity_score
 from eedom.core.report_schema import (
     REPORT_SCHEMA_VERSION,
     PluginReportModel,
@@ -23,6 +22,7 @@ from eedom.core.report_schema import (
     ReportModel,
     ReportVerdict,
 )
+from eedom.core.review_summary import ReviewSummary, summarize_review
 
 
 def _plugin_status(result: PluginResult) -> str:
@@ -48,12 +48,13 @@ def render_json(
     results: list[PluginResult],
     repo: str = "",
     commit: str = "",
+    summary: ReviewSummary | None = None,
 ) -> str:
-    from eedom.core.renderer import _build_sections
-
-    verdict, _, _ = _build_sections(results, None)
-    security_score = calculate_severity_score(results)
-    quality_score = calculate_quality_score(results)
+    # Single source of truth: the canonical verdict/counts/scores. Callers pass the
+    # diff-scoped summary; absent that, compute a repo-wide one so the JSON still
+    # agrees with the other outputs.
+    if summary is None:
+        summary = summarize_review(results)
 
     total_findings = sum(len(r.findings) for r in results)
 
@@ -78,9 +79,15 @@ def render_json(
         timestamp=datetime.now(UTC).isoformat(),
         repo=repo,
         commit=commit,
-        verdict=ReportVerdict(verdict),
-        security_score=security_score,
-        quality_score=quality_score,
+        verdict=ReportVerdict(summary.verdict.value),
+        security_score=summary.security_score,
+        quality_score=summary.quality_score,
+        error_count=summary.error_count,
+        warning_count=summary.warning_count,
+        note_count=summary.note_count,
+        crashed_count=summary.crashed_count,
+        skipped_count=summary.skipped_count,
+        blocking_count=summary.blocking_count,
         total_findings=total_findings,
         total_plugins=len(results),
         plugins=plugins,

--- a/src/eedom/core/renderer.py
+++ b/src/eedom/core/renderer.py
@@ -170,6 +170,7 @@ def render_comment(
     file_count: int = 0,
     template_dir: Path | None = None,
     plugin_renderers: dict[str, object] | None = None,
+    verdict: str | None = None,
 ) -> str:
     # Serialize findings to plain dicts so the dict-shaped renderer internals
     # (_build_sections -> templates, _extract_mi, classify_findings) operate on
@@ -184,9 +185,17 @@ def render_comment(
     template = env.get_template("comment.md.j2")
 
     if _is_monorepo(results):
-        verdict, summary_rows, sections = _build_monorepo_sections(results, plugin_renderers)
+        _, summary_rows, sections = _build_monorepo_sections(results, plugin_renderers)
     else:
-        verdict, summary_rows, sections = _build_sections(results, plugin_renderers)
+        _, summary_rows, sections = _build_sections(results, plugin_renderers)
+
+    # The badge verdict is the single source of truth (review_summary). Callers pass
+    # the canonical, diff-scoped verdict; absent that, fall back to the repo-wide one
+    # so the badge still matches summarize_review rather than the section builder.
+    if verdict is None:
+        from eedom.core.review_summary import summarize_review
+
+        verdict = summarize_review(results).verdict.value
 
     severity_score = calculate_severity_score(results)
     quality_score = calculate_quality_score(results)

--- a/src/eedom/core/report_schema.py
+++ b/src/eedom/core/report_schema.py
@@ -94,6 +94,18 @@ class ReportModel(BaseModel):
     verdict: ReportVerdict
     security_score: float = Field(description="0-100, security plugins only.")
     quality_score: float = Field(description="0-100, quality plugins only (advisory).")
+    # Verdict counts (single source of truth — eedom.core.review_summary). Additive
+    # within schema v1; consumers (e.g. the CI header/label) read these instead of
+    # re-deriving counts from findings.
+    error_count: int = Field(default=0, description="Error-level (critical/high) findings.")
+    warning_count: int = Field(default=0, description="Warning-level (medium) findings.")
+    note_count: int = Field(default=0, description="Note-level (low/info) findings.")
+    crashed_count: int = Field(default=0, description="Plugins that crashed.")
+    skipped_count: int = Field(default=0, description="Plugins skipped (e.g. not installed).")
+    blocking_count: int = Field(
+        default=0,
+        description="Attributable error-level security findings — what drives a 'blocked' verdict.",
+    )
     total_findings: int = 0
     total_plugins: int = 0
     plugins: list[PluginReportModel] = Field(default_factory=list)

--- a/src/eedom/core/review_summary.py
+++ b/src/eedom/core/review_summary.py
@@ -1,0 +1,140 @@
+# tested-by: tests/unit/test_review_summary.py
+"""The single source of truth for a review's verdict, counts, and scores (#output-SoT).
+
+Every output eedom produces — the markdown PR comment badge, the JSON report, the
+SARIF run properties, and the CI header/label — must agree on "what did this review
+conclude". They used to disagree: the markdown badge, the JSON report, and a Python
+snippet embedded in the GitHub workflow each computed a verdict independently, from
+different inputs and rules. ``summarize_review`` is now the one place that decision is
+made; all renderers and the workflow consume its result.
+
+Verdict policy (diff-scoped gate):
+  - A finding **blocks** only when it is error-level (critical/high), in a
+    security-gating category (dependency / supply_chain / infra), AND attributable to
+    the change under review — i.e. its file is in ``changed_files``. Pre-existing
+    dependency CVEs on files the PR did not touch are advisory, not blocking.
+  - ``changed_files=None`` means "no diff scope" (a full-repo scan, e.g. the release
+    gate): every finding is attributable, so the gate is repo-wide.
+  - Quality-category findings never block (advisory by design); they still count toward
+    ``warning_count`` / the quality score.
+
+Determinism: same results + same changed_files -> same summary (order-independent).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from eedom._base import Contract
+from eedom.core.plugin import finding_get
+
+# Canonical severity -> SARIF-style level map. The one mapping the whole system uses
+# (SARIF imports this); unmapped severities fall back to "note" (least alarming).
+SEVERITY_TO_LEVEL: dict[str, str] = {
+    "critical": "error",
+    "high": "error",
+    "error": "error",
+    "medium": "warning",
+    "moderate": "warning",
+    "warning": "warning",
+    "low": "note",
+    "info": "note",
+    "note": "note",
+}
+
+# Categories whose findings gate a merge ("security blocks, quality advises").
+SECURITY_CATEGORIES = frozenset({"dependency", "supply_chain", "infra"})
+
+
+class ReviewVerdict(StrEnum):
+    """The canonical verdict vocabulary (worst-first precedence)."""
+
+    blocked = "blocked"
+    incomplete = "incomplete"
+    warnings = "warnings"
+    clear = "clear"
+
+
+class ReviewSummary(Contract):
+    """The one computed conclusion of a review, consumed by every output."""
+
+    verdict: ReviewVerdict
+    error_count: int = 0
+    warning_count: int = 0
+    note_count: int = 0
+    crashed_count: int = 0
+    skipped_count: int = 0
+    blocking_count: int = 0  # attributable, error-level, security findings (what blocks)
+    security_score: float = 100.0
+    quality_score: float = 100.0
+
+
+def level_for(severity: object) -> str:
+    """Return the SARIF-style level ("error"/"warning"/"note") for a severity."""
+    return SEVERITY_TO_LEVEL.get(str(severity or "").lower(), "note")
+
+
+def _norm(path: object) -> str:
+    """Normalize a path for changed-file membership tests."""
+    return str(path or "").lstrip("./")
+
+
+def summarize_review(
+    results: list,
+    *,
+    changed_files: set[str] | None = None,
+) -> ReviewSummary:
+    """Compute the canonical :class:`ReviewSummary` for *results*.
+
+    *changed_files* (repo-relative paths) scopes the blocking decision to the change
+    under review; ``None`` disables scoping (full-repo gate). See module docstring.
+    """
+    from eedom.core.renderer import calculate_quality_score, calculate_severity_score
+
+    changed = {_norm(f) for f in changed_files} if changed_files is not None else None
+
+    errors = warnings = notes = crashed = skipped = blocking = 0
+    for r in results:
+        if getattr(r, "error", None):
+            crashed += 1
+            continue
+        if (getattr(r, "summary", {}) or {}).get("status") == "skipped":
+            skipped += 1
+        is_security = str(getattr(r, "category", "") or "") in SECURITY_CATEGORIES
+        for finding in getattr(r, "findings", []):
+            level = level_for(finding_get(finding, "severity"))
+            if level == "error":
+                errors += 1
+            elif level == "warning":
+                warnings += 1
+            else:
+                notes += 1
+            if level == "error" and is_security:
+                file = finding_get(finding, "file")
+                attributable = changed is None or (bool(file) and _norm(file) in changed)
+                if attributable:
+                    blocking += 1
+
+    if blocking > 0:
+        verdict = ReviewVerdict.blocked
+    elif crashed > 0:
+        verdict = ReviewVerdict.incomplete
+    elif errors > 0 or warnings > 0:
+        # Advisory findings (incl. non-attributable security ones) — worth noting,
+        # not blocking. Skipped plugins are informational only (skipped_count) and
+        # never downgrade the verdict on their own.
+        verdict = ReviewVerdict.warnings
+    else:
+        verdict = ReviewVerdict.clear
+
+    return ReviewSummary(
+        verdict=verdict,
+        error_count=errors,
+        warning_count=warnings,
+        note_count=notes,
+        crashed_count=crashed,
+        skipped_count=skipped,
+        blocking_count=blocking,
+        security_score=calculate_severity_score(results),
+        quality_score=calculate_quality_score(results),
+    )

--- a/src/eedom/core/sarif.py
+++ b/src/eedom/core/sarif.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 from eedom.core.plugin import PluginResult
+from eedom.core.review_summary import SEVERITY_TO_LEVEL, ReviewSummary, summarize_review
 from eedom.core.version import get_version
 
 _SARIF_SCHEMA = (
@@ -18,19 +19,9 @@ _SARIF_SCHEMA = (
     "schema/sarif-schema-2.1.0.json"
 )
 
-# Maps finding severity strings (any case) to SARIF level values.
-# Unmapped values fall back to "note" (least alarming safe default).
-_SEVERITY_TO_LEVEL: dict[str, str] = {
-    "critical": "error",
-    "high": "error",
-    "error": "error",
-    "medium": "warning",
-    "moderate": "warning",
-    "warning": "warning",
-    "low": "note",
-    "info": "note",
-    "note": "note",
-}
+# Severity -> SARIF level uses the canonical map (review_summary), so SARIF, the
+# JSON report, and the verdict all classify severities identically.
+_SEVERITY_TO_LEVEL = SEVERITY_TO_LEVEL
 
 
 def _rule_id(finding: dict, plugin_name: str) -> str:
@@ -158,6 +149,7 @@ def to_sarif(
     results: list[PluginResult],
     repo_path: str | None = None,
     max_findings_per_run: int = 0,
+    summary: ReviewSummary | None = None,
 ) -> dict:
     """Convert plugin results to a SARIF v2.1.0 document.
 
@@ -170,11 +162,28 @@ def to_sarif(
     Returns:
         A dict that serialises to a valid SARIF 2.1.0 JSON document.
     """
-    return {
+    if summary is None:
+        summary = summarize_review(results)
+    doc = {
         "$schema": _SARIF_SCHEMA,
         "version": "2.1.0",
+        # Canonical verdict/counts (single source of truth) as a top-level property
+        # bag so SARIF consumers and the CI gate read the same conclusion as the
+        # markdown badge and JSON report.
+        "properties": {
+            "eedom_verdict": summary.verdict.value,
+            "error_count": summary.error_count,
+            "warning_count": summary.warning_count,
+            "note_count": summary.note_count,
+            "crashed_count": summary.crashed_count,
+            "skipped_count": summary.skipped_count,
+            "blocking_count": summary.blocking_count,
+            "security_score": summary.security_score,
+            "quality_score": summary.quality_score,
+        },
         "runs": [_plugin_to_run(r, repo_path, max_findings_per_run) for r in results],
     }
+    return doc
 
 
 class SarifRenderer:

--- a/src/eedom/core/use_cases.py
+++ b/src/eedom/core/use_cases.py
@@ -14,7 +14,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from eedom.core.plugin import finding_get
+from eedom.core.review_summary import ReviewSummary, summarize_review
 
 if TYPE_CHECKING:
     from eedom.core.context import ApplicationContext
@@ -45,28 +45,18 @@ class ReviewResult:
     verdict: str
     security_score: float
     quality_score: float
+    summary: ReviewSummary | None = None
 
 
 def _derive_verdict(results: list) -> str:
-    """Derive a verdict string from a list of PluginResult objects.
+    """Repo-wide verdict string (thin shim over the canonical summarizer, SoT).
 
-    Priority: blocked > warnings > incomplete > clear.
+    Kept for back-compat; the canonical computation lives in
+    ``eedom.core.review_summary.summarize_review``.
     """
-    verdict = "clear"
-    for r in results:
-        if getattr(r, "error", None):
-            if verdict == "clear":
-                verdict = "incomplete"
-            continue
-        findings = getattr(r, "findings", [])
-        category = getattr(r, "category", "")
-        has_crit = any(finding_get(f, "severity") in ("critical", "high") for f in findings)
-        is_security = category in {"dependency", "supply_chain", "infra"}
-        if has_crit and is_security:
-            verdict = "blocked"
-        elif findings and verdict != "blocked":
-            verdict = "warnings"
-    return verdict
+    from eedom.core.review_summary import summarize_review
+
+    return summarize_review(results).verdict.value
 
 
 def _enrich_results(context: ApplicationContext, results: list, repo_path: Path) -> list:
@@ -103,18 +93,19 @@ def review_repository(
     repo_path: Path,
     options: ReviewOptions,
     repo_files: list | None = None,
+    changed_files: set[str] | None = None,
 ) -> ReviewResult:
     """Run all matching plugins and return a structured ReviewResult.
 
-    Delegates execution to ``context.analyzer_registry.run_all()``.
-    Scores and verdict are derived from the aggregated plugin results.
+    Delegates execution to ``context.analyzer_registry.run_all()``. The verdict,
+    counts, and scores come from the single source of truth
+    (``review_summary.summarize_review``) so every output agrees.
 
     When *repo_files* is provided (diff mode), code/quality plugins receive
     *files* (diff-scoped) while dependency/infra/supply_chain plugins receive
-    *repo_files* (full repo).
+    *repo_files* (full repo). *changed_files* scopes the **blocking** decision to
+    the change under review (``None`` = full-repo gate); see ``summarize_review``.
     """
-    from eedom.core.renderer import calculate_quality_score, calculate_severity_score
-
     plugin_results = context.analyzer_registry.run_all(
         files,
         repo_path,
@@ -127,13 +118,12 @@ def review_repository(
 
     plugin_results = _enrich_results(context, plugin_results, repo_path)
 
-    verdict = _derive_verdict(plugin_results)
-    security_score = calculate_severity_score(plugin_results)
-    quality_score = calculate_quality_score(plugin_results)
+    summary = summarize_review(plugin_results, changed_files=changed_files)
 
     return ReviewResult(
         results=plugin_results,
-        verdict=verdict,
-        security_score=security_score,
-        quality_score=quality_score,
+        verdict=summary.verdict.value,
+        security_score=summary.security_score,
+        quality_score=summary.quality_score,
+        summary=summary,
     )

--- a/tests/unit/test_output_verdict_consistency.py
+++ b/tests/unit/test_output_verdict_consistency.py
@@ -1,0 +1,73 @@
+"""Every output must report the same verdict (#output-SoT regression guard).
+# tested-by: tests/unit/test_output_verdict_consistency.py
+
+The bug this prevents: the markdown PR-comment badge said BLOCKED while the CI header
+said "approved" because they computed the verdict independently. Now the markdown
+badge, the JSON report, and the SARIF property bag all derive from one summary; this
+test fails if any path drifts.
+"""
+
+from __future__ import annotations
+
+import json
+
+import orjson
+
+from eedom.core.json_report import render_json
+from eedom.core.plugin import PluginResult
+from eedom.core.renderer import render_comment
+from eedom.core.review_summary import summarize_review
+from eedom.core.sarif import to_sarif
+
+_BADGE = {
+    "blocked": "BLOCKED",
+    "warnings": "PASS WITH WARNINGS",
+    "incomplete": "INCOMPLETE",
+    "clear": "ALL CLEAR",
+}
+
+
+def _scenario(name):
+    f = lambda sev, file="src/app.py": {  # noqa: E731
+        "id": "x",
+        "severity": sev,
+        "message": "m",
+        "file": file,
+    }
+    return {
+        "blocked": [PluginResult(plugin_name="trivy", category="dependency", findings=[f("high")])],
+        "warnings": [
+            PluginResult(plugin_name="complexity", category="quality", findings=[f("medium")])
+        ],
+        "incomplete": [
+            PluginResult(plugin_name="osv-scanner", category="dependency", findings=[], error="x")
+        ],
+        "clear": [PluginResult(plugin_name="trivy", category="dependency", findings=[])],
+    }[name]
+
+
+import pytest
+
+
+@pytest.mark.parametrize("scenario", ["blocked", "warnings", "incomplete", "clear"])
+def test_markdown_json_sarif_agree(scenario):
+    results = _scenario(scenario)
+    summary = summarize_review(results)  # repo-wide (no diff scope)
+    verdict = summary.verdict.value
+
+    md = render_comment(results, repo="o/r", pr_num=1, title="t", verdict=verdict)
+    json_doc = json.loads(render_json(results, summary=summary))
+    sarif_doc = json.loads(orjson.dumps(to_sarif(results, summary=summary)))
+
+    assert _BADGE[verdict] in md
+    assert json_doc["verdict"] == verdict
+    assert sarif_doc["properties"]["eedom_verdict"] == verdict
+
+
+def test_counts_agree_json_sarif():
+    results = _scenario("blocked")
+    summary = summarize_review(results)
+    json_doc = json.loads(render_json(results, summary=summary))
+    sarif_doc = json.loads(orjson.dumps(to_sarif(results, summary=summary)))
+    for key in ("error_count", "warning_count", "blocking_count"):
+        assert json_doc[key] == sarif_doc["properties"][key] == getattr(summary, key)

--- a/tests/unit/test_review_summary.py
+++ b/tests/unit/test_review_summary.py
@@ -1,0 +1,88 @@
+"""The review-output single source of truth (#output-SoT).
+# tested-by: tests/unit/test_review_summary.py
+
+DPS-12 domains: Determinism (same results+scope -> same summary, order-independent),
+Integrity (the verdict reflects exactly the blocking rule — no drift between outputs),
+Boundedness (counts equal the findings present).
+"""
+
+from __future__ import annotations
+
+from eedom.core.plugin import PluginResult
+from eedom.core.review_summary import ReviewVerdict, summarize_review
+
+
+def _res(name, category, findings, *, error=None, status=None):
+    summary = {"status": status} if status else {}
+    return PluginResult(
+        plugin_name=name, category=category, findings=findings, summary=summary, error=error
+    )
+
+
+def _f(severity, file="src/app.py"):
+    return {"id": "x", "severity": severity, "message": "m", "file": file}
+
+
+def test_clean_is_clear():
+    assert summarize_review([_res("trivy", "dependency", [])]).verdict == ReviewVerdict.clear
+
+
+def test_skipped_only_is_clear_not_warnings():
+    s = summarize_review([_res("cspell", "quality", [], status="skipped")])
+    assert s.verdict == ReviewVerdict.clear
+    assert s.skipped_count == 1
+
+
+def test_crashed_is_incomplete():
+    s = summarize_review([_res("osv-scanner", "dependency", [], error="boom")])
+    assert s.verdict == ReviewVerdict.incomplete
+    assert s.crashed_count == 1
+
+
+def test_quality_high_never_blocks():
+    s = summarize_review([_res("complexity", "quality", [_f("high")])])
+    assert s.verdict == ReviewVerdict.warnings
+    assert s.blocking_count == 0
+
+
+def test_security_high_blocks_when_repo_wide():
+    s = summarize_review([_res("trivy", "dependency", [_f("high", "requirements.txt")])])
+    assert s.verdict == ReviewVerdict.blocked
+    assert s.blocking_count == 1
+
+
+def test_diff_scoped_blocks_only_pr_introduced():
+    results = [_res("trivy", "dependency", [_f("high", "requirements.txt")])]
+    # PR did not touch requirements.txt -> advisory, not blocking
+    advisory = summarize_review(results, changed_files={"README.md"})
+    assert advisory.verdict == ReviewVerdict.warnings
+    assert advisory.blocking_count == 0
+    assert advisory.error_count == 1  # still surfaced
+    # PR touched requirements.txt -> blocking
+    gated = summarize_review(results, changed_files={"requirements.txt"})
+    assert gated.verdict == ReviewVerdict.blocked
+    assert gated.blocking_count == 1
+
+
+def test_counts_match_findings():
+    s = summarize_review(
+        [_res("semgrep", "code", [_f("critical"), _f("medium"), _f("low"), _f("info")])]
+    )
+    assert (s.error_count, s.warning_count, s.note_count) == (1, 1, 2)
+
+
+class TestProperties:
+    def test_determinism_order_independent(self):
+        a = _res("trivy", "dependency", [_f("high", "a.txt")])
+        b = _res("complexity", "quality", [_f("medium")])
+        c = _res("cspell", "quality", [], status="skipped")
+        s1 = summarize_review([a, b, c], changed_files={"a.txt"})
+        s2 = summarize_review([c, b, a], changed_files={"a.txt"})
+        assert s1 == s2  # Determinism: order does not matter
+
+    def test_path_normalization_is_stable(self):
+        results = [_res("trivy", "dependency", [_f("high", "src/x.py")])]
+        # "./src/x.py" vs "src/x.py" must attribute identically
+        assert (
+            summarize_review(results, changed_files={"./src/x.py"}).verdict == ReviewVerdict.blocked
+        )


### PR DESCRIPTION
## The bug

A PR comment could show **`dom: approved — 0 errors, 0 warnings`** in the header while the body badge said **`🔴 BLOCKED`** — the same review, two verdicts.

Root cause: the verdict/counts were computed in **three** places, from different inputs and rules:
| Output | Path | Rule |
|---|---|---|
| Body badge | `use_cases._derive_verdict` → `comment.md.j2` | crit/high in a security category blocks |
| JSON report | `renderer._build_sections` | separate impl |
| CI header/label | **Python embedded in `gatekeeper.yml`** | re-counts SARIF `level==error/warning` |

They disagreed on both the blocking rule and severity reading (SARIF maps `high→error`, yet the header counted 0).

## The fix — one computation, every output consumes it

- **`core/review_summary.py`** (new): `ReviewVerdict` + `ReviewSummary` + `summarize_review()`. One severity→level map (SARIF imports it), one verdict rule.
  - **Diff-scoped gate** (per your call): a finding blocks only when it's error-level, in a security-gating category (dependency/supply_chain/infra), **and attributable to the change** (its file ∈ `changed_files`). `changed_files=None` ⇒ repo-wide gate (release path). Pre-existing dependency CVEs on untouched files are **advisory, not blocking**. Quality findings never block. Skipped plugins are informational (counted, never downgrade).
- `use_cases.review_repository` threads `changed_files` and returns a `ReviewSummary`; `_derive_verdict` is now a thin shim over it.
- `render_comment` takes the canonical verdict for the badge; `render_json` + `to_sarif` take the summary. JSON gains `error/warning/note/crashed/skipped/blocking` counts; SARIF gains a top-level `properties` bag with verdict + counts.
- CLI computes the summary **once** (diff-scoped when `--diff` is given) and feeds all three renderers.
- `gatekeeper.yml` **deletes its bespoke SARIF re-derivation** and reads verdict + counts from `review.json` (jq); maps `clear→approved` for the label/header; adds the `dom: incomplete` label.

Net: for the screenshot PR (2 workflow files; 7 pre-existing trivy dep CVEs), header and body now **both** say *PASS WITH WARNINGS* — advisory, consistent.

## Tests
- `test_review_summary.py` — rules, diff-scoping, determinism, path normalization (DPS-12: Determinism/Integrity/Boundedness).
- `test_output_verdict_consistency.py` — **markdown badge == JSON verdict == SARIF property** across all four verdicts (the exact regression guard).
- Report schema artifact regenerated (additive count fields, schema v1 unchanged).
- Full unit + contract suite green (2311 passed); `ruff`/`black`/actions-policy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat

---
_Generated by [Claude Code](https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat)_