### PR TITLE
chore(deps): bump pydantic-settings 2.14.0 → 2.14.2 (GHSA-4xgf-cpjx-pc3j)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "click==8.3.3",
     "pydantic==2.13.3",
-    "pydantic-settings==2.14.0",
+    "pydantic-settings==2.14.2",
     "structlog==25.5.0",
     "httpx==0.28.1",
     "orjson==3.11.8",

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ requires-dist = [
     { name = "psycopg-pool", marker = "extra == 'db'", specifier = "==3.3.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = "==24.0.0" },
     { name = "pydantic", specifier = "==2.13.3" },
-    { name = "pydantic-settings", specifier = "==2.14.0" },
+    { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "rich", specifier = "==15.0.0" },
     { name = "starlette", marker = "extra == 'copilot'", specifier = "==1.3.1" },
@@ -710,16 +710,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `pydantic-settings 2.14.0 → 2.14.2`, clearing **GHSA-4xgf-cpjx-pc3j** (medium) — the last fixable advisory Dom was flagging on `main`.

## How

`pyproject.toml` bumped and `uv.lock` regenerated with `uv lock` (uv 0.8.17): **only** pydantic-settings changed, and `uv lock --check` confirms the lock is consistent. This is the first dependency bump produced the *correct* way under the new `uv` ecosystem from #427 — pyproject + lock updated atomically, no drift.

## Testing

`uv lock --check` passes. Authoritative run is container `make test` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J87bhrpLghAixbsJcg8Yat)_