### PR TITLE
fix(enrich): enrich findings on the review/CI path (bootstrap_review + line/start_line)

### DIFF
--- a/tests/unit/test_capability_counts.py
+++ b/tests/unit/test_capability_counts.py
@@ -65,9 +65,11 @@ class TestCapabilitiesDocInSync:
     """The docs/CAPABILITIES.md headline matches the canonical numbers."""
 
     def test_headline_counts_present(self):
-        text = (_REPO / "docs" / "CAPABILITIES.md").read_text()
+        # Whitespace-normalized so the guard survives line-wrapping/reflow of the
+        # identity paragraph (a phrase like "12 code graph checks" may span a newline).
+        text = " ".join((_REPO / "docs" / "CAPABILITIES.md").read_text().split())
         for needle in (
-            f"{_PLUGINS} plugins",
+            f"{_PLUGINS} scanner plugins",
             f"{_SEMGREP} custom semgrep rules",
             f"{_CODEGRAPH} code graph checks",
             f"{_OPA} OPA policy rules",


### PR DESCRIPTION
## The bug (found by running eedom on datum-ax)

The detect-then-enrich pass (ADR-006) claimed "every plugin's findings get enriched", but on the **`eedom review` CLI path** (which the gatekeeper workflow uses) findings carried **no enrichment at all**. Two root causes:

1. **`bootstrap_review()` didn't wire enrichers.** It built the `ApplicationContext` without the `enrichers` field, so `get_enrichers()` returned `[]` and the pass no-opped. Only the production `bootstrap()` wired them — so the webhook/pipeline path enriched, but the CLI/CI path silently didn't.
2. **`line` vs `start_line` mismatch.** The enrichers keyed on `finding["line"]`, but semgrep findings carry `start_line`. Even once enrichers ran, they skipped those findings.

## Fix

- `bootstrap_review()` now wires `build_default_enrichers()` (enclosing_symbol + code_graph).
- New shared `core.enrichment.finding_line()` (tolerates `line` **and** `start_line`); all three enrichers route `applies_to`/`enrich` through it.

**Verified on datum-ax:** semgrep findings now attach `enclosing_symbol` + `blast_radius` (e.g. `postgres_ledger.py` → `totals`); 13/28 mypy findings enrich — the other 15 are module-level import lines with no enclosing symbol (correctly skipped).

## Also: pre-existing main breakage
The `chore(docs): overhaul documentation` commit (`ba48f89`) broke `test_capability_counts` — it reworded "19 plugins" → "19 scanner plugins" and reflowed the identity paragraph so "12 code graph checks" spans a newline. This test is **red on `main` right now**. Fixed the guard to match the precise wording and be whitespace-normalized (survives reflow).

## Tests
- `finding_line()` (line/start_line/missing/bad-value)
- enclosing-symbol enricher on a `start_line`-only finding
- `bootstrap_review` wires the default enrichers
- Full unit + contract suite green (2311 passed); ruff/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat

---
_Generated by [Claude Code](https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat)_