### PR TITLE
chore(docs): overhaul documentation to match current repo

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## 1. System Overview
 
 Eagle Eyed Dom is a deterministic code and dependency review platform for CI. It
-exposes two evaluation paths — a legacy dependency review pipeline and a 15-plugin
+exposes two evaluation paths — a legacy dependency review pipeline and a 19-plugin
 review system — both fully fail-open with zero LLM in the decision path.
 
 **Dependency review** (`evaluate` command): when a PR modifies a dependency manifest,
@@ -13,11 +13,17 @@ structured decision, writes a Markdown memo for PR commenting, persists evidence
 atomically, seals the evidence bundle with a SHA-256 chain, and appends the decision to
 an append-only Parquet audit log.
 
-**Plugin review** (`review` command): runs up to 15 plugins organized into five
-categories (dependency, code, infra, quality, supply_chain) against a repository or
-diff. Plugins are discovered automatically, can be filtered by name or category, and
-each renders its results via a Jinja2 template. Output is a Markdown comment or SARIF
-v2.1.0. Watch mode (`--watch`) re-runs the review on every file change.
+**Plugin review** (`review` command): runs 19 scanner plugins organized into five
+categories (dependency, code, infra, quality, supply_chain) plus the OPA policy
+plugin (which always runs last) against a repository or diff. In addition to the
+plugins, a `DeterministicScanner` (Section 21) runs 21 AST-based detectors
+(EED-001..EED-021) in the same parallel pass. The flow is: file enumeration →
+parallel scan (plugins + deterministic detectors) → normalize/dedup (highest
+severity wins) → detect-then-enrich (Section 22) → OPA policy/decision → render
+(Markdown comment or SARIF v2.1.0) plus evidence/Parquet persistence. Plugins are
+discovered automatically, can be filtered by name or category, and each renders its
+results via a Jinja2 template. Watch mode (`--watch`) re-runs the review on every
+file change.
 
 All failure paths are fail-open: a scanner timeout produces a `ScanResult.skipped`, a
 plugin exception returns `PluginResult(error=...)`, an OPA failure produces
@@ -104,7 +110,7 @@ repo path / diff
 
 | Module | Responsibility |
 |--------|---------------|
-| `cli/main.py` | Click CLI entry point. Four commands: `evaluate` (dependency review pipeline), `review` (15-plugin repo review), `plugins` (list registered plugins), and `check-health` (binary + DB probe). Reads diff from file or stdin, constructs the appropriate pipeline or registry, delegates all logic, formats output. Never contains business logic. SARIF output (`--format sarif`) and watch mode (`--watch`) are coordinated here but implemented in `core/sarif.py` and the watchdog observer respectively. |
+| `cli/main.py` | Click CLI entry point. Six commands: `evaluate` (dependency review pipeline), `review` (19-plugin repo review), `query` (DuckDB queries over the Parquet audit log), `check-health` (binary + DB probe), `plugins` (list registered plugins), and `schema` (emit JSON Schema for domain models). Reads diff from file or stdin, constructs the appropriate pipeline or registry, delegates all logic, formats output. Never contains business logic. SARIF output (`--format sarif`) and watch mode (`--watch`) are coordinated here but implemented in `core/sarif.py` and the watchdog observer respectively. |
 
 Imports: `click`, `structlog`, `core.models.OperatingMode`, `core.pipeline.ReviewPipeline`,
 `core.config.EedomSettings`, `core.plugin.PluginCategory`, `core.renderer.render_comment`,
@@ -284,25 +290,36 @@ instantiates every `ScannerPlugin` subclass found.
 `get_default_registry()` (`plugins/__init__.py`) creates a fresh registry and registers
 all auto-discovered plugins from `src/eedom/plugins/`.
 
-### All 15 Plugins
+### All 19 Plugins (+ OPA Policy Plugin)
+
+19 scanner plugins are auto-discovered via `@ANALYZERS.register`, plus the OPA policy
+plugin (`OpaPlugin`, `plugins/_opa.py`), which declares `depends_on=["*"]` so it always
+runs last with the aggregated findings. (20 `ScannerPlugin` subclasses in total.) The
+`opa` row below is listed in its policy role; `OpaPlugin` itself reports the `dependency`
+category since `PluginCategory` has no policy value.
 
 | Plugin | Category | Description |
 |--------|----------|-------------|
-| `blast-radius` | quality | Code graph impact analysis — AST to SQLite, SQL checks |
-| `clamav` | supply_chain | Malware/virus scanning (ClamAV) |
-| `complexity` | quality | Cyclomatic complexity (Lizard) + maintainability index (Radon) |
-| `cpd` | code | Copy-paste detection — token-based duplication (12 languages) |
-| `cspell` | quality | Code-aware spell checking (en-CA, 11 tech dictionaries) |
-| `gitleaks` | supply_chain | Secret and credential detection (800+ patterns) |
-| `kube-linter` | infra | K8s/Helm security — schema validation, resource limits, privileged containers |
-| `ls-lint` | quality | File naming convention linter |
-| `opa` | dependency | Policy enforcement — 6 Rego rules (deny/warn/approve) |
 | `osv-scanner` | dependency | Known vulnerability database lookup (OSV/GHSA/CVE) |
-| `scancode` | dependency | License detection (SPDX expression extraction) |
-| `semgrep` | code | Code pattern analysis — AST matching with dynamic rulesets |
-| `supply-chain` | supply_chain | Unpinned dependency detection + lockfile integrity + Docker latest-tag detection |
-| `syft` | dependency | SBOM generation — CycloneDX JSON (18 ecosystems) |
 | `trivy` | dependency | Vulnerability scanning (Trivy database) |
+| `scancode` | dependency | License detection (SPDX expression extraction) |
+| `syft` | dependency | SBOM generation — CycloneDX JSON (18 ecosystems) |
+| `supply-chain` | supply_chain | Unpinned dependency + lockfile integrity + Docker latest-tag detection |
+| `gitleaks` | supply_chain | Secret and credential detection (800+ patterns) |
+| `clamav` | supply_chain | Malware/virus scanning (ClamAV) |
+| `semgrep` | code | Code pattern analysis — AST matching with dynamic rulesets |
+| `cpd` | code | Copy-paste detection — token-based duplication (12 languages) |
+| `mypy` | code | Static type checking for Python (type-error findings) |
+| `swiftlint` | code | Swift style and convention linting |
+| `swiftformat` | code | Swift formatting drift detection |
+| `blast-radius` | quality | Code graph impact analysis — AST to SQLite, SQL checks |
+| `complexity` | quality | Cyclomatic complexity (Lizard) + maintainability index (Radon) |
+| `cspell` | quality | Code-aware spell checking (en-CA, 11 tech dictionaries) |
+| `ls-lint` | quality | File naming convention linter |
+| `cfn-nag` | infra | CloudFormation security linting (insecure resource patterns) |
+| `cdk-nag` | infra | AWS CDK / synthesized-template policy checks |
+| `kube-linter` | infra | K8s/Helm security — schema validation, resource limits, privileged containers |
+| `opa` | policy | Policy enforcement — 6 Rego rules (deny/warn/approve); runs last via `depends_on=["*"]` |
 
 ### Plugin Failure Modes
 
@@ -1114,3 +1131,129 @@ watchdog is required for --watch mode. Install with: uv add watchdog
 
 Watch mode is purely additive — the review command runs identically with or without
 `--watch`; the flag only adds the filesystem monitoring loop after the first run.
+
+
+## 21. Deterministic Detectors
+
+The `src/eedom/detectors/` module provides 21 AST-based bug detectors
+(`EED-001`..`EED-021`) that run alongside the scanner plugins. They are
+deterministic — the same source always produces the same findings — and require no
+subprocess, network, or external binary.
+
+By category: **8 security**, **10 reliability**, **2 configuration**, **1 process**.
+The full per-detector reference lives in `docs/detectors.md`; `DetectorCategory`
+(`detectors/categories.py`) is a `StrEnum` mapped to `FindingCategory` for scanner
+integration.
+
+### Framework and Registry
+
+Every detector subclasses `BugDetector` (`detectors/framework.py`) and declares
+`detector_id`, `name`, `category`, `severity`, and `target_files` (default `("*.py",)`).
+Detectors register via the `@register_detector` decorator into the `DETECTORS` registry
+(`detectors/_registry.py`) and are auto-discovered by `discover_detectors()`.
+
+| Concern | Mechanism |
+|---------|-----------|
+| Determinism | Pure AST traversal; no I/O in `detect()`; same input → same findings |
+| Fail-safe | `detect_safe()` wraps `detect()` and catches all exceptions → `[]` |
+| Suppression | `# noqa: EED-XXX` (or bare `# noqa`) on the finding's line skips it |
+| Caching | `ASTCache` parses each file once and shares the tree across detectors |
+
+### Pipeline Integration
+
+Detectors are exposed to the pipeline as `DeterministicScanner` (`detectors/scanner.py`,
+`tool_name="deterministic"`), which satisfies the core `ScannerPort` structurally
+(`name` + `scan`). It enumerates files through the resolved `FileSourcePort`
+(Section on file enumeration), runs all applicable detectors per file via the AST cache,
+filters suppressed findings, and converts each `DetectorFinding` to the core `Finding`
+model. Per ADR-DET-002 a detected bug is a *finding*, not a *failure*: the scanner's
+status is always `success`. Per ADR-DET-006 detectors run inside the `review` command's
+parallel scan pass rather than a separate `detect` command; `--scanners deterministic`
+runs only the detectors.
+
+
+## 22. Detect-Then-Enrich (ADR-006)
+
+After detection and dedup, but before policy evaluation, findings pass through a
+sequential **enrichment** pass that attaches deterministic context to each finding
+without changing the verdict. The seam is defined by `EnricherPort` (`applies_to` +
+`enrich`), driven by `enrich_findings()` (`core/enrich.py`) with an `EnrichmentContext`,
+and backed by the core `ENRICHERS` registry (`core/registries.py`).
+
+Enrichers write only to `metadata['enrichment']`; they never add, drop, or re-rank
+findings. The pass runs sequentially (not in the plugin ThreadPool) so shared tool state
+— e.g. the CodeGraph — is built once and read without locks.
+
+### Enrichers
+
+| Enricher | Key file | What it adds | Default |
+|----------|----------|--------------|---------|
+| `enclosing_symbol` | `detectors/enrichers/enclosing_symbol.py` | Enclosing function/class for a finding's line | on |
+| `code_graph` | `plugins/enrichers/code_graph.py` | Enclosing symbol + upstream blast-radius callers (capped at 25) | on |
+| `semgrep` | `plugins/enrichers/semgrep.py` | Related semgrep matches | opt-in |
+
+`DEFAULT_ENRICHERS = ("enclosing_symbol", "code_graph")` (`core/config.py`); `semgrep`
+stays opt-in. Composition happens in `composition/bootstrap.py`: `build_enrichers(settings)`
+resolves `settings.enabled_enrichers` against the registry (unknown keys skipped), and
+`load_adapters()` fires the registration decorators.
+
+| Concern | Mechanism |
+|---------|-----------|
+| Fail-open | A raising enricher is logged and skipped; the finding survives unchanged |
+| Verdict-independence | Writes only `metadata['enrichment']`; never affects deny/warn/decision |
+| Time-bounded | `enrichment_timeout` (30s) budget; on exhaustion remaining enrichers are skipped |
+| Determinism | Deterministic context (symbols, callers); no scoring or LLM |
+
+
+## 23. Webhook Server
+
+`src/eedom/webhook/server.py` is a Starlette ASGI application exposing a single
+`POST /webhook` route for GitHub pull-request webhooks. It is a third presentation-tier
+entry point (alongside `cli/` and `agent/`) and reuses the same `review_repository`
+use-case via the wired `ApplicationContext`.
+
+### Request Handling
+
+| Stage | Behaviour |
+|-------|-----------|
+| Payload size | Reject > 1 MB with HTTP 413 before any HMAC work (DoS guard) |
+| Authentication | HMAC-SHA256 over the raw body; missing/invalid signature → HTTP 401 |
+| Content-Type | Must be `application/json`, else HTTP 400 |
+| Event routing | Only `pull_request` events with action `opened`, `synchronize`, or `reopened` trigger a review |
+| Review | `review_repository` runs in a worker thread under a 300 s `asyncio.wait_for` timeout |
+| Comment | Result posted to the PR via the GitHub API; token scrubbed from any error log |
+
+### Config and Fail-Open
+
+Configuration is via `EEDOM_WEBHOOK_*` env vars (`webhook/config.py`, `WebhookSettings`):
+the HMAC secret, GitHub token (`SecretStr`), and host/port (default **12800**). The
+fail-open contract is explicit: every processing error after authentication is logged and
+returns HTTP 200, so a review or comment failure never wedges GitHub's webhook delivery.
+The only non-200 responses are authentication (401) and input-validation (400/413)
+failures. The production app is built lazily and thread-safely via the module-level `app`
+attribute for `uvicorn eedom.webhook.server:app`.
+
+
+## 24. Composition Root
+
+`src/eedom/composition/bootstrap.py` is the presentation-side composition tier. It is
+the one place permitted to import `data` / `adapters` / `plugins` to construct the
+core-owned `ApplicationContext`; core depends only on the port *types*, never on this
+wiring.
+
+| Function | Responsibility |
+|----------|---------------|
+| `bootstrap(settings)` | Production wiring — builds the full `ApplicationContext` from `EedomSettings` |
+| `load_adapters()` | Imports every adapter module so its `@REGISTRY.register` factories run (idempotent) |
+| `build_enrichers(settings)` | Resolves enabled enrichers from the `ENRICHERS` registry (Section 22) |
+| `build_scanners` / `build_decision_store` / `build_publisher` / … | Per-adapter factories threading timeouts/paths through registry factories |
+| `bootstrap_test()` / `bootstrap_review()` | All-fake / minimal contexts for unit tests and the review command |
+
+Because core may not import across tier boundaries, `load_adapters()` explicitly imports
+adapter modules (persistence, GitHub publisher, OPA, PyPI, file source, the enrichers,
+graph/semgrep runners, etc.) to populate the registries in `core/registries.py`. Wiring
+is fail-open by construction: `build_decision_store()`/`build_decision_repository()` fall
+back to `NullRepository`/`NullDecisionStore` when `db_dsn` is unset or the connection
+fails, `build_audit_sink()` falls back to `NullAuditSink` without `evidence_path`, and
+`build_publisher()` falls back to `NullPublisher` without a GitHub token — so the pipeline
+always proceeds regardless of which infrastructure is available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with the eedom scanner.
 
 ## What This Is
 
-Eagle Eyed Dom — fully deterministic dependency and code review for CI. 18 plugins, 33 custom semgrep rules, 12 code graph checks, 6 OPA policy rules, 600+ tests, zero LLM in the decision path.
+Eagle Eyed Dom — fully deterministic dependency and code review for CI. 19 scanner plugins (+ OPA policy plugin), 21 deterministic detectors, 61 custom semgrep rules, 12 code graph checks, 6 OPA policy rules, 600+ tests, zero LLM in the decision path.
 
 ## Commands
 
@@ -72,17 +72,23 @@ podman run --rm --platform linux/amd64 \
 Three-tier — imports flow downward only (cli -> core -> data):
 
 - `src/eedom/cli/` — thin CLI adapter. Parses args, delegates to core, formats output.
-- `src/eedom/core/` — all business logic. Pipeline, policy, plugin registry, renderer, SARIF, config.
+- `src/eedom/core/` — all business logic. Pipeline, policy, plugin registry, renderer, SARIF, config, enrichment seam.
 - `src/eedom/data/` — persistence and external calls. Scanners, DB, evidence, parquet, PyPI client.
-- `src/eedom/plugins/` — 18 scanner plugins with auto-discovery via `PluginRegistry`.
+- `src/eedom/plugins/` — 19 scanner plugins (+ OPA policy plugin) with auto-discovery via `PluginRegistry`.
+- `src/eedom/plugins/enrichers/` — code-graph + opt-in semgrep finding enrichers (ADR-006).
+- `src/eedom/detectors/` — 21 deterministic AST bug detectors (EED-001..021), exposed as a `DeterministicScanner`. See `docs/detectors.md`.
+- `src/eedom/composition/` — composition root: `bootstrap()` wires adapters/enrichers into an `ApplicationContext` (NullRepository fallback when no DB).
+- `src/eedom/webhook/` — Starlette ASGI webhook server (GitHub PR events, HMAC-SHA256, port 12800).
 - `src/eedom/agent/` — GATEKEEPER Copilot Agent (second presentation-tier entry point).
 - `src/eedom/templates/` — Jinja2 templates for PR comment rendering.
+
+**Detect-then-enrich (ADR-006)**: a post-detection, pre-policy pass decorates every finding's `metadata['enrichment']` with deterministic context (enclosing symbol, blast-radius callers, nearby semgrep matches). Sequential, fail-open, time-bounded (`enrichment_timeout`), verdict-independent. Registry: `ENRICHERS` in `core/registries.py`.
 
 ## Critical Design Rules
 
 **Fail-open**: No scanner failure blocks a build. Every external call has a timeout. Every failure returns a typed result.
 
-**Timeouts**: scanner=60s, combined=180s, OPA=10s, LLM=30s, pipeline=300s. All from config.
+**Timeouts**: scanner=60s, combined=180s, OPA=10s, LLM=30s, enrichment=30s, pipeline=300s. All from config.
 
 **OPA input uses `input.pkg` not `input.package`**: `package` is reserved in Rego v1.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="assets/hero.svg" alt="Eagle Eyed Dom" width="900">
   <br>
   <strong>Fully deterministic dependency review for CI.</strong><br>
-  18 plugins. 6 OPA policy rules. 18 ecosystems. Zero LLM in the decision path.
+  19 plugins. 21 detectors. 6 OPA policy rules. 18 ecosystems. Zero LLM in the decision path.
   <br><br>
 
   <a href="#quick-start"><img src="https://img.shields.io/badge/get_started-→-d4251a?style=flat-square" alt="Get Started"></a>
-  <a href="#the-18-plugins"><img src="https://img.shields.io/badge/18_plugins-deterministic-f2c14a?style=flat-square&labelColor=0e0706" alt="18 Plugins"></a>
+  <a href="#the-19-plugins"><img src="https://img.shields.io/badge/19_plugins-deterministic-f2c14a?style=flat-square&labelColor=0e0706" alt="19 Plugins"></a>
   <a href="#opa-policy-rules"><img src="https://img.shields.io/badge/OPA-6_rules-1e3a8a?style=flat-square" alt="OPA Rules"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-PolyForm_Shield-7ae582?style=flat-square" alt="PolyForm Shield License"></a>
 </div>
@@ -29,7 +29,7 @@ Both outcomes cost real money. One costs velocity. The other costs incidents.
 
 ---
 
-When a PR touches a dependency manifest — `requirements.txt`, `package.json`, `Cargo.toml`, `go.mod`, any of 18 ecosystems — eedom detects the changed packages, runs 18 plugins in parallel, deduplicates findings, evaluates them against OPA policy, writes tamper-evident evidence, and appends the decision to a Parquet audit log.
+When a PR touches a dependency manifest — `requirements.txt`, `package.json`, `Cargo.toml`, `go.mod`, any of 18 ecosystems — eedom detects the changed packages, runs 19 plugins in parallel (plus 21 deterministic AST detectors and 61 custom semgrep rules on changed source), deduplicates findings, decorates each with deterministic context (detect-then-enrich), evaluates them against OPA policy, writes tamper-evident evidence, and appends the decision to a Parquet audit log.
 
 Every scanning tool is deterministic. The decision is deterministic. Nothing blocks the build unless OPA says so.
 
@@ -42,7 +42,7 @@ Every scanning tool is deterministic. The decision is deterministic. Nothing blo
 
 ---
 
-## The 18 Plugins
+## The 19 Plugins
 
 <div align="center">
   <img src="assets/scanners.svg" alt="Scanner lineup" width="700">
@@ -50,7 +50,7 @@ Every scanning tool is deterministic. The decision is deterministic. Nothing blo
 
 <br>
 
-All deterministic. Zero LLM. The only AI is the optional Copilot agent wrapper that synthesizes results into PR comments — and even that is pluggable and removable.
+All deterministic. Zero LLM. The only AI is the optional Copilot agent wrapper that synthesizes results into PR comments — and even that is pluggable and removable. The 19 scanner plugins below feed their findings to a 20th **OPA policy plugin**, which runs last and makes the accept/reject decision.
 
 ### Dependency (run on every evaluation)
 
@@ -60,45 +60,51 @@ All deterministic. Zero LLM. The only AI is the optional Copilot agent wrapper t
 | 2 | **OSV-Scanner** | Known vulnerability database (CVE/GHSA) |
 | 3 | **Trivy** | Vulnerability scanning |
 | 4 | **ScanCode** | License detection (SPDX) |
-| 5 | **OPA** | Policy enforcement (6 Rego rules) — see [policy rules](#opa-policy-rules) |
 
 ### Code Analysis (run on changed source files)
 
 | # | Plugin | What it does |
 |---|--------|-------------|
-| 6 | **Semgrep** | AST pattern matching (dynamic rulesets + custom org rules) |
-| 7 | **PMD CPD** | Copy-paste detection (12 languages) |
-
-### Type Checking
-
-| # | Plugin | What it does |
-|---|--------|-------------|
-| 8 | **Mypy** | Deterministic cross-file Python type checking |
+| 5 | **Semgrep** | AST pattern matching (dynamic rulesets + 61 custom org rules) |
+| 6 | **PMD CPD** | Copy-paste detection (15 languages) |
+| 7 | **Mypy** | Deterministic cross-file Python type checking (prefers pyright) |
+| 8 | **SwiftLint** | Swift style + code smells (200+ rules + 13 custom) |
+| 9 | **SwiftFormat** | Swift formatting lint (all findings auto-fixable) |
 
 ### Infrastructure
 
 | # | Plugin | What it does |
 |---|--------|-------------|
-| 9 | **kube-linter** | K8s/Helm security validation |
-| 10 | **CDK Nag** | CDK CloudFormation security scanning |
-| 11 | **cfn-nag** | CloudFormation template security scanning |
+| 10 | **kube-linter** | K8s/Helm security validation |
+| 11 | **CDK Nag** | CDK CloudFormation security scanning |
+| 12 | **cfn-nag** | CloudFormation template security scanning |
 
 ### Quality
 
 | # | Plugin | What it does |
 |---|--------|-------------|
-| 12 | **Lizard + Radon** | Cyclomatic complexity + maintainability index |
-| 13 | **cspell** | Code-aware spell checking (en-CA, 15 dictionaries) |
-| 14 | **ls-lint** | File naming conventions |
-| 15 | **Blast Radius** | AST→SQLite code graph, 8+ SQL checks |
+| 13 | **Lizard + Radon** | Cyclomatic complexity + maintainability index |
+| 14 | **cspell** | Code-aware spell checking (en-CA, 15 dictionaries) |
+| 15 | **ls-lint** | File naming conventions |
+| 16 | **Blast Radius** | AST→SQLite code graph, 12 SQL checks |
 
 ### Supply Chain
 
 | # | Plugin | What it does |
 |---|--------|-------------|
-| 16 | **Supply Chain** | Unpinned deps + lockfile integrity + latest tag detection |
-| 17 | **ClamAV** | Malware/virus scanning |
-| 18 | **Gitleaks** | Secret/credential detection (800+ patterns) |
+| 17 | **Supply Chain** | Unpinned deps + lockfile integrity + latest tag detection |
+| 18 | **ClamAV** | Malware/virus scanning |
+| 19 | **Gitleaks** | Secret/credential detection (800+ patterns) |
+
+### Policy
+
+| Plugin | What it does |
+|--------|-------------|
+| **OPA** | Policy enforcement (6 Rego rules), runs last (`depends_on=["*"]`) — see [policy rules](#opa-policy-rules) |
+
+### Plus 21 deterministic detectors
+
+On changed source, eedom also runs **21 AST bug detectors** (`EED-001`…`EED-021`) — SQL injection, missing JWT audience claim, secrets typed as plain `str`, subprocess without timeout, unbounded caches, non-atomic writes, and more. Deterministic, fail-safe, suppressible with `# noqa: EED-NNN`. See [`docs/detectors.md`](docs/detectors.md).
 
 **Scanner disagreement:** When OSV-Scanner and Trivy report the same CVE, the normalizer deduplicates on `(advisory_id, category, package_name, version)`. Highest severity wins.
 
@@ -278,13 +284,14 @@ src/eedom/
 │   ├── diff.py             #   Text diff parser (requirements.txt, pyproject.toml)
 │   ├── sbom_diff.py        #   CycloneDX SBOM differ (18 ecosystems via purl)
 │   ├── normalizer.py       #   Finding deduplication (highest severity wins)
+│   ├── enrich.py           #   Detect-then-enrich pass (ENRICHERS, fail-open) — ADR-006
 │   ├── actionability.py    #   Actionable vs blocked finding classification
 │   ├── orchestrator.py     #   Parallel scanner runner (ThreadPoolExecutor)
 │   ├── decision.py         #   Pure assembler — OPA verdict → ReviewDecision
 │   ├── memo.py             #   Markdown PR comment generator
 │   ├── seal.py             #   SHA-256 evidence chain
 │   └── taskfit*.py         #   Optional LLM advisory (disabled by default)
-├── plugins/                # 18 scanner plugin implementations
+├── plugins/                # 19 scanner plugins + OPA policy plugin + enrichers
 │   ├── blast_radius.py     #   AST→SQLite code graph + SQL checks
 │   ├── semgrep.py          #   AST pattern matching
 │   ├── clamav.py           #   Malware/virus scanning
@@ -292,7 +299,15 @@ src/eedom/
 │   ├── mypy.py             #   Cross-file Python type checking
 │   ├── cdk_nag.py          #   CDK CloudFormation security scanning
 │   ├── cfn_nag.py          #   CloudFormation template scanning
-│   └── ...                 #   + 11 more (one file per plugin)
+│   ├── enrichers/          #   Detect-then-enrich: code-graph + opt-in semgrep (ADR-006)
+│   └── ...                 #   + 13 more (one file per plugin, incl. _opa.py)
+├── detectors/              # 21 deterministic AST bug detectors (EED-001..021)
+│   ├── security/           #   8 detectors (SQL injection, JWT audience, SecretStr, ...)
+│   ├── reliability/        #   subprocess timeout, unbounded cache, atomic write, ...
+│   ├── scanner.py          #   DeterministicScanner (ScannerPort) — runs them in the pipeline
+│   └── _registry.py        #   @register_detector + discover_detectors()
+├── composition/            # Composition root: bootstrap() wires the ApplicationContext
+├── webhook/                # Starlette ASGI server — GitHub PR webhooks (HMAC, port 12800)
 ├── templates/              # Jinja2 templates for PR comments
 │   ├── comment.md.j2       #   Main comment wrapper (verdict + sections)
 │   └── *.md.j2             #   Per-plugin section templates
@@ -516,7 +531,7 @@ Watch mode debounces file-system events (500 ms default). Press `Ctrl+C` to stop
 
 ## Monorepo Support
 
-Eagle Eyed Dom auto-discovers packages across a monorepo and runs all 18 plugins per-package.
+Eagle Eyed Dom auto-discovers packages across a monorepo and runs all 19 plugins per-package.
 
 ### Package discovery
 

--- a/WHY.md
+++ b/WHY.md
@@ -4,7 +4,7 @@ Eagle Eyed Dom (eedom) is a fully deterministic dependency and code review engin
 
 Every PR that touches a dependency manifest or source file triggers the same tedious checklist: known CVEs, license compatibility, package age, leaked secrets, copy-paste duplication, cyclomatic complexity — eedom runs all of it in under ten minutes, without a human.
 
-The pipeline detects changed packages across 18 ecosystems, fans out across 18 specialist plugins in parallel (Syft, OSV-Scanner, Trivy, ScanCode, Semgrep, Gitleaks, ClamAV, and more), deduplicates overlapping findings by advisory ID with highest-severity-wins logic, then hands the normalized result set to an OPA policy engine that makes the accept/reject decision in pure Rego — no prompts, no probability, no "it depends on the model's mood today."
+The pipeline detects changed packages across 18 ecosystems, fans out across 19 specialist plugins in parallel (Syft, OSV-Scanner, Trivy, ScanCode, Semgrep, Gitleaks, ClamAV, and more), deduplicates overlapping findings by advisory ID with highest-severity-wins logic, then hands the normalized result set to an OPA policy engine that makes the accept/reject decision in pure Rego — no prompts, no probability, no "it depends on the model's mood today."
 
 What makes eedom different is the constraint it refuses to break: **zero LLM in the decision path.** The build passes or fails on deterministic rules that any engineer can read, audit, and debate — not on a language model's interpretation of those rules.
 
@@ -68,7 +68,7 @@ Sources: [snyk.io/plans](https://snyk.io/plans/), [sonatype.com/products/pricing
 
 eedom is designed to be extended by the teams that use it. When you see a recurring anti-pattern in code review, you encode it as a rule — and dom catches it on every PR from that point forward.
 
-### Custom Semgrep Rules (33 and growing)
+### Custom Semgrep Rules (61 and growing)
 
 Drop a YAML file in `policies/semgrep/` and eedom picks it up automatically. Real examples from the repo:
 
@@ -94,11 +94,13 @@ Drop a YAML file in `policies/semgrep/` and eedom picks it up automatically. Rea
   severity: WARNING
 ```
 
-33 rules ship out of the box across 8 categories: security, reliability, code smells, SOLID violations, testing anti-patterns, contract enforcement, architecture constraints, and banned patterns. Each rule covers 14 file extensions (Python, TypeScript, JavaScript, Go, Ruby, Java, Terraform, Kubernetes, Shell, Docker, and more).
+61 rules ship out of the box across 8 categories: security, reliability, code smells, SOLID violations, testing anti-patterns, contract enforcement, architecture constraints, and banned patterns. Each rule covers 14 file extensions (Python, TypeScript, JavaScript, Go, Ruby, Java, Terraform, Kubernetes, Shell, Docker, and more).
 
 ### Custom Code Graph Checks (12 and growing)
 
 The blast-radius plugin builds an AST-to-SQLite code graph, then runs SQL checks against it. Add your own:
+
+### More Custom Checks
 
 ```yaml
 # Flag functions that call too many other functions
@@ -137,6 +139,10 @@ graph.register_check(
     description="What this catches"
 )
 ```
+
+### Deterministic Bug Detectors (21 and growing)
+
+Beyond semgrep, eedom ships **21 deterministic AST bug detectors** (`EED-001`…`EED-021`) in `src/eedom/detectors/` — SQL injection via string formatting, JWT tokens with no audience claim, secrets typed as plain `str` instead of `SecretStr`, subprocess calls without a timeout, unbounded caches, non-atomic file writes, and more. They fire with no LLM, never crash a scan (fail-safe), and are suppressible per-line with `# noqa: EED-NNN`. Full reference: [`docs/detectors.md`](docs/detectors.md).
 
 ### OPA Policy Rules (6 rules, pure Rego)
 
@@ -180,7 +186,8 @@ No other tool — free or paid — offers these capabilities:
 - **Code graph analysis** — 12 SQL checks against an AST-derived call graph: blast radius, fan-out, layer violations, circular dependencies, inheritance depth, orphan symbols, SRP violations
 - **Actionability classification** — every finding is classified as fixable (upgrade available) or blocked (no upstream fix), so teams know what they can actually act on
 - **Sealed evidence chain** — SHA-256 hash chain over every scan artifact, appended to a Parquet audit lake queryable with DuckDB. Tamper with any artifact and the chain breaks
-- **33 custom semgrep rules** — security, reliability, SOLID, testing, architecture, and contract enforcement patterns that catch what generic rulesets miss
+- **61 custom semgrep rules** — security, reliability, SOLID, testing, architecture, and contract enforcement patterns that catch what generic rulesets miss
+- **21 deterministic bug detectors** — AST rules that catch SQL injection, missing JWT claims, secrets as plain strings, subprocess timeouts, unbounded caches, and more — no LLM, suppressible per-line
 - **Natural language code queries** — 12 templates: "what has the highest fan-out?", "show me layer violations", "what depends on X?" — all against the code graph, no LLM required
 - **Deterministic + free** — the only tool in the "broad scan + policy engine" quadrant that costs $0
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -6,20 +6,23 @@
   output format, or integration. Keep counts accurate. See CLAUDE.md rule.
 
   LAST VERIFIED: 2026-06-21
-  VERIFICATION: grep -c 'class.*ScannerPlugin' src/eedom/plugins/*.py → 19
+  VERIFICATION: 19 auto-discovered scanner plugins (@ANALYZERS.register) + OPA policy
+  plugin (20 ScannerPlugin subclasses total); 21 detectors in src/eedom/detectors/;
+  61 semgrep rule ids in policies/semgrep/.
 -->
 
 ## Identity
 
 Eagle Eyed Dom — fully deterministic dependency, security, and code review for CI.
-19 plugins, 61 custom semgrep rules, 12 code graph checks, 6 OPA policy rules,
-600+ tests. Zero LLM in the decision path.
+19 scanner plugins, 21 deterministic detectors, 61 custom semgrep rules, 12 code graph
+checks, 6 OPA policy rules, 600+ tests. Zero LLM in the decision path.
 
 ## Quick Numbers
 
 | Metric | Count |
 |--------|-------|
-| Scanner plugins | 19 (5 categories) |
+| Scanner plugins | 19 (5 categories) + OPA policy plugin |
+| Deterministic detectors | 21 (EED-001..EED-021) |
 | Custom semgrep rules | 61 (11 rule files) |
 | Code graph SQL checks | 12 |
 | OPA Rego policy rules | 6 (4 deny, 2 warn) |
@@ -39,7 +42,12 @@ Eagle Eyed Dom — fully deterministic dependency, security, and code review for
 
 ## Plugins by Category
 
-### dependency (5)
+The 19 auto-discovered scanner plugins (registered via `@ANALYZERS.register`) split across
+five categories below. The **OPA policy plugin** is the 20th `ScannerPlugin` subclass but is
+wired separately — it consumes every other plugin's findings and runs last
+(`depends_on=["*"]`); see [OPA Policy Rules](#opa-policy-rules-6-rules).
+
+### dependency (4)
 
 | Plugin | File | Detects |
 |--------|------|---------|
@@ -47,7 +55,6 @@ Eagle Eyed Dom — fully deterministic dependency, security, and code review for
 | trivy | `plugins/trivy.py` | Vulnerability scanning via Trivy database (`trivy fs --scanners vuln`). |
 | scancode | `plugins/scancode.py` | License detection with SPDX expression extraction and confidence scoring. |
 | syft | `plugins/syft.py` | CycloneDX SBOM generation. 18 ecosystems (npm, PyPI, Cargo, Go, Ruby, Composer, Dart, Elixir, etc). |
-| opa | `plugins/opa.py` | Policy enforcement — runs after all other plugins (`depends_on=["*"]`). 6 Rego rules: deny/warn/approve. |
 
 ### supply_chain (3)
 
@@ -162,6 +169,40 @@ All in `policies/semgrep/`.
 - `org.swiftui.formatter-allocation-in-view` — formatter allocated in body
 - `org.swiftui.image-decode-inline` — inline image decode in body
 - `org.swiftui.nslock-use-actor-instead` — NSLock in SwiftUI; prefer an actor
+
+---
+
+## Deterministic Detectors (21)
+
+AST-driven, fail-safe bug-pattern rules in `src/eedom/detectors/`, exposed to the pipeline
+as a single `DeterministicScanner` (`tool_name="deterministic"`). Each is suppressible inline
+with `# noqa: EED-NNN`. Full reference: [`docs/detectors.md`](detectors.md).
+
+| ID | Name | Category | Severity |
+|----|------|----------|----------|
+| EED-001 | JWT Missing Audience Claim | security | high |
+| EED-002 | Error Information Exposure | security | high |
+| EED-003 | API Endpoint Missing Rate Limiting | security | medium |
+| EED-004 | Secret Should Use SecretStr | security | high |
+| EED-005 | SQL Injection via String Formatting | security | critical |
+| EED-016 | CI Verification Gate Bypass | security | high |
+| EED-017 | Presentation Tier Imports Data Tier | security | medium |
+| EED-020 | Fixed Heredoc Delimiter w/ GITHUB_OUTPUT | security | low |
+| EED-006 | Unbounded Cache Without Eviction | reliability | medium |
+| EED-007 | Circuit Breaker Missing Half-Open State | reliability | medium |
+| EED-008 | Path String Concatenation | reliability | medium |
+| EED-009 | Cache Lookup Without Freshness Check | reliability | low |
+| EED-010 | Batch Insert Without Rollback Handling | reliability | medium |
+| EED-011 | Health Check Without DB Verification | reliability | medium |
+| EED-012 | Subprocess Call Without Timeout | reliability | medium |
+| EED-015 | High Cardinality Metric Labels | reliability | medium |
+| EED-019 | Nullable advisory_id in Dedup Key | reliability | low |
+| EED-021 | Non-Atomic File Write | reliability | medium |
+| EED-013 | Config Merge Dropping Telemetry | configuration | low |
+| EED-018 | Dockerfile Pin Drift | configuration | medium |
+| EED-014 | Missing Tested-By Annotation | process | low |
+
+By category: security 8, reliability 10, configuration 2, process 1.
 
 ---
 
@@ -314,7 +355,7 @@ File: `core/nl_query.py`. Keyword-matched SQL queries against the code graph. No
 
 | Capability | SonarQube | eedom |
 |------------|-----------|-------|
-| Semantic bug detection | Deep per-language rules (25+ languages) | Semgrep AST + 33 custom rules |
+| Semantic bug detection | Deep per-language rules (25+ languages) | Semgrep AST + 61 custom rules + 21 deterministic detectors |
 | Stylistic code smells | Hundreds of built-in rules | Not primary focus |
 | Structural code smells | Limited | 12 graph checks (dead code, god functions, SRP, layer violations, circular deps, deep inheritance, stubs) |
 | Complexity | Cyclomatic + cognitive | Cyclomatic (Lizard) + MI (Radon) — parity |

--- a/docs/architecture-cloud.md
+++ b/docs/architecture-cloud.md
@@ -25,7 +25,7 @@ configuration without guesswork.
 
 **Container image production-ready.** The Dockerfile is a hardened multi-stage
 build with SHA-256 verified binaries, SLSA provenance attestation
-(`.github/workflows/build-container.yml`), and all 15 scanner plugins baked in.
+(`.github/workflows/build-container.yml`), and all 19 scanner plugins baked in.
 This image can deploy to any container runtime (ECS Fargate, Cloud Run, EKS)
 without modification.
 
@@ -909,7 +909,7 @@ The following modules are cloud-ready as-is and require zero modifications:
 - `src/eedom/core/sarif.py` -- SARIF generation
 - `src/eedom/core/repo_config.py` -- repo config loading
 - `src/eedom/core/taskfit.py` -- LLM advisory
-- `src/eedom/plugins/*` -- all 15 plugins
+- `src/eedom/plugins/*` -- all 19 plugins
 - `src/eedom/data/scanners/*` -- all scanner implementations
 - `src/eedom/data/pypi.py` -- PyPI client
 - `src/eedom/cli/` -- CLI entry point (self-hosted mode)

--- a/docs/architecture-enterprise.md
+++ b/docs/architecture-enterprise.md
@@ -26,7 +26,7 @@ Eedom has a surprisingly solid foundation for a tool at its maturity stage. Thes
 
 **Structured logging.** Consistent use of `structlog` throughout. No `print()` statements. Correlation via `request_id`. DSN credential masking in `src/eedom/data/db.py:_safe_dsn()`.
 
-**Plugin architecture.** 15 plugins with auto-discovery, category filtering, and dependency ordering. The `ScannerPlugin` ABC in `src/eedom/core/plugin.py` is a clean extension point.
+**Plugin architecture.** 19 scanner plugins (+ OPA policy plugin) with auto-discovery, category filtering, and dependency ordering. The `ScannerPlugin` ABC in `src/eedom/core/plugin.py` is a clean extension point.
 
 ### What Is Not Enterprise-Ready
 
@@ -74,7 +74,7 @@ The sections below detail each gap. The summary:
 
 **Current state:** Scanning is in-process via `ThreadPoolExecutor` in `src/eedom/core/orchestrator.py`. The `ScanOrchestrator` runs all scanners in the same process as the pipeline. The pipeline processes packages sequentially in a `for req in requests` loop in `src/eedom/core/pipeline.py:165`. The `scan_queue` table exists in `migrations/002_package_catalog.sql` but there is no worker that consumes it.
 
-**What breaks at 100 repos:** Scanner binary execution (syft, trivy, osv-scanner, gitleaks, semgrep) is CPU and I/O intensive. Running 15 plugins in-process for 100 concurrent PRs on a single runner will exhaust CPU, memory, and subprocess limits. The 300s pipeline timeout (`config.py:69`) means at most ~12 concurrent evaluations per runner before queueing.
+**What breaks at 100 repos:** Scanner binary execution (syft, trivy, osv-scanner, gitleaks, semgrep) is CPU and I/O intensive. Running 19 plugins in-process for 100 concurrent PRs on a single runner will exhaust CPU, memory, and subprocess limits. The 300s pipeline timeout (`config.py:69`) means at most ~12 concurrent evaluations per runner before queueing.
 
 **What breaks at 1000 repos:** The single PostgreSQL instance becomes a bottleneck for write throughput. Evidence storage on local disk runs out of space. The Parquet audit log (`src/eedom/data/parquet_writer.py`) does append-only writes to a single file, which becomes a contention point and eventually a multi-GB file that is slow to read.
 

--- a/docs/detectors.md
+++ b/docs/detectors.md
@@ -1,0 +1,119 @@
+# Deterministic Detectors
+
+Eedom ships **21 deterministic bug detectors** (`EED-001` … `EED-021`) in
+`src/eedom/detectors/`. They complement the 19 scanner plugins: where a plugin shells out
+to an external tool or queries an external database (CVEs, licenses, SBOMs), a *detector* is
+a small, self-contained, AST-driven rule that flags a specific bug pattern in source you
+own. No external binary, no network, no LLM — same input always yields the same finding.
+
+## Detector vs. plugin
+
+| | Detector | Plugin |
+|---|----------|--------|
+| Input | Source AST / text in this repo | External data (PyPI, CVE/OSV, license corpora) |
+| Output | `DetectorFinding` → `Finding` (code-pattern bug) | `Finding` (vuln / license / SBOM metadata) |
+| Scope | File-level code rule | Project / dependency level |
+| Example | "JWT encoded without an `aud` claim" | "this version of Django has CVE-2024-…" |
+| Dependency | Python stdlib `ast` only | a wrapped CLI (osv-scanner, syft, trivy, …) |
+
+Detectors and plugin findings flow into the **same** pipeline: the detector set is exposed
+as a single `DeterministicScanner` (`src/eedom/detectors/scanner.py`) implementing
+`ScannerPort` with `tool_name="deterministic"`, so the orchestrator runs it in parallel
+alongside the plugins, and its findings go through the same normalize → enrich → policy
+stages.
+
+## How a detector works
+
+Every detector subclasses `BugDetector` (`src/eedom/detectors/framework.py`) and exposes
+five members:
+
+- `detector_id` — the stable `EED-NNN` id
+- `name` — human label
+- `category` — a `DetectorCategory` (security, reliability, configuration, process, …)
+- `severity` — a `FindingSeverity` (critical / high / medium / low)
+- `target_files` — `fnmatch` globs the detector applies to (e.g. `("*.py",)`, `Dockerfile*`)
+- `detect(file_path) -> list[DetectorFinding]` — the actual analysis
+
+Guarantees baked into the base class:
+
+- **Fail-safe** — the scanner calls `detect_safe()`, which wraps `detect()` and returns `[]`
+  on *any* exception. A buggy detector can never crash a scan or block a build.
+- **Suppressible** — a `# noqa: EED-NNN` comment on the offending line silences exactly that
+  detector; `# noqa` with no id silences all of them on that line.
+- **Deterministic** — analysis is pure AST/text inspection. Same file, same findings.
+
+Registration and discovery are decorator-driven: `@register_detector`
+(`src/eedom/detectors/_registry.py`) adds the class to the `DETECTORS` registry, and
+`discover_detectors()` imports every `eedom.detectors.*` subpackage so those decorators fire.
+Instances are cached and reused across files.
+
+### AST machinery
+
+Shared helpers live in `src/eedom/detectors/ast_utils.py`: a content-addressed `ASTCache`
+(parse each file once, reuse across detectors), plus matchers like `find_function_calls`,
+`get_call_name`, `has_decorator`, `find_exception_handlers`, `is_secret_field_name`, and a
+`BatchVisitor` for single-pass multi-detector traversal. Python is analyzed via the stdlib
+`ast`; YAML / Dockerfile / shell detectors use targeted text + structural parsing.
+
+## The 21 detectors
+
+### Security (8)
+
+| ID | Name | Severity | Catches |
+|----|------|----------|---------|
+| EED-001 | JWT Missing Audience Claim | high | `jwt.encode()` payloads with no `aud` claim (token replay across services) |
+| EED-002 | Error Information Exposure | high | exception variables interpolated into response/output strings |
+| EED-003 | API Endpoint Missing Rate Limiting | medium | Flask/FastAPI routes lacking a `@rate_limit`/`@throttle` decorator |
+| EED-004 | Secret Should Use SecretStr | high | Pydantic secret-named fields typed as plain `str` instead of `SecretStr` |
+| EED-005 | SQL Injection via String Formatting | critical | `cursor.execute()` built with f-strings, `%`, or `.format()` |
+| EED-016 | CI Verification Gate Bypass | high | shell scripts that exit `0` when a required GitHub Actions status is absent/null |
+| EED-017 | Presentation Tier Imports Data Tier Directly | medium | files in `agent/`/`cli/` importing `eedom.data.*` (three-tier breach) |
+| EED-020 | Fixed Heredoc Delimiter with GITHUB_OUTPUT/GITHUB_ENV | low | fixed heredoc delimiters writing to GitHub Actions output sinks |
+
+### Reliability (10)
+
+| ID | Name | Severity | Catches |
+|----|------|----------|---------|
+| EED-006 | Unbounded Cache Without Eviction | medium | `@cache` / `@lru_cache()` with no `maxsize` |
+| EED-007 | Circuit Breaker Missing Half-Open State | medium | breaker classes with no half-open recovery path |
+| EED-008 | Path String Concatenation | medium | paths built with `+`/f-strings/`%` instead of `pathlib.Path` |
+| EED-009 | Cache Lookup Without Freshness Check | low | cache `.get()` lookups with no TTL/timestamp validation |
+| EED-010 | Batch Insert Without Rollback Handling | medium | `executemany()`/execute loops with no try/except + rollback |
+| EED-011 | Health Check Without Database Verification | medium | `/health`,`/ready`,`/status` endpoints that never touch the DB |
+| EED-012 | Subprocess Call Without Timeout | medium | `subprocess.run/Popen/...` with no `timeout=` |
+| EED-015 | High Cardinality Metric Labels | medium | Prometheus metrics labeled with `user_id`/`request_id`/`email`/uuid |
+| EED-019 | Nullable advisory_id in Dedup Key | low | dedup-key tuples with an unguarded `advisory_id` (None collapses findings) |
+| EED-021 | Non-Atomic File Write | medium | `.write_bytes()/.write_text()` with no `os.rename()`/`.replace()` swap |
+
+### Configuration (2)
+
+| ID | Name | Severity | Catches |
+|----|------|----------|---------|
+| EED-013 | Config Merge Dropping Telemetry | low | `{**base, **override}` / `.update()` merges that drop telemetry keys |
+| EED-018 | Dockerfile Pin Drift | medium | hardcoded `pip install pkg==x` or `:latest` image tags (reproducibility drift) |
+
+### Process (1)
+
+| ID | Name | Severity | Catches |
+|----|------|----------|---------|
+| EED-014 | Missing Tested-By Annotation | low | source files lacking the `# tested-by: tests/...` annotation |
+
+## Configuration
+
+The detector scanner runs as part of the standard pipeline. Findings carry their
+`EED-NNN` id as `source_tool`, map to the appropriate `Finding` category, and are eligible
+for detect-then-enrich (ADR-006) like any other finding — e.g. the `enclosing_symbol`
+enricher annotates each with its enclosing function/class.
+
+Suppress a single occurrence inline:
+
+```python
+cursor.execute(f"SELECT * FROM t WHERE id = {user_id}")  # noqa: EED-005
+```
+
+## See also
+
+- [`docs/CAPABILITIES.md`](CAPABILITIES.md) — full capability matrix
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — how the detector scanner plugs into the pipeline
+- [`docs/adr/006-detect-then-enrich.md`](adr/006-detect-then-enrich.md) — the enrichment seam
+- `src/eedom/detectors/` — implementation

--- a/docs/elevator-pitch.md
+++ b/docs/elevator-pitch.md
@@ -2,11 +2,11 @@
   <img src="../assets/hero.svg" alt="Eagle Eyed Dom" width="900">
   <br>
   <strong>Fully deterministic dependency review for CI.</strong><br>
-  15 plugins. 6 OPA policy rules. 18 ecosystems. Zero LLM in the decision path.
+  19 plugins. 6 OPA policy rules. 18 ecosystems. Zero LLM in the decision path.
   <br><br>
 
   <a href="../README.md#quick-start"><img src="https://img.shields.io/badge/get_started-→-d4251a?style=flat-square" alt="Get Started"></a>
-  <a href="../README.md#the-15-plugins"><img src="https://img.shields.io/badge/15_plugins-deterministic-f2c14a?style=flat-square&labelColor=0e0706" alt="15 Plugins"></a>
+  <a href="../README.md#the-19-plugins"><img src="https://img.shields.io/badge/19_plugins-deterministic-f2c14a?style=flat-square&labelColor=0e0706" alt="19 Plugins"></a>
   <a href="../README.md#opa-policy-rules"><img src="https://img.shields.io/badge/OPA-6_rules-1e3a8a?style=flat-square" alt="OPA Rules"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/license-PolyForm_Shield-7ae582?style=flat-square" alt="PolyForm Shield License"></a>
 </div>
@@ -23,7 +23,7 @@ Meanwhile, the things that slip through — an unpinned dependency with a known 
 
 ## What eedom does
 
-Drop it into your CI pipeline. It runs 15 scanners on every PR, evaluates findings against policy rules you control, and posts a clear verdict: **BLOCKED**, **WARNINGS**, or **ALL CLEAR** with a 0-100 health score.
+Drop it into your CI pipeline. It runs 19 scanners on every PR, evaluates findings against policy rules you control, and posts a clear verdict: **BLOCKED**, **WARNINGS**, or **ALL CLEAR** with a 0-100 health score.
 
 Your engineers open the PR. The review is already there. They read the verdict, focus on the business logic, and skip the mechanical checklist. The cognitive burden shifts from "did anyone check the deps" to "the tool checked the deps, here's what it found."
 
@@ -55,7 +55,7 @@ Most scanning tools produce a wall of findings and leave the engineer to triage.
 
 3. **Fail-open, fail-loud.** If a scanner times out or a binary is missing, the PR is NOT blocked. But the failure is visible in the comment — `[TIMEOUT] scancode timed out after 60s`. No silent passes. No phantom cleans.
 
-4. **One comment, not fifteen.** All 15 scanners produce one unified PR comment with a single verdict. Your engineers read one thing, not one alert per tool.
+4. **One comment, not nineteen.** All 19 scanners produce one unified PR comment with a single verdict. Your engineers read one thing, not one alert per tool.
 
 ## How to adopt it
 
@@ -85,7 +85,7 @@ GATEKEEPER wraps the same pipeline as an interactive Copilot agent — ask it ab
 
 Everything. No vendor lock-in on policy.
 
-- **`.eagle-eyed-dom.yaml`** — enable/disable any of the 15 plugins, set thresholds, configure per-repo
+- **`.eagle-eyed-dom.yaml`** — enable/disable any of the 19 plugins, set thresholds, configure per-repo
 - **OPA rules** — 6 Rego rules, version-controlled, individually toggleable. Add your own.
 - **`--disable clamav,cspell`** — turn off plugins per-run from the CLI
 - **Monorepo support** — auto-discovers packages, runs per-package, respects per-directory config overrides

--- a/docs/plugins/quality.md
+++ b/docs/plugins/quality.md
@@ -95,3 +95,46 @@ Enforces file and directory naming conventions across the project tree.
 | Warning | File or directory name does not match the configured pattern |
 
 Consistent naming makes navigation predictable and removes the cognitive load of guessing whether a file is `UserService`, `user-service`, or `user_service`.
+
+---
+
+## mypy
+
+Runs cross-file type checking. Prefers pyright (faster, stricter) when available, falls back to mypy.
+
+| Severity | Condition |
+|----------|-----------|
+| Error | Type incompatibility at a public API boundary |
+| Warning | Missing type annotation on a public function |
+
+Advisory — helps reviewers understand type contract violations early without blocking merges. Type mismatches are cheaper to fix in review than to trace in production.
+
+---
+
+## swiftlint
+
+Detects Swift style and code smell violations using 200+ built-in rules plus 13 project-specific custom rules.
+
+| Severity | Condition |
+|----------|-----------|
+| Warning | Swift style violation or code smell (e.g., force try/cast, NSLock in async context, weak self handling) |
+
+Advisory — surfaces patterns that are unlikely to pass thorough code review, making the conversation about simplification and safety easier to start.
+
+---
+
+## swiftformat
+
+Reports Swift source files that need reformatting. All findings are auto-fixable with `swiftformat .`.
+
+| Severity | Condition |
+|----------|-----------|
+| Info | File does not match the configured formatting rules |
+
+Advisory — purely informational. Formatting consistency improves readability and reduces review friction.
+
+---
+
+## See also
+
+- [Deterministic detectors](../detectors.md) — 21 AST-based bug-pattern rules (EED-001..EED-021) that run alongside the plugins.

--- a/docs/plugins/security.md
+++ b/docs/plugins/security.md
@@ -125,14 +125,32 @@ Blocks because root containers and unlimited resources are trivially exploitable
 
 ---
 
-## mypy
+## cfn-nag
 
-Runs strict type checking to catch type contract violations at API boundaries before runtime.
+Scans CloudFormation templates for security misconfigurations: IAM wildcards, open security groups, unencrypted resources.
 
 | Severity | Condition |
 |----------|-----------|
-| Critical | Wrong argument type passed at a public API or service boundary |
-| High | Incompatible method override breaks the base class contract |
-| Warning | Missing type annotation on a public function |
+| Critical | IAM policy with "Resource": "*" + "Action": "*" (overly permissive) |
+| High | Security group open to 0.0.0.0/0, S3 bucket without encryption, EBS volume without encryption |
 
-Blocks because a type mismatch at a boundary produces silent data corruption or runtime crashes in callers — catching it statically is always cheaper than tracing it in production.
+Blocks because overly permissive IAM roles and open network endpoints are trivial escalation paths that cannot be remediated post-deploy without a full stack rebuild.
+
+---
+
+## cdk-nag
+
+Scans AWS CDK synthesized templates for security violations. Always runs `cdk synth` first — never uses a stale `cdk.out/`.
+
+| Severity | Condition |
+|----------|-----------|
+| Critical | Overly permissive IAM grants or publicly accessible resources |
+| High | Unencrypted storage, missing encryption keys, privileged container settings |
+
+Blocks for the same reason as cfn-nag: CDK violations represent infrastructure-as-code bugs that manifest at synthesis time and are security-critical at scale.
+
+---
+
+## See also
+
+- [Deterministic detectors](../detectors.md) — 21 AST-based bug-pattern rules (EED-001..EED-021) that run alongside the plugins.


### PR DESCRIPTION
## What

Full documentation overhaul, ground-truthed against source. The docs had drifted hard from the code, and an entire subsystem (the deterministic detectors) was undocumented everywhere.

### Verified corrections

| Fact | Docs said | Reality |
|------|-----------|---------|
| Scanner plugins | "18" / "15" | **19** (+ OPA policy plugin) |
| Custom semgrep rules | "33" | **61** (11 files) |
| Deterministic detectors | *undocumented* | **21** (EED-001..021) |
| New subsystems | *absent* | `detectors/`, `plugins/enrichers/`, `webhook/`, `composition/` |

### Changes

- **New `docs/detectors.md`** — full reference for the 21-detector module (the biggest gap).
- **`docs/CAPABILITIES.md`** — added detectors; fixed an internal inconsistency where the category tables summed to 20 while the headline said 19 (`opa` was folded into "dependency"); the five scanner categories now sum cleanly to 19 with OPA presented as the policy plugin.
- **`ARCHITECTURE.md`** — rebuilt the plugin table to 19 + OPA; CLI four → six commands; four new sections (Deterministic Detectors, Detect-Then-Enrich / ADR-006, Webhook Server, Composition Root); corrected pipeline-stage narrative.
- **`README.md`** — SwiftLint/SwiftFormat rows, OPA separated as the policy plugin, blast-radius check count `8+` → `12`, detectors pointer, and `detectors/`/`enrichers/`/`webhook/`/`composition/` in the source tree.
- **`CLAUDE.md`, `WHY.md`, `docs/elevator-pitch.md`, `docs/architecture-{cloud,enterprise}.md`** — count fixes + detector/enrichment coverage.
- **`docs/plugins/{security,quality}.md`** — moved mypy to advisory, added cfn-nag/cdk-nag (gating) and swiftlint/swiftformat/mypy (advisory), cross-linked detectors.

### Verification

- Global sweep for stale `15/18 plugin` and `33 semgrep` returns empty (CHANGELOG excluded).
- README anchor `#the-19-plugins` matches its heading.
- `docs/detectors.md` lists exactly 21 EED ids = 21 detector files on disk.

Docs-only `chore:` — no version bump expected from release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y55RdKfWghPBbezP8Q6FZu)_