### PR TITLE
fix(dependabot): switch to uv ecosystem (end lockfile drift) + harden fixture exclusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  # Use the "uv" ecosystem (not "pip"): uv updates pyproject.toml AND uv.lock
+  # atomically, so version bumps never leave the lockfile out of sync (the pip
+  # ecosystem edited pyproject.toml only, producing un-mergeable lockfile drift).
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -12,15 +15,20 @@ updates:
     cooldown:
       default-days: 14
     open-pull-requests-limit: 5
-    # Keep intentionally-pinned vulnerable e2e scan fixtures out of Dependabot
-    # (see config/scan-exclusions.toml); enforced by tests/unit/test_dependabot_policy.py.
+    # Keep the intentionally-pinned vulnerable e2e scan fixtures out of Dependabot
+    # (see config/scan-exclusions.toml). exclude-paths is the documented mechanism,
+    # but the uv graph builder currently has a bug that can ignore it
+    # (dependabot/dependabot-core#15102), so we layer protection:
+    #   1. uv does not scan requirements.txt, so the fixture requirements.txt files
+    #      are out of scope, and the fixture pyproject.toml is not a uv project
+    #      (no uv.lock, not a workspace member), so uv should not manage it.
+    #   2. ignore the fixture-only packages that are NOT real eedom deps.
+    #   3. the authoritative backstop is tests/unit/test_dependabot_policy.py
+    #      (test_vuln_fixture_keeps_known_vulnerable_dependency_pins), which fails
+    #      any PR that bumps a fixture pin.
+    # jinja2 is a real eedom dep and is intentionally NOT ignored here.
     exclude-paths:
       - "tests/e2e/fixtures/**"
-    # Defense-in-depth: also ignore the fixture-only packages that are NOT real
-    # eedom deps, to cut PR noise if exclude-paths is not honored for nested pip
-    # manifests. jinja2 is a real dep and is intentionally NOT listed here; any
-    # fixture bump that still slips through is caught by the guard test above
-    # plus the generated osv-scanner.toml ignores.
     ignore:
       - dependency-name: "requests"
       - dependency-name: "flask"

--- a/tests/unit/test_dependabot_policy.py
+++ b/tests/unit/test_dependabot_policy.py
@@ -34,17 +34,35 @@ def _dependabot_updates() -> list[dict[object, object]]:
     return [update for update in updates if isinstance(update, dict)]
 
 
-def test_dependabot_excludes_intentional_vulnerability_fixture() -> None:
-    pip_updates = [
+def _root_python_updates() -> list[dict[object, object]]:
+    """Root Python update blocks, regardless of pip/uv ecosystem naming."""
+    return [
         update
         for update in _dependabot_updates()
-        if update.get("package-ecosystem") == "pip" and update.get("directory") == "/"
+        if update.get("package-ecosystem") in {"uv", "pip"} and update.get("directory") == "/"
     ]
-    assert pip_updates, "Dependabot must have a root pip update block"
+
+
+def test_dependabot_root_python_uses_uv_ecosystem() -> None:
+    """Root Python updates must use the uv ecosystem, not pip.
+
+    The pip ecosystem edits pyproject.toml without regenerating uv.lock, which
+    produces un-mergeable lockfile drift. uv updates both atomically.
+    """
+    root = _root_python_updates()
+    assert root, "Dependabot must have a root Python update block"
+    assert all(
+        update.get("package-ecosystem") == "uv" for update in root
+    ), "Root Python updates must use package-ecosystem 'uv' to keep pyproject.toml and uv.lock in sync"
+
+
+def test_dependabot_excludes_intentional_vulnerability_fixture() -> None:
+    python_updates = _root_python_updates()
+    assert python_updates, "Dependabot must have a root Python update block"
 
     excluded = {
         item
-        for update in pip_updates
+        for update in python_updates
         for item in update.get("exclude-paths", [])
         if isinstance(item, str)
     }
@@ -59,13 +77,9 @@ def test_dependabot_excludes_intentional_vulnerability_fixture() -> None:
 
 
 def test_dependabot_version_updates_have_minimum_package_age() -> None:
-    pip_update = next(
-        update
-        for update in _dependabot_updates()
-        if update.get("package-ecosystem") == "pip" and update.get("directory") == "/"
-    )
-    cooldown = pip_update.get("cooldown")
-    assert isinstance(cooldown, dict), "Root pip updates must define a cooldown"
+    python_update = next(iter(_root_python_updates()))
+    cooldown = python_update.get("cooldown")
+    assert isinstance(cooldown, dict), "Root Python updates must define a cooldown"
     assert cooldown.get("default-days") == 14
 
 


### PR DESCRIPTION
## What

Fixes the two root causes behind the recurring broken Dependabot PRs (#383/#401/#402/#417), rather than papering over them.

## Root causes

1. **Lockfile drift.** The `pip` ecosystem edits `pyproject.toml` *without* regenerating `uv.lock`, so every Python bump landed an inconsistent lock (un-mergeable; #401/#417).
2. **Fixture pollution.** `exclude-paths` *is* a valid Dependabot key, but the uv/pip graph builder has an upstream bug that ignores it ([dependabot-core#15102](https://github.com/dependabot/dependabot-core/issues/15102)), so the intentionally-pinned vulnerable e2e scan fixtures kept getting bumped (caught by the guard test).

## Fix

- **Switch the root Python updater to `package-ecosystem: "uv"`.** uv updates `pyproject.toml` + `uv.lock` **atomically** (no drift) and does **not** scan `requirements.txt`, so the fixture `requirements.txt` files leave Dependabot's scope. The fixture `pyproject.toml` is not a uv project (no `uv.lock`, not a workspace member), so uv should not manage it.
- **Defense-in-depth retained:** keep `exclude-paths` (documented mechanism), keep `ignore` for the fixture-only non-eedom deps (`requests`/`flask`/`cryptography`), and rely on `test_vuln_fixture_keeps_known_vulnerable_dependency_pins` as the authoritative backstop. `jinja2` is a real dep and is intentionally not ignored.

## Tests

- Generalize the existing policy guards to the root Python block (pip **or** uv).
- Add `test_dependabot_root_python_uses_uv_ecosystem` to lock in the uv choice and prevent regression to the drift-prone pip ecosystem.

Validated locally: all `test_dependabot_policy` assertions pass against the new config; `scripts/sync_scan_exclusions.py` passes; YAML is valid. Authoritative run is the container `make test` + `workflow-policy` `uv run --frozen` checks in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat)_